### PR TITLE
[MOB-14405] - Share pushIdentifier in messaging extension shared state

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -242,8 +242,8 @@
 				92315435261E3B36004AE7D3 /* AEPMessaging.h */,
 				92315436261E3B36004AE7D3 /* Messaging.swift */,
 				92315437261E3B36004AE7D3 /* MessagingConstants.swift */,
-				92315438261E3B36004AE7D3 /* Info.plist */,
 				923155762620FC53004AE7D3 /* Event+Messaging.swift */,
+				92315438261E3B36004AE7D3 /* Info.plist */,
 			);
 			path = Sources;
 			sourceTree = "<group>";

--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -965,7 +965,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "1.0.0-beta-1";
+				MARKETING_VERSION = "1.0.0-beta-2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.messaging;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1001,7 +1001,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "1.0.0-beta-1";
+				MARKETING_VERSION = "1.0.0-beta-2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.messaging;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -15,6 +15,7 @@ import AEPServices
 import UserNotifications
 
 @objc public extension Messaging {
+
     /// Sends the push notification interactions as an experience event to Adobe Experience Edge.
     /// - Parameters:
     ///   - response: UNNotificationResponse object which contains the payload and xdm informations.
@@ -40,13 +41,13 @@ import UserNotifications
                                         MessagingConstants.EventDataKeys.APPLICATION_OPENED: applicationOpened,
                                         MessagingConstants.EventDataKeys.ADOBE_XDM: xdm ?? [:]] // If xdm data is nil we use empty dictionary
         if customActionId == nil {
-            eventData[MessagingConstants.EventDataKeys.EVENT_TYPE] = MessagingConstants.EventDataKeys.EVENT_TYPE_PUSH_TRACKING_APPLICATION_OPENED
+            eventData[MessagingConstants.EventDataKeys.EVENT_TYPE] = MessagingConstants.EventDataValue.PUSH_TRACKING_APPLICATION_OPENED
         } else {
-            eventData[MessagingConstants.EventDataKeys.EVENT_TYPE] = MessagingConstants.EventDataKeys.EVENT_TYPE_PUSH_TRACKING_CUSTOM_ACTION
+            eventData[MessagingConstants.EventDataKeys.EVENT_TYPE] = MessagingConstants.EventDataValue.PUSH_TRACKING_CUSTOM_ACTION
             eventData[MessagingConstants.EventDataKeys.ACTION_ID] = customActionId
         }
 
