### PR TITLE
[MOB-18293] - Handling Notification Actions

### DIFF
--- a/AEPMessaging/Sources/Event+Messaging.swift
+++ b/AEPMessaging/Sources/Event+Messaging.swift
@@ -297,8 +297,8 @@ extension Event {
         data?[MessagingConstants.Event.Data.Key.ACTION_ID] as? String
     }
     
-    var pushClickThroughLink: URL? {
-        guard let link = data?[MessagingConstants.Event.Data.Key.PUSH_CLICK_THROUGH_LINK] as? String else {
+    var pushClickThroughUrl: URL? {
+        guard let link = data?[MessagingConstants.Event.Data.Key.PUSH_CLICK_THROUGH_URL] as? String else {
             return nil
         }
         return URL(string: link)

--- a/AEPMessaging/Sources/Event+Messaging.swift
+++ b/AEPMessaging/Sources/Event+Messaging.swift
@@ -296,6 +296,13 @@ extension Event {
     var actionId: String? {
         data?[MessagingConstants.Event.Data.Key.ACTION_ID] as? String
     }
+    
+    var pushClickThroughLink: URL? {
+        guard let link = data?[MessagingConstants.Event.Data.Key.PUSH_CLICK_THROUGH_LINK] as? String else {
+            return nil
+        }
+        return URL(string: link)
+    }
 
     var applicationOpened: Bool {
         data?[MessagingConstants.Event.Data.Key.APPLICATION_OPENED] as? Bool ?? false

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -43,13 +43,13 @@ import UserNotifications
         if customActionId == nil {
             eventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.APPLICATION_OPENED
             
-            // Messaging extension can handle click through url's when the user taps on the notification
-            // Messaging extension CANNOT handle click through url's when the user taps on any of the action buttons by swiping the notifications. They must be handled in the application.
+            // The messaging extension can handle click-through url when the user taps on the notification
+            // The messaging extension CANNOT handle click-through url when the user long-presses the notification and taps on any of the action buttons. In such cases, the application must handle them instead.
             if (applicationOpened) {
-                // Add the click thorough url to the eventData if the application is opened and when the customActionId is nil                
+                // Add click-through url to the eventData if the application is opened and when the customActionId is nil
                 // (TODO: Decide if we should also accept UNNotificationDefaultActionIdentifier as customActionId to process sending the clickthrough url through eventData)
-                if let actionUrl = notificationRequest.content.userInfo [MessagingConstants.PushNotification.UserInfoKey.ACTION_URL] as? String {
-                    eventData[MessagingConstants.Event.Data.Key.PUSH_CLICK_THROUGH_LINK] = actionUrl
+                if let actionUrl = notificationRequest.content.userInfo[MessagingConstants.PushNotification.UserInfoKey.ACTION_URL] as? String {
+                    eventData[MessagingConstants.Event.Data.Key.PUSH_CLICK_THROUGH_URL] = actionUrl
                 }
             }
             

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -42,6 +42,17 @@ import UserNotifications
                                         MessagingConstants.XDM.Key.ADOBE_XDM: xdm ?? [:]] // If xdm data is nil we use empty dictionary
         if customActionId == nil {
             eventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.APPLICATION_OPENED
+            
+            // Messaging extension can handle click through url's when the user taps on the notification
+            // Messaging extension CANNOT handle click through url's when the user taps on any of the action buttons by swiping the notifications. They must be handled in the application.
+            if (applicationOpened) {
+                // Add the click thorough url to the eventData if the application is opened and when the customActionId is nil                
+                // (TODO: Decide if we should also accept UNNotificationDefaultActionIdentifier as customActionId to process sending the clickthrough url through eventData)
+                if let actionUrl = notificationRequest.content.userInfo [MessagingConstants.PushNotification.UserInfoKey.ACTION_URL] as? String {
+                    eventData[MessagingConstants.Event.Data.Key.PUSH_CLICK_THROUGH_LINK] = actionUrl
+                }
+            }
+            
         } else {
             eventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.CUSTOM_ACTION
             eventData[MessagingConstants.Event.Data.Key.ACTION_ID] = customActionId

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -13,6 +13,7 @@
 import AEPCore
 import AEPServices
 import Foundation
+import UIKit
 
 @objc(AEPMobileMessaging)
 public class Messaging: NSObject, Extension {
@@ -277,9 +278,19 @@ public class Messaging: NSObject, Extension {
 
         // Check if the event type is `MessagingConstants.Event.EventType.messaging` and
         // eventSource is `EventSource.requestContent` handle processing of the tracking information
-        if event.isMessagingRequestContentEvent, configSharedState.keys.contains(MessagingConstants.SharedState.Configuration.EXPERIENCE_EVENT_DATASET) {
-            handleTrackingInfo(event: event)
-            return
+        if event.isMessagingRequestContentEvent {
+            
+            //  Handle push click through action if the event data contains the web/deeplink
+            if let actionLink = event.pushClickThroughLink {
+                DispatchQueue.main.async {
+                    UIApplication.shared.open(actionLink)
+                }                
+            }
+            
+            if(configSharedState.keys.contains(MessagingConstants.SharedState.Configuration.EXPERIENCE_EVENT_DATASET)) {
+                handleTrackingInfo(event: event)
+                return
+            }
         }
     }
     

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -281,7 +281,7 @@ public class Messaging: NSObject, Extension {
         if event.isMessagingRequestContentEvent {
             
             //  Handle push click through action if the event data contains the web/deeplink
-            if let actionLink = event.pushClickThroughLink {
+            if let actionLink = event.pushClickThroughUrl {
                 DispatchQueue.main.async {
                     UIApplication.shared.open(actionLink)
                 }                

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -58,6 +58,7 @@ enum MessagingConstants {
                 static let MESSAGE_ID = "id"
                 static let APPLICATION_OPENED = "applicationOpened"
                 static let ACTION_ID = "actionId"
+                static let PUSH_CLICK_THROUGH_LINK = "pushClickThroughLink"
                 static let REFRESH_MESSAGES = "refreshmessages"
                 static let ADOBE_XDM = "adobe_xdm"
                 static let REQUEST_EVENT_ID = "requestEventId"
@@ -286,5 +287,11 @@ enum MessagingConstants {
             static let ECID = "ECID"
             static let ID = "id"
         }
+    }
+    
+    enum PushNotification {
+        enum UserInfoKey {
+            static let ACTION_URL = "adb_uri"
+        }        
     }
 }

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -58,7 +58,7 @@ enum MessagingConstants {
                 static let MESSAGE_ID = "id"
                 static let APPLICATION_OPENED = "applicationOpened"
                 static let ACTION_ID = "actionId"
-                static let PUSH_CLICK_THROUGH_LINK = "pushClickThroughLink"
+                static let PUSH_CLICK_THROUGH_URL = "pushClickThroughUrl"
                 static let REFRESH_MESSAGES = "refreshmessages"
                 static let ADOBE_XDM = "adobe_xdm"
                 static let REQUEST_EVENT_ID = "requestEventId"

--- a/TestApps/MessagingDemoApp/SceneDelegate.swift
+++ b/TestApps/MessagingDemoApp/SceneDelegate.swift
@@ -26,5 +26,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         guard let urlContexts = URLContexts.first else { return }
         Assurance.startSession(url: urlContexts.url)
+        
+        let alert = UIAlertController(title: "Deeplink Received", message: "\(urlContexts.url.description)", preferredStyle: UIAlertController.Style.alert)
+        alert.addAction(UIAlertAction(title: "Cool", style: UIAlertAction.Style.default, handler: nil))
+        self.window?.rootViewController?.present(alert, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
### Definition
Notification Action is defined as an action that the Messaging Extension takes in response to interacting with the notification.
Typically these actions can be to open a web URL or a deeplink associated with that application.

### How notification action is set
While designing a push notification campaign. Notification action is set by editing the click behavior field.
In iOS deeplink/ weburl action links are sent to the device through the push notification payload. They are available in a custom field "adb_uri".

![Screenshot 2023-04-11 at 11 52 56 AM](https://user-images.githubusercontent.com/8909148/231261124-49e8d8f8-9b8e-4b25-a28c-aa568864fcdf.png). 


### Notification body click action 
Notification body click action determines the action taken when clicking on the body of the notification. This will typically open the application and hence requires the customers to call  Messaging API handleNotificationResponse with  applicationOpened : true
customActionId : nil
`Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)`


###  Notification custom button click action
Notification custom button click action determines the action taken when the user clicks either of the action buttons in a notification. On this action we require the customers to call Messaging API handleNotificationResponse with
applicationOpened : true/false (depending upon if the action was set to bring the application to foreground)
customActionId : response.actionIdentifier

`Messaging.handleNotificationResponse(response, applicationOpened: false/true, customActionId: response.actionIdentifier)`

![image](https://user-images.githubusercontent.com/8909148/231264345-a4a9d29d-45b3-4903-a949-dd515b236dc1.png)


### Why cant we handle notification custom button click action
With the [examples](https://github.com/adobe/aepsdk-messaging-ios/compare/main...PravinPK:aepsdk-messaging-ios:dev-v1.1.1?expand=1#diff-7b5f15992292d4c8a9c5241e39c2f11afced0fc54a089fb8d0b3492105e08c4eR143-R180) in this PR. The notification custom actions along with its category is pre-created by the application and registered at launch time. Therefore AJO doesn't control the creation of action buttons from its authoring UI. The authoring UI should only ask for the categoryID of the already registered category that can be invoked. 

Since AJO doesn't have the power to define the actions of a custom notification button. So Messaging SDK would not be able to handle the custom notification action links. This has to be handled by the application as shown [here](https://github.com/adobe/aepsdk-messaging-ios/compare/main...PravinPK:aepsdk-messaging-ios:dev-v1.1.1?expand=1#diff-7b5f15992292d4c8a9c5241e39c2f11afced0fc54a089fb8d0b3492105e08c4eR184-R196).


### A Complex Scenario
Assume an AJO consumer wants to design the following notification such that

![Screenshot 2023-04-11 at 1 52 07 PM](https://user-images.githubusercontent.com/8909148/231285453-ae9bf8f7-fdc4-4824-85fd-c839df1bf105.png)

1. Clicking on the body should open a deeplink to the tutorial
2. Clicking on the custom action "Read Later" should dismiss the notification
3. Clicking on the custom action  "Show Details" should open the app with a deeplink
4. Clicking on the custom action "Unsubscribe" should open the app with deeplink to unsubscribe

To achieve this example:
1. The app should be predefined to register a notification category called "tutorial" with 3 buttons with names as shown above
2. The app should also be predefined to handle the action when each of these action buttons is clicked

3. Now the user goes to AJO UI and sets the notification content with
        Body click behavior - DEEPLINK  (with deeplink of that specific tutorial) 
        iOS categoryID - "tutorial" (this will show the 3 button that are preconfigured)
       + any custom notification payload that are necessary

4.  In this example the messaging SDK should only handle the action of the notification body but not the 3 action buttons. Hence in this PR the notification interaction event includes the "pushclickthroughurl" in eventData only when the API is passed with customaction `nil` and `applicationOpened` = true ([code here](https://github.com/adobe/aepsdk-messaging-ios/pull/174/files#))