-        let event = Event(name: MessagingConstants.EventName.MESSAGING_PUSH_NOTIFICATION_INTERACTION_EVENT,
+        let event = Event(name: MessagingConstants.EventName.PUSH_NOTIFICATION_INTERACTION,
                           type: MessagingConstants.EventType.messaging,
                           source: EventSource.requestContent,
                           data: eventData)

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -23,9 +23,7 @@ public class Messaging: NSObject, Extension {
     public var runtime: ExtensionRuntime
 
     // =================================================================================================================
-
     // MARK: - ACPExtension protocol methods
-
     // =================================================================================================================
     public required init?(runtime: ExtensionRuntime) {
         self.runtime = runtime
@@ -63,9 +61,13 @@ public class Messaging: NSObject, Extension {
         return configurationSharedState.status == .set && edgeIdentitySharedState.status == .set
     }
 
+    // =================================================================================================================
+    // MARK: - Event Handers
+    // =================================================================================================================
+
     /// Processes the events in the event queue in the order they were received.
     ///
-    /// A valid Configuration and edge identity shared state is required for processing events.
+    /// A valid `Configuration` and `EdgeIdentity` shared state is required for processing events.
     ///
     /// - Parameters:
     ///   - event: An `Event` to be processed
@@ -97,7 +99,8 @@ public class Messaging: NSObject, Extension {
 
             // get identityMap from the edge identity xdm shared state
             guard let identityMap = edgeIdentitySharedState[MessagingConstants.SharedState.EdgeIdentity.IDENTITY_MAP] as? [AnyHashable: Any] else {
-                Log.warning(label: MessagingConstants.LOG_TAG, "Cannot process event that identity map is not available from edge identity xdm shared state - '\(event.id.uuidString)'.")
+                Log.warning(label: MessagingConstants.LOG_TAG, "Cannot process event that identity map is not available" +
+                    "from edge identity xdm shared state - '\(event.id.uuidString)'.")
                 return
             }
 
@@ -144,7 +147,7 @@ public class Messaging: NSObject, Extension {
                     MessagingConstants.PushNotificationDetails.NAMESPACE: [
                         MessagingConstants.PushNotificationDetails.CODE: MessagingConstants.PushNotificationDetails.JsonValues.ECID
                     ],
-                    MessagingConstants.PushNotificationDetails.ID: ecid
+                    MessagingConstants.PushNotificationDetails.ECID: ecid
                     ]]
             ]
         ]
@@ -152,7 +155,7 @@ public class Messaging: NSObject, Extension {
         // Creating xdm edge event data
         let xdmEventData: [String: Any] = [MessagingConstants.XDMDataKeys.DATA: profileEventData]
         // Creating xdm edge event with request content source type
-        let event = Event(name: MessagingConstants.EventName.MESSAGING_PUSH_PROFILE_EDGE_EVENT,
+        let event = Event(name: MessagingConstants.EventName.PUSH_PROFILE_EDGE,
                           type: EventType.edge,
                           source: EventSource.requestContent,
                           data: xdmEventData)
@@ -167,14 +170,16 @@ public class Messaging: NSObject, Extension {
     private func handleTrackingInfo(event: Event, _ config: [AnyHashable: Any]) {
         guard let expEventDatasetId = config[MessagingConstants.SharedState.Configuration.EXPERIENCE_EVENT_DATASET] as? String, !expEventDatasetId.isEmpty else {
             Log.warning(label: MessagingConstants.LOG_TAG,
-                        "Failed to handle tracking information for push notification : Experience event dataset ID from the config is invalid or not available. '\(event.id.uuidString)'")
+                        "Failed to handle tracking information for push notification: " +
+                "Experience event dataset ID from the config is invalid or not available. '\(event.id.uuidString)'")
             return
         }
 
         // Get the xdm data with push tracking details
         guard var xdmMap = getXdmData(event: event, config: config) else {
             Log.warning(label: MessagingConstants.LOG_TAG,
-                        "Failed to handle tracking information for push notification : error while creating xdmMap with the push tracking details from the event and config. '\(event.id.uuidString)'")
+                        "Failed to handle tracking information for push notification: " +
+                "Error while creating xdmMap with the push tracking details from the event and config. '\(event.id.uuidString)'")
             return
         }
 
@@ -192,7 +197,7 @@ public class Messaging: NSObject, Extension {
             ]
             ]]
         // Creating xdm edge event with request content source type
-        let event = Event(name: MessagingConstants.EventName.MESSAGING_PUSH_TRACKING_EDGE_EVENT,
+        let event = Event(name: MessagingConstants.EventName.PUSH_TRACKING_EDGE,
                           type: EventType.edge,
                           source: EventSource.requestContent,
                           data: xdmEventData)
@@ -205,7 +210,7 @@ public class Messaging: NSObject, Extension {
     ///  - xdmDict: `[AnyHashable: Any]` which is updated with the cjm tracking information.
     private func addAdobeData(event: Event, xdmDict: [String: Any]) -> [String: Any] {
         var xdmDictResult = xdmDict
-        guard let _ = event.adobeXdm else {
+        if event.adobeXdm == nil {
             Log.warning(label: MessagingConstants.LOG_TAG,
                         "Failed to update xdmMap with adobe/cjm related informations : adobe/cjm information are invalid or not available in the event '\(event.id.uuidString)'.")
             return xdmDictResult
@@ -235,7 +240,8 @@ public class Messaging: NSObject, Extension {
                 guard let messageProfile = convertStringToDictionary(
                     jsonString: MessagingConstants.AdobeTrackingKeys.MESSAGE_PROFILE_JSON) else {
                         Log.warning(label: MessagingConstants.LOG_TAG,
-                                    "Failed to update xdmMap with adobe/cjm informations : converting message profile string to dictionary failed in the event '\(event.id.uuidString)'.")
+                                    "Failed to update xdmMap with adobe/cjm informations:" +
+                            "converting message profile string to dictionary failed in the event '\(event.id.uuidString)'.")
                         return xdmDictResult
                 }
                 // Merging the dictionary
@@ -245,7 +251,8 @@ public class Messaging: NSObject, Extension {
             }
         } else {
             Log.warning(label: MessagingConstants.LOG_TAG,
-                        "Failed to send adobe/cjm information data with the tracking, \(MessagingConstants.AdobeTrackingKeys.EXPERIENCE) is missing in the event '\(event.id.uuidString)'.")
+                        "Failed to send adobe/cjm information data with the tracking," +
+                "\(MessagingConstants.AdobeTrackingKeys.EXPERIENCE) is missing in the event '\(event.id.uuidString)'.")
         }
         return xdmDictResult
     }

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -90,12 +90,13 @@ public class Messaging: NSObject, Extension {
         }
 
         if event.isGenericIdentityRequestContentEvent {
-            // read the push token from the event and set it to shared state if push token is valid
+
             guard let token = event.token, !token.isEmpty else {
                 Log.debug(label: MessagingConstants.LOG_TAG, "Ignoring event with missing or invalid push identifier - '\(event.id.uuidString)'.")
                 return
             }
-            runtime.createSharedState(data: [MessagingConstants.SharedStateKeys.PUSH_IDENTIFIER: token], event: event)
+            // If the push token is valid update the shared state.
+            runtime.createSharedState(data: [MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER: token], event: event)
 
             // get identityMap from the edge identity xdm shared state
             guard let identityMap = edgeIdentitySharedState[MessagingConstants.SharedState.EdgeIdentity.IDENTITY_MAP] as? [AnyHashable: Any] else {
@@ -147,7 +148,7 @@ public class Messaging: NSObject, Extension {
                     MessagingConstants.PushNotificationDetails.NAMESPACE: [
                         MessagingConstants.PushNotificationDetails.CODE: MessagingConstants.PushNotificationDetails.JsonValues.ECID
                     ],
-                    MessagingConstants.PushNotificationDetails.ECID: ecid
+                    MessagingConstants.PushNotificationDetails.ID: ecid
                     ]]
             ]
         ]

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -233,10 +233,10 @@ public class Messaging: NSObject, Extension {
             if var cjmDict = experienceDict[MessagingConstants.AdobeTrackingKeys.CUSTOMER_JOURNEY_MANAGEMENT] as? [String: Any] {
                 // Adding Message profile and push channel context to CUSTOMER_JOURNEY_MANAGEMENT
                 guard let messageProfile = convertStringToDictionary(
-                        text: MessagingConstants.AdobeTrackingKeys.MESSAGE_PROFILE_JSON) else {
-                    Log.warning(label: MessagingConstants.LOG_TAG,
-                                "Failed to update xdmMap with adobe/cjm informations : converting message profile string to dictionary failed in the event '\(event.id.uuidString)'.")
-                    return xdmDictResult
+                    jsonString: MessagingConstants.AdobeTrackingKeys.MESSAGE_PROFILE_JSON) else {
+                        Log.warning(label: MessagingConstants.LOG_TAG,
+                                    "Failed to update xdmMap with adobe/cjm informations : converting message profile string to dictionary failed in the event '\(event.id.uuidString)'.")
+                        return xdmDictResult
                 }
                 // Merging the dictionary
                 cjmDict += messageProfile
@@ -295,19 +295,19 @@ public class Messaging: NSObject, Extension {
         return xdmDict
     }
 
-    /// Helper methods
+    // MARK: - Private - Helper methods
 
-    /// Converts a dictionary string to dictionary object
+    /// Converts a json string into dictionary object.
     /// - Parameters:
-    ///   - text: String dictionary which needs to be converted
-    /// - Returns: Dictionary
-    private func convertStringToDictionary(text: String) -> [String: Any]? {
-        if let data = text.data(using: .utf8) {
+    ///   - jsonString: json String that needs to be converted to a dictionary
+    /// - Returns: A  dictionary representation of the string. Returns `nil` if the json serialization of the string fails.
+    private func convertStringToDictionary(jsonString: String) -> [String: Any]? {
+        if let data = jsonString.data(using: .utf8) {
             do {
                 let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any]
                 return json
             } catch {
-                Log.debug(label: MessagingConstants.LOG_TAG, "Unexpected error occured while converting string \(text) to dictionary: Error -  \(error).")
+                Log.debug(label: MessagingConstants.LOG_TAG, "Unexpected error occurred while converting string \(jsonString) to dictionary: Error -  \(error).")
                 return nil
             }
         }

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum MessagingConstants {
     static let LOG_TAG = "Messaging"
     static let EXTENSION_NAME = "com.adobe.messaging"
-    static let EXTENSION_VERSION = "1.0.0-beta-1"
+    static let EXTENSION_VERSION = "1.0.0-beta-2"
     static let FRIENDLY_NAME = "AEPMessaging"
 
     enum EventName {
@@ -26,6 +26,10 @@ enum MessagingConstants {
 
     enum EventType {
         static let messaging = "com.adobe.eventType.messaging"
+    }
+
+    enum SharedStateKeys {
+        static let PUSH_IDENTIFIER = "pushidentifier"
     }
 
     enum EventDataKeys {
@@ -51,7 +55,7 @@ enum MessagingConstants {
 
         static let MESSAGE_PROFILE_JSON = "{\n   \"messageProfile\":" +
             "{\n      \"channel\": {\n         \"_id\": \"https://ns.adobe.com/xdm/channels/push\"\n      }\n   }" +
-            ",\n   \"pushChannelContext\": {\n      \"platform\": \"apns\"\n   }\n}"
+        ",\n   \"pushChannelContext\": {\n      \"platform\": \"apns\"\n   }\n}"
     }
 
     enum XDMDataKeys {

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -19,9 +19,9 @@ enum MessagingConstants {
     static let FRIENDLY_NAME = "AEPMessaging"
 
     enum EventName {
-        static let MESSAGING_PUSH_NOTIFICATION_INTERACTION_EVENT = "Push notification interaction event"
-        static let MESSAGING_PUSH_TRACKING_EDGE_EVENT = "Push tracking edge event"
-        static let MESSAGING_PUSH_PROFILE_EDGE_EVENT = "Push notification profile edge event"
+        static let PUSH_NOTIFICATION_INTERACTION = "Push notification interaction event"
+        static let PUSH_TRACKING_EDGE = "Push tracking edge event"
+        static let PUSH_PROFILE_EDGE = "Push notification profile edge event"
     }
 
     enum EventType {
@@ -39,8 +39,11 @@ enum MessagingConstants {
         static let APPLICATION_OPENED = "applicationOpened"
         static let ACTION_ID = "actionId"
         static let ADOBE_XDM = "adobe_xdm"
-        static let EVENT_TYPE_PUSH_TRACKING_APPLICATION_OPENED = "pushTracking.applicationOpened"
-        static let EVENT_TYPE_PUSH_TRACKING_CUSTOM_ACTION = "pushTracking.customAction"
+    }
+
+    enum EventDataValue {
+        static let PUSH_TRACKING_APPLICATION_OPENED = "pushTracking.applicationOpened"
+        static let PUSH_TRACKING_CUSTOM_ACTION = "pushTracking.customAction"
     }
 
     enum AdobeTrackingKeys {
@@ -52,7 +55,6 @@ enum MessagingConstants {
         static let APPLICATION = "application"
         static let LAUNCHES = "launches"
         static let LAUNCHES_VALUE = "value"
-
         static let MESSAGE_PROFILE_JSON = "{\n   \"messageProfile\":" +
             "{\n      \"channel\": {\n         \"_id\": \"https://ns.adobe.com/xdm/channels/push\"\n      }\n   }" +
         ",\n   \"pushChannelContext\": {\n      \"platform\": \"apns\"\n   }\n}"
@@ -82,7 +84,7 @@ enum MessagingConstants {
         static let IDENTITY = "identity"
         static let NAMESPACE = "namespace"
         static let CODE = "code"
-        static let ID = "id"
+        static let ECID = "id"
 
         enum JsonValues {
             static let ECID = "ECID"

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -28,10 +28,6 @@ enum MessagingConstants {
         static let messaging = "com.adobe.eventType.messaging"
     }
 
-    enum SharedStateKeys {
-        static let PUSH_IDENTIFIER = "pushidentifier"
-    }
-
     enum EventDataKeys {
         static let PUSH_IDENTIFIER = "pushidentifier"
         static let EVENT_TYPE = "eventType"
@@ -84,7 +80,7 @@ enum MessagingConstants {
         static let IDENTITY = "identity"
         static let NAMESPACE = "namespace"
         static let CODE = "code"
-        static let ECID = "id"
+        static let ID = "id"
 
         enum JsonValues {
             static let ECID = "ECID"
@@ -95,6 +91,10 @@ enum MessagingConstants {
 
     struct SharedState {
         static let STATE_OWNER = "stateowner"
+
+        enum Messaging {
+            static let PUSH_IDENTIFIER = "pushidentifier"
+        }
 
         enum Configuration {
             static let NAME = "com.adobe.module.configuration"

--- a/AEPMessaging/Tests/FunctionalTests/MessagingFunctionalTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingFunctionalTests.swift
@@ -59,7 +59,7 @@ class MessagingFunctionalTests: XCTestCase {
 
         // verify that push token is shared in sharedState
         XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
-        XCTAssertEqual("mockPushToken", mockRuntime.firstSharedState![MessagingConstants.SharedStateKeys.PUSH_IDENTIFIER] as! String)
+        XCTAssertEqual("mockPushToken", mockRuntime.firstSharedState![MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER] as! String)
     }
 
     func testPushTokenSync_emptyToken() {
@@ -114,7 +114,7 @@ class MessagingFunctionalTests: XCTestCase {
 
         // verify that push token is shared in sharedState
         XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
-        XCTAssertEqual("mockPushToken", try XCTUnwrap(mockRuntime.firstSharedState?[MessagingConstants.SharedStateKeys.PUSH_IDENTIFIER] as? String))
+        XCTAssertEqual("mockPushToken", try XCTUnwrap(mockRuntime.firstSharedState?[MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER] as? String))
     }
 
     func testPushTokenSync_withSandbox() {
@@ -149,6 +149,6 @@ class MessagingFunctionalTests: XCTestCase {
 
         // verify that push token is shared in sharedState
         XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
-        XCTAssertEqual("mockPushToken", mockRuntime.firstSharedState![MessagingConstants.SharedStateKeys.PUSH_IDENTIFIER] as! String)
+        XCTAssertEqual("mockPushToken", mockRuntime.firstSharedState![MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER] as! String)
     }
 }

--- a/AEPMessaging/Tests/FunctionalTests/MessagingPublicAPITests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingPublicAPITests.swift
@@ -135,7 +135,7 @@ class MessagingPublicAPITests: XCTestCase {
             "journeyVersionID": "some-journeyVersionId",
             "journeyVersionInstanceId": "someJourneyVersionInstanceId",
             "messageID": "567"
-        ]]]]]
+            ]]]]]
         let data = [MessagingConstants.EventDataKeys.MESSAGE_ID: "mockMessageId",
                     MessagingConstants.EventDataKeys.APPLICATION_OPENED: true,
                     MessagingConstants.EventDataKeys.EVENT_TYPE: MessagingConstants.EventDataKeys.EVENT_TYPE_PUSH_TRACKING_CUSTOM_ACTION,

--- a/AEPMessaging/Tests/FunctionalTests/MessagingPublicAPITests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingPublicAPITests.swift
@@ -138,7 +138,7 @@ class MessagingPublicAPITests: XCTestCase {
             ]]]]]
         let data = [MessagingConstants.EventDataKeys.MESSAGE_ID: "mockMessageId",
                     MessagingConstants.EventDataKeys.APPLICATION_OPENED: true,
-                    MessagingConstants.EventDataKeys.EVENT_TYPE: MessagingConstants.EventDataKeys.EVENT_TYPE_PUSH_TRACKING_CUSTOM_ACTION,
+                    MessagingConstants.EventDataKeys.EVENT_TYPE: MessagingConstants.EventDataValue.PUSH_TRACKING_CUSTOM_ACTION,
                     MessagingConstants.EventDataKeys.ACTION_ID: "mockCustomActionId",
                     MessagingConstants.EventDataKeys.ADOBE_XDM: cjmData] as [String: Any]
         return data

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -47,15 +47,15 @@ class MessagingPublicApiTest: XCTestCase {
             XCTAssertEqual(EventSource.requestContent, event.source)
 
             guard let eventData = event.data,
-                  let applicationOpened = eventData[MessagingConstants.EventDataKeys.APPLICATION_OPENED] as? Bool,
-                  let eventDataType = eventData[MessagingConstants.EventDataKeys.EVENT_TYPE] as? String,
-                  let actionId = eventData[MessagingConstants.EventDataKeys.ACTION_ID] as? String,
-                  let messageId = eventData[MessagingConstants.EventDataKeys.MESSAGE_ID] as? String,
-                  let xdm = eventData[MessagingConstants.EventDataKeys.ADOBE_XDM] as? [String: Any]
-            else {
-                XCTFail()
-                expectation.fulfill()
-                return
+                let applicationOpened = eventData[MessagingConstants.EventDataKeys.APPLICATION_OPENED] as? Bool,
+                let eventDataType = eventData[MessagingConstants.EventDataKeys.EVENT_TYPE] as? String,
+                let actionId = eventData[MessagingConstants.EventDataKeys.ACTION_ID] as? String,
+                let messageId = eventData[MessagingConstants.EventDataKeys.MESSAGE_ID] as? String,
+                let xdm = eventData[MessagingConstants.EventDataKeys.ADOBE_XDM] as? [String: Any]
+                else {
+                    XCTFail()
+                    expectation.fulfill()
+                    return
             }
 
             XCTAssertTrue(applicationOpened)

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -42,7 +42,7 @@ class MessagingPublicApiTest: XCTestCase {
 
         EventHub.shared.getExtensionContainer(MockExtension.self)?.eventListeners.clear()
         EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MessagingConstants.EventType.messaging, source: EventSource.requestContent) { event in
-            XCTAssertEqual(MessagingConstants.EventName.MESSAGING_PUSH_NOTIFICATION_INTERACTION_EVENT, event.name)
+            XCTAssertEqual(MessagingConstants.EventName.PUSH_NOTIFICATION_INTERACTION, event.name)
             XCTAssertEqual(MessagingConstants.EventType.messaging, event.type)
             XCTAssertEqual(EventSource.requestContent, event.source)
 
@@ -59,7 +59,7 @@ class MessagingPublicApiTest: XCTestCase {
             }
 
             XCTAssertTrue(applicationOpened)
-            XCTAssertEqual(MessagingConstants.EventDataKeys.EVENT_TYPE_PUSH_TRACKING_CUSTOM_ACTION, eventDataType)
+            XCTAssertEqual(MessagingConstants.EventDataValue.PUSH_TRACKING_CUSTOM_ACTION, eventDataType)
             XCTAssertEqual(actionId, mockCustomActinoId)
             XCTAssertEqual(messageId, mockIdentifier)
             XCTAssertNotNil(xdm)

--- a/SampleApps/MessagingDemoApp/AppDelegate.swift
+++ b/SampleApps/MessagingDemoApp/AppDelegate.swift
@@ -115,8 +115,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         content.body = "This is example how to create "
 
         content.userInfo = ["_xdm": ["cjm": ["_experience": ["customerJourneyManagement":
-                                                                ["messageExecution": ["messageExecutionID": "16-Sept-postman", "messageID": "567",
-                                                                                      "journeyVersionID": "some-journeyVersionId", "journeyVersionInstanceId": "someJourneyVersionInstanceId"]]]]]]
+            ["messageExecution": ["messageExecutionID": "16-Sept-postman", "messageID": "567",
+                                  "journeyVersionID": "some-journeyVersionId", "journeyVersionInstanceId": "someJourneyVersionInstanceId"]]]]]]
 
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 2, repeats: false)
         let identifier = "Local Notification"
@@ -136,8 +136,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         content.body = "This is example how to create "
         content.categoryIdentifier = "MEETING_INVITATION"
         content.userInfo = ["_xdm": ["cjm": ["_experience": ["customerJourneyManagement":
-                                                                ["messageExecution": ["messageExecutionID": "16-Sept-postman", "messageID": "567",
-                                                                                      "journeyVersionID": "some-journeyVersionId", "journeyVersionInstanceId": "someJourneyVersionInstanceId"]]]]]]
+            ["messageExecution": ["messageExecutionID": "16-Sept-postman", "messageID": "567",
+                                  "journeyVersionID": "some-journeyVersionId", "journeyVersionInstanceId": "someJourneyVersionInstanceId"]]]]]]
 
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 2, repeats: false)
         let identifier = "Local Notification"


### PR DESCRIPTION
- On every MobileCore.SetPushIdentifier API call, which dispatches Generic Request Identity event is listened by Messaging extension.
- Now the push identifier is extracted and shared in Messaging extension's shared state

StateStateDetails
```
{
 "pushidentifier" : '<push_token>"
}
```

This shared state in read by Assurance extension, which forwards the data to Griffon session for populating the PushDebug plugin

**Note**
- Pushtoken is shared in shared state regardless of the ability of Messaging extension to sync the token with the edge network