### PR TITLE
MOB 18751 - Simplified HandleNotificationResponse API 

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -159,6 +159,13 @@
 		B45151C97D7CC04168690FB8 /* Pods_MessagingDemoApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69F23BE01498B5A36EEE4CDC /* Pods_MessagingDemoApp.framework */; };
 		B6165DA629A67ADA0031B84D /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6165DA529A67ADA0031B84D /* NotificationService.swift */; };
 		B6165DAA29A67ADA0031B84D /* NotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B6165DA329A67AD90031B84D /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B631AE102A61205A00E8B82E /* CountDownLatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE0F2A61205A00E8B82E /* CountDownLatch.swift */; };
+		B631AE112A612DA000E8B82E /* CountDownLatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE0F2A61205A00E8B82E /* CountDownLatch.swift */; };
+		B631AE132A6131BA00E8B82E /* FunctionalTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE122A6131BA00E8B82E /* FunctionalTestBase.swift */; };
+		B631AE162A61336800E8B82E /* MessagingNotificationTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE152A61336800E8B82E /* MessagingNotificationTrackingTests.swift */; };
+		B631AE182A61374500E8B82E /* IntrumentedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE172A61374500E8B82E /* IntrumentedExtension.swift */; };
+		B631AE1A2A6139CE00E8B82E /* UserDefaults+Test.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE192A6139CE00E8B82E /* UserDefaults+Test.swift .swift */; };
+		B631AE1C2A613A1E00E8B82E /* FileManager+Test.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE1B2A613A1E00E8B82E /* FileManager+Test.swift .swift */; };
 		B6D6A02B265FB1FA005042BE /* Dictionary+Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928639FB263757A7000AFA53 /* Dictionary+Flatten.swift */; };
 /* End PBXBuildFile section */
 
@@ -424,6 +431,12 @@
 		B6165DA329A67AD90031B84D /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6165DA529A67ADA0031B84D /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		B6165DA729A67ADA0031B84D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B631AE0F2A61205A00E8B82E /* CountDownLatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountDownLatch.swift; sourceTree = "<group>"; };
+		B631AE122A6131BA00E8B82E /* FunctionalTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionalTestBase.swift; sourceTree = "<group>"; };
+		B631AE152A61336800E8B82E /* MessagingNotificationTrackingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingNotificationTrackingTests.swift; sourceTree = "<group>"; };
+		B631AE172A61374500E8B82E /* IntrumentedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntrumentedExtension.swift; sourceTree = "<group>"; };
+		B631AE192A6139CE00E8B82E /* UserDefaults+Test.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Test.swift .swift"; sourceTree = "<group>"; };
+		B631AE1B2A613A1E00E8B82E /* FileManager+Test.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Test.swift .swift"; sourceTree = "<group>"; };
 		C003D7513651C8FD2BC84411 /* Pods-AEPMessaging.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPMessaging.debug.xcconfig"; path = "Target Support Files/Pods-AEPMessaging/Pods-AEPMessaging.debug.xcconfig"; sourceTree = "<group>"; };
 		CFBC956862FD1C6747587F09 /* Pods-E2EFunctionalTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.debug.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		CFC660CD22A375E0F809B475 /* Pods-E2EFunctionalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.release.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -726,6 +739,11 @@
 				2402745B29FC424000884DFE /* TestableMessagingDelegate.swift */,
 				243EA6DF2739D9D700195945 /* TestableMessagingMobileParameters.swift */,
 				928639D026374463000AFA53 /* TestableNetworkService.swift */,
+				B631AE0F2A61205A00E8B82E /* CountDownLatch.swift */,
+				B631AE122A6131BA00E8B82E /* FunctionalTestBase.swift */,
+				B631AE1B2A613A1E00E8B82E /* FileManager+Test.swift .swift */,
+				B631AE172A61374500E8B82E /* IntrumentedExtension.swift */,
+				B631AE192A6139CE00E8B82E /* UserDefaults+Test.swift .swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -791,6 +809,7 @@
 				2469A6032759999E00E56457 /* FunctionalTestApp */,
 				24EE301D28FF61F0005E417C /* InAppMessagingEventTests.swift */,
 				92863A012637706F000AFA53 /* MessagingFunctionalTests.swift */,
+				B631AE152A61336800E8B82E /* MessagingNotificationTrackingTests.swift */,
 				92FC587A2636840C005BAE02 /* MessagingPublicAPITests.swift */,
 				92FC587C2636840C005BAE02 /* Info.plist */,
 			);
@@ -1572,6 +1591,7 @@
 				2450596F2673DBFE00CC7CA0 /* Event+MessagingTests.swift in Sources */,
 				243EA6DA2739D47500195945 /* MockMessaging.swift in Sources */,
 				243EA6D42733261E00195945 /* MessagingEdgeEventTypeTests.swift in Sources */,
+				B631AE112A612DA000E8B82E /* CountDownLatch.swift in Sources */,
 				2402745E29FC424000884DFE /* TestableMessagingDelegate.swift in Sources */,
 				243EA6CF273325CC00195945 /* Message+FullscreenMessageDelegateTests.swift in Sources */,
 				245059712673DBFE00CC7CA0 /* MessagingTests.swift in Sources */,
@@ -1599,17 +1619,23 @@
 			buildActionMask = 2147483647;
 			files = (
 				92FC58D326368900005BAE02 /* MockNetworkService.swift in Sources */,
+				B631AE182A61374500E8B82E /* IntrumentedExtension.swift in Sources */,
+				B631AE132A6131BA00E8B82E /* FunctionalTestBase.swift in Sources */,
 				92FC58CE263688FD005BAE02 /* TestableExtensionRuntime.swift in Sources */,
 				928639FC263757A7000AFA53 /* Dictionary+Flatten.swift in Sources */,
 				2402745D29FC424000884DFE /* TestableMessagingDelegate.swift in Sources */,
 				24EE301E28FF61F0005E417C /* InAppMessagingEventTests.swift in Sources */,
 				92FC58C8263688F0005BAE02 /* EventHub+Testable.swift in Sources */,
+				B631AE1A2A6139CE00E8B82E /* UserDefaults+Test.swift .swift in Sources */,
+				B631AE102A61205A00E8B82E /* CountDownLatch.swift in Sources */,
 				928639D126374463000AFA53 /* TestableNetworkService.swift in Sources */,
 				92FC594526372E34005BAE02 /* MockNotificationResponseCoder.swift in Sources */,
 				92FC587B2636840C005BAE02 /* MessagingPublicAPITests.swift in Sources */,
 				2469A5FB2759401900E56457 /* ConfigurationLoader.swift in Sources */,
 				92863A022637706F000AFA53 /* MessagingFunctionalTests.swift in Sources */,
 				92FC58D826368901005BAE02 /* MockExtension.swift in Sources */,
+				B631AE162A61336800E8B82E /* MessagingNotificationTrackingTests.swift in Sources */,
+				B631AE1C2A613A1E00E8B82E /* FileManager+Test.swift .swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -60,7 +60,6 @@ import UserNotifications
     /// - Parameters:
     ///   - response: UNNotificationResponse object which contains the payload and xdm informations.
     static func handleNotificationResponse(_ response: UNNotificationResponse) {
-
         hasApplicationOpenedForResponse(response, completion: { isAppOpened in
 
             let notificationRequest = response.notification.request
@@ -83,7 +82,6 @@ import UserNotifications
                               data: modifiedEventData)
             MobileCore.dispatch(event: event)
         })
-
     }
 
     /// Initiates a network call to retrieve remote In-App Message definitions.
@@ -105,7 +103,7 @@ import UserNotifications
             completion(false)
         default:
             // If customAction has been performed by the user,
-            // then examine the custom action option to check if the action has brought the app to foreground.
+            // then examine the registered custom action option to check if the action has brought the app to foreground.
             UNUserNotificationCenter.current().getNotificationCategories { categories in
                 for category in categories where category.identifier == response.notification.request.content.categoryIdentifier {
                     for action in category.actions where action.identifier == response.actionIdentifier {
@@ -133,8 +131,8 @@ import UserNotifications
             // This results in opening of the application.
             modifiedEventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.APPLICATION_OPENED
 
-            // Coming in next PR,
-            // TODO: add any notificaiton action url to the event data to be processed.
+        // Coming in next PR,
+        // TODO: add any notificaiton action url to the event data to be processed.
         case UNNotificationDismissActionIdentifier:
             // customActionId `UNNotificationDefaultActionIdentifier` indicates user has dismissed the notification by tapping "Clear" action button
             modifiedEventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.CUSTOM_ACTION
@@ -148,5 +146,4 @@ import UserNotifications
 
         return modifiedEventData
     }
-
 }

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -21,7 +21,7 @@ import UserNotifications
     ///   - applicationOpened: Boolean values denoting whether the application was opened when notification was clicked
     ///   - customActionId: String value of the custom action (e.g button id on the notification) which was clicked.
     ///
-    @available(*, deprecated, message: "This method is deprecated. Use Messaging.handleNotificationResponse(response) instead to automatically track application open and handle notification actions.")
+    @available(*, deprecated, message: "This method is deprecated. Use Messaging.handleNotificationResponse(:) instead to automatically track application open and handle notification actions.")
     @objc(handleNotificationResponse:applicationOpened:withCustomActionId:)
     static func handleNotificationResponse(_ response: UNNotificationResponse, applicationOpened: Bool, customActionId: String?) {
         let notificationRequest = response.notification.request
@@ -29,7 +29,7 @@ import UserNotifications
         // Checking if the message has the optional xdm key
         let xdm = notificationRequest.content.userInfo[MessagingConstants.XDM.AdobeKeys._XDM] as? [String: Any]
         if xdm == nil {
-            Log.debug(label: MessagingConstants.LOG_TAG, "XDM specific fields are missing from push notification response.")
+            Log.debug(label: MessagingConstants.LOG_TAG, "Optional XDM specific fields are missing from push notification response.")
         }
 
         let messageId = notificationRequest.identifier
@@ -57,8 +57,7 @@ import UserNotifications
     }
 
     /// Sends the push notification interactions as an experience event to Adobe Experience Edge.
-    /// - Parameters:
-    ///   - response: UNNotificationResponse object which contains the payload and xdm informations.
+    /// - Parameter response: UNNotificationResponse object which contains the payload and xdm informations.
     static func handleNotificationResponse(_ response: UNNotificationResponse) {
         hasApplicationOpenedForResponse(response, completion: { isAppOpened in
 
@@ -67,7 +66,7 @@ import UserNotifications
             // Checking if the message has the optional xdm key
             let xdm = notificationRequest.content.userInfo[MessagingConstants.XDM.AdobeKeys._XDM] as? [String: Any]
             if xdm == nil {
-                Log.debug(label: MessagingConstants.LOG_TAG, "Optional XDM specific fields are missing from push notification interaction.")
+                Log.debug(label: MessagingConstants.LOG_TAG, "Optional XDM specific fields are missing from push notification response.")
             }
 
             let eventData: [String: Any] = [MessagingConstants.Event.Data.Key.MESSAGE_ID: notificationRequest.identifier,
@@ -151,12 +150,13 @@ import UserNotifications
         // Coming in next PR,
         // TODO: add any notificaiton action url to the event data to be processed.
         case UNNotificationDismissActionIdentifier:
-            // customActionId `UNNotificationDefaultActionIdentifier` indicates user has dismissed the notification by tapping "Clear" action button
+            // customActionId `UNNotificationDefaultActionIdentifier` indicates user has dismissed the
+            // notification by tapping "Clear" action button.
             modifiedEventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.CUSTOM_ACTION
             modifiedEventData[MessagingConstants.Event.Data.Key.ACTION_ID] = "Dismiss"
         default:
-            // If customActionId is none of the default values. This means
-            // This results in opening of the application.
+            // If customActionId is none of the default values.
+            // This indicates that a custom action on a notification is taken by the user.
             modifiedEventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.CUSTOM_ACTION
             modifiedEventData[MessagingConstants.Event.Data.Key.ACTION_ID] = response.actionIdentifier
         }

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -20,6 +20,8 @@ import UserNotifications
     ///   - response: UNNotificationResponse object which contains the payload and xdm informations.
     ///   - applicationOpened: Boolean values denoting whether the application was opened when notification was clicked
     ///   - customActionId: String value of the custom action (e.g button id on the notification) which was clicked.
+    ///
+    @available(*, deprecated, message: "This method is deprecated. Use Messaging.handleNotificationResponse(response) instead to automatically track application open and handle notification actions.")
     @objc(handleNotificationResponse:applicationOpened:withCustomActionId:)
     static func handleNotificationResponse(_ response: UNNotificationResponse, applicationOpened: Bool, customActionId: String?) {
         let notificationRequest = response.notification.request
@@ -27,7 +29,7 @@ import UserNotifications
         // Checking if the message has the optional xdm key
         let xdm = notificationRequest.content.userInfo[MessagingConstants.XDM.AdobeKeys._XDM] as? [String: Any]
         if xdm == nil {
-            Log.debug(label: MessagingConstants.LOG_TAG, "Optional XDM specific fields are missing from push notification interaction.")
+            Log.debug(label: MessagingConstants.LOG_TAG, "XDM specific fields are missing from push notification response.")
         }
 
         let messageId = notificationRequest.identifier
@@ -54,6 +56,36 @@ import UserNotifications
         MobileCore.dispatch(event: event)
     }
 
+    /// Sends the push notification interactions as an experience event to Adobe Experience Edge.
+    /// - Parameters:
+    ///   - response: UNNotificationResponse object which contains the payload and xdm informations.
+    static func handleNotificationResponse(_ response: UNNotificationResponse) {
+
+        hasApplicationOpenedForResponse(response, completion: { isAppOpened in
+
+            let notificationRequest = response.notification.request
+
+            // Checking if the message has the optional xdm key
+            let xdm = notificationRequest.content.userInfo[MessagingConstants.XDM.AdobeKeys._XDM] as? [String: Any]
+            if xdm == nil {
+                Log.debug(label: MessagingConstants.LOG_TAG, "Optional XDM specific fields are missing from push notification interaction.")
+            }
+
+            let eventData: [String: Any] = [MessagingConstants.Event.Data.Key.MESSAGE_ID: notificationRequest.identifier,
+                                            MessagingConstants.Event.Data.Key.APPLICATION_OPENED: isAppOpened,
+                                            MessagingConstants.Event.Data.Key.ADOBE_XDM: xdm ?? [:]] // If xdm data is nil we use
+
+            let modifiedEventData = addNotificationActionToEventData(eventData, response)
+
+            let event = Event(name: MessagingConstants.Event.Name.PUSH_NOTIFICATION_INTERACTION,
+                              type: MessagingConstants.Event.EventType.messaging,
+                              source: EventSource.requestContent,
+                              data: modifiedEventData)
+            MobileCore.dispatch(event: event)
+        })
+
+    }
+
     /// Initiates a network call to retrieve remote In-App Message definitions.
     static func refreshInAppMessages() {
         let eventData: [String: Any] = [MessagingConstants.Event.Data.Key.REFRESH_MESSAGES: true]
@@ -64,4 +96,57 @@ import UserNotifications
 
         MobileCore.dispatch(event: event)
     }
+
+    private static func hasApplicationOpenedForResponse(_ response: UNNotificationResponse, completion: @escaping (Bool) -> Void) {
+        switch response.actionIdentifier {
+        case UNNotificationDefaultActionIdentifier:
+            completion(true)
+        case UNNotificationDismissActionIdentifier:
+            completion(false)
+        default:
+            // If customAction has been performed by the user,
+            // then examine the custom action option to check if the action has brought the app to foreground.
+            UNUserNotificationCenter.current().getNotificationCategories { categories in
+                for category in categories where category.identifier == response.notification.request.content.categoryIdentifier {
+                    for action in category.actions where action.identifier == response.actionIdentifier {
+                        if action.options.contains(.foreground) {
+                            completion(true)
+                            return
+                        } else {
+                            completion(false)
+                            return
+                        }
+                    }
+                }
+                // unlikely case
+                // if the custom actionID is not found in the registered categories return false
+                completion(false)
+            }
+        }
+    }
+
+    private static func addNotificationActionToEventData(_ eventData: [String: Any], _ response: UNNotificationResponse) -> [String: Any] {
+        var modifiedEventData = eventData
+        switch response.actionIdentifier {
+        case UNNotificationDefaultActionIdentifier:
+            // customActionId `UNNotificationDefaultActionIdentifier` indicates user tapped the notification body.
+            // This results in opening of the application.
+            modifiedEventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.APPLICATION_OPENED
+
+            // Coming in next PR,
+            // TODO: add any notificaiton action url to the event data to be processed.
+        case UNNotificationDismissActionIdentifier:
+            // customActionId `UNNotificationDefaultActionIdentifier` indicates user has dismissed the notification by tapping "Clear" action button
+            modifiedEventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.CUSTOM_ACTION
+            modifiedEventData[MessagingConstants.Event.Data.Key.ACTION_ID] = "Dismiss"
+        default:
+            // If customActionId is none of the default values. This means
+            // This results in opening of the application.
+            modifiedEventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.CUSTOM_ACTION
+            modifiedEventData[MessagingConstants.Event.Data.Key.ACTION_ID] = response.actionIdentifier
+        }
+
+        return modifiedEventData
+    }
+
 }

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -95,6 +95,18 @@ import UserNotifications
         MobileCore.dispatch(event: event)
     }
 
+    // MARK: - Private Helper Methods
+    
+    /// Determines whether the user's response to a notification has caused the application to open
+    ///
+    /// This method analyzes the registered categories and notification action buttons of the application
+    /// and determines if the application was opened based on the action performed by the user. The result is provided through the `completion` closure.
+    ///
+    /// - Parameters:
+    ///   - response: The user's response to a notification, represented by a `UNNotificationResponse` object.
+    ///   - completion: A closure that takes a `Bool` parameter indicating whether the application was opened or not. This closure is invoked asynchronously once the determination is made.
+    ///
+    /// - Note: The completion handler is invoked asynchronously, so any code relying on the result should be placed within the completion handler or called from there.
     private static func hasApplicationOpenedForResponse(_ response: UNNotificationResponse, completion: @escaping (Bool) -> Void) {
         switch response.actionIdentifier {
         case UNNotificationDefaultActionIdentifier:
@@ -116,13 +128,19 @@ import UserNotifications
                         }
                     }
                 }
-                // unlikely case
-                // if the custom actionID is not found in the registered categories return false
+                // Unlikely Case: If the custom actionID is not found in the registered categories, then return false
                 completion(false)
             }
         }
     }
 
+
+    /// Modifies the provided event data based on the user's response to a notification.
+    ///
+    /// - Parameters:
+    ///   - eventData: The original event data dictionary.
+    ///   - response: The user's response to a notification, represented by a `UNNotificationResponse` object.
+    /// - Returns: The modified event data dictionary.
     private static func addNotificationActionToEventData(_ eventData: [String: Any], _ response: UNNotificationResponse) -> [String: Any] {
         var modifiedEventData = eventData
         switch response.actionIdentifier {

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -96,7 +96,7 @@ import UserNotifications
     }
 
     // MARK: - Private Helper Methods
-    
+
     /// Determines whether the user's response to a notification has caused the application to open
     ///
     /// This method analyzes the registered categories and notification action buttons of the application
@@ -133,7 +133,6 @@ import UserNotifications
             }
         }
     }
-
 
     /// Modifies the provided event data based on the user's response to a notification.
     ///

--- a/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
@@ -1,0 +1,230 @@
+/*
+ Copyright 2023 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+@testable import AEPCore
+@testable import AEPMessaging
+import AEPEdgeIdentity
+import XCTest
+
+class MessagingNotificationTrackingTests: FunctionalTestBase {
+    
+    static let mockUserInfo = ["_xdm" :
+                                ["cjm":
+                                    ["_experience":
+                                        ["customerJourneyManagement":
+                                            ["messageExecution":
+                                                ["messageExecutionID": "mockExecutionID",
+                                                 "journeyVersionID": "mockJourneyVersionID",
+                                                 "journeyVersionInstanceId": "mockJourneyVersionInstanceId",
+                                                 "messageID": "mockMessageId"]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+    ]
+    
+    
+    public class override func setUp() {
+        super.setUp()
+        FunctionalTestBase.debugEnabled = true
+    }
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = true
+        FileManager.default.clearCache()
+
+        // hub shared state update for 1 extension versions (InstrumentedExtension (registered in FunctionalTestBase), IdentityEdge, Edge Identity, Config
+        setExpectationEvent(type: EventType.hub, source: EventSource.sharedState, expectedCount: 3)
+        
+
+        // expectations for update config request&response events
+        setExpectationEvent(type: EventType.configuration, source: EventSource.requestContent, expectedCount: 1)
+        setExpectationEvent(type: EventType.configuration, source: EventSource.responseContent, expectedCount: 1)
+        setExpectationEvent(type: EventType.edge, source: EventSource.requestContent, expectedCount: 1)
+        
+        // wait for async registration because the EventHub is already started in FunctionalTestBase
+        let waitForRegistration = CountDownLatch(1)
+        MobileCore.registerExtensions([Messaging.self, Identity.self], {
+            print("Extensions registration is complete")
+            waitForRegistration.countDown()
+        })
+        XCTAssertEqual(DispatchTimeoutResult.success, waitForRegistration.await(timeout: 2))
+        MobileCore.updateConfigurationWith(configDict: ["messaging.eventDataset": "mockDataset"])
+
+        assertExpectedEvents(ignoreUnexpectedEvents: false)
+        resetTestExpectations()
+        setNotificationCategories()
+    }
+    
+    // MARK: - Tests
+    
+    func test_notificationTracking_whenUser_tapsNotificationBody() {
+        // setup
+        setExpectationEvent(type: EventType.edge, source: EventSource.requestContent, expectedCount: 1)
+        let response = prepareNotificationResponse()!
+        
+        // test
+        Messaging.handleNotificationResponse(response)
+        
+        // verify
+        let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
+        XCTAssertEqual(1, events.count)
+        let edgeEvent = events.first!
+        let flattenEdgeEvent = edgeEvent.data?.flattening()
+        
+        // verify push tracking information
+        XCTAssertEqual(1, flattenEdgeEvent?["xdm.application.launches.value"] as? Int)
+        XCTAssertEqual("pushTracking.applicationOpened", flattenEdgeEvent?["xdm.eventType"] as? String)
+        XCTAssertNil(flattenEdgeEvent?["xdm.pushNotificationTracking.customAction.actionID"] as? String)
+        
+        // verify cjm/mixins and other xdm related data
+        XCTAssertEqual("mockJourneyVersionID", flattenEdgeEvent?["xdm._experience.customerJourneyManagement.messageExecution.journeyVersionID"] as? String)
+        XCTAssertEqual("mockJourneyVersionInstanceId", flattenEdgeEvent?["xdm._experience.customerJourneyManagement.messageExecution.journeyVersionInstanceId"] as? String)
+        XCTAssertEqual("mockMessageId", flattenEdgeEvent?["xdm._experience.customerJourneyManagement.messageExecution.messageID"] as? String)
+        XCTAssertEqual("apns", flattenEdgeEvent?["xdm._experience.customerJourneyManagement.pushChannelContext.platform"] as? String)
+        XCTAssertEqual("https://ns.adobe.com/xdm/channels/push", flattenEdgeEvent?["xdm._experience.customerJourneyManagement.messageProfile.channel._id"] as? String)
+        XCTAssertEqual("mockExecutionID", flattenEdgeEvent?["xdm._experience.customerJourneyManagement.messageExecution.messageExecutionID"] as? String)
+        
+        XCTAssertEqual("apns", flattenEdgeEvent?["xdm.pushNotificationTracking.pushProvider"] as? String)
+        XCTAssertEqual("messageId", flattenEdgeEvent?["xdm.pushNotificationTracking.pushProviderMessageID"] as? String)
+        XCTAssertEqual("mockDataset", flattenEdgeEvent?["meta.collect.datasetId"] as? String)
+    }
+    
+    func test_notificationTracking_whenUser_DismissesNotification() {
+        // setup
+        setExpectationEvent(type: EventType.edge, source: EventSource.requestContent, expectedCount: 1)
+        let response = prepareNotificationResponse(actionIdentifier: UNNotificationDismissActionIdentifier)!
+        
+        // test
+        Messaging.handleNotificationResponse(response)
+        
+        // verify
+        let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
+        XCTAssertEqual(1, events.count)
+        let edgeEvent = events.first!
+        let flattenEdgeEvent = edgeEvent.data?.flattening()
+        
+        // verify push tracking information
+        XCTAssertEqual(0, flattenEdgeEvent?["xdm.application.launches.value"] as? Int)
+        XCTAssertEqual("pushTracking.customAction", flattenEdgeEvent?["xdm.eventType"] as? String)
+        XCTAssertEqual("Dismiss",flattenEdgeEvent?["xdm.pushNotificationTracking.customAction.actionID"] as? String)
+    }
+    
+    func test_notificationTracking_whenUser_tapsNotificationActionThatOpensTheApp() {
+        // setup
+        setExpectationEvent(type: EventType.edge, source: EventSource.requestContent, expectedCount: 1)
+        let response = prepareNotificationResponse(actionIdentifier: "ForegroundActionId", categoryIdentifier: "CategoryId")!
+        
+        // test
+        Messaging.handleNotificationResponse(response)
+        
+        // verify
+        let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
+        XCTAssertEqual(1, events.count)
+        let edgeEvent = events.first!
+        let flattenEdgeEvent = edgeEvent.data?.flattening()
+        
+        // verify push tracking information
+        XCTAssertEqual(1, flattenEdgeEvent?["xdm.application.launches.value"] as? Int)
+        XCTAssertEqual("pushTracking.customAction", flattenEdgeEvent?["xdm.eventType"] as? String)
+        XCTAssertEqual("ForegroundActionId",flattenEdgeEvent?["xdm.pushNotificationTracking.customAction.actionID"] as? String)
+    }
+    
+    
+    func test_notificationTracking_whenUser_tapsNotificationActionThatDoNotOpenTheApp() {
+        // setup
+        setExpectationEvent(type: EventType.edge, source: EventSource.requestContent, expectedCount: 1)
+        let response = prepareNotificationResponse(actionIdentifier: "DeclineActionId", categoryIdentifier: "CategoryId")!
+        
+        // test
+        Messaging.handleNotificationResponse(response)
+        
+        // verify
+        let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
+        XCTAssertEqual(1, events.count)
+        let edgeEvent = events.first!
+        let flattenEdgeEvent = edgeEvent.data?.flattening()
+        
+        // verify push tracking information
+        XCTAssertEqual(0, flattenEdgeEvent?["xdm.application.launches.value"] as? Int)
+        XCTAssertEqual("pushTracking.customAction", flattenEdgeEvent?["xdm.eventType"] as? String)
+        XCTAssertEqual("DeclineActionId",flattenEdgeEvent?["xdm.pushNotificationTracking.customAction.actionID"] as? String)
+    }
+    
+    func test_notificationTracking_whenUser_tapsNotificationActionThatDoNotOpenTheApp_Case2() {
+        // This test simulates clicking on a notification action button for which notification options buttons are empty
+        // setup
+        setExpectationEvent(type: EventType.edge, source: EventSource.requestContent, expectedCount: 1)
+        let response = prepareNotificationResponse(actionIdentifier: "notForegroundActionId", categoryIdentifier: "CategoryId")!
+        
+        // test
+        Messaging.handleNotificationResponse(response)
+        
+        // verify
+        let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
+        XCTAssertEqual(1, events.count)
+        let edgeEvent = events.first!
+        let flattenEdgeEvent = edgeEvent.data?.flattening()
+        
+        // verify push tracking information
+        XCTAssertEqual(0, flattenEdgeEvent?["xdm.application.launches.value"] as? Int)
+        XCTAssertEqual("pushTracking.customAction", flattenEdgeEvent?["xdm.eventType"] as? String)
+        XCTAssertEqual("notForegroundActionId",flattenEdgeEvent?["xdm.pushNotificationTracking.customAction.actionID"] as? String)
+    }
+    
+    
+    // MARK: - Private Helpers functions
+    
+    private func prepareNotificationResponse(withUserInfo userInfo : [String:Any] = mockUserInfo,
+                                             actionIdentifier: String = UNNotificationDefaultActionIdentifier,
+                                             categoryIdentifier: String = "") -> UNNotificationResponse? {
+        let dateInfo = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: Date())
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateInfo, repeats: false)
+        let notificationContent = UNMutableNotificationContent()
+        notificationContent.userInfo = userInfo
+        notificationContent.categoryIdentifier = categoryIdentifier
+
+        let request = UNNotificationRequest(identifier: "messageId" , content: notificationContent, trigger: trigger)
+        guard let response = UNNotificationResponse(coder: MockNotificationResponseCoder(with: request,
+                                                                                         actionIdentifier:actionIdentifier)) else {
+            XCTFail()
+            return nil
+        }
+        return response
+    }
+    
+    private func setNotificationCategories() {
+        let acceptAction = UNNotificationAction(identifier: "ForegroundActionId",
+              title: "Foreground",
+              options: [.foreground])
+        let declineAction = UNNotificationAction(identifier: "DeclineActionId",
+              title: "Decline",
+              options: [.destructive,.authenticationRequired])
+        let notForegroundAction = UNNotificationAction(identifier: "notForegroundActionId",
+              title: "NotForeground",
+              options: [])
+        // Define the notification type
+        let meetingInviteCategory =
+              UNNotificationCategory(identifier: "CategoryId",
+              actions: [acceptAction, declineAction, notForegroundAction],
+              intentIdentifiers: [],
+              hiddenPreviewsBodyPlaceholder: "",
+              options: .customDismissAction)
+        // Register the notification type.
+        let notificationCenter = UNUserNotificationCenter.current()
+        notificationCenter.setNotificationCategories([meetingInviteCategory])
+    }
+    
+}
+

--- a/AEPMessaging/Tests/TestHelpers/CountDownLatch.swift
+++ b/AEPMessaging/Tests/TestHelpers/CountDownLatch.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import Foundation
+
+/// CountDown latch to be used for asserts and expectations
+class CountDownLatch {
+    private let initialCount: Int32
+    private var currentCount: Int32
+    private let waitSemaphore = DispatchSemaphore(value: 0)
+
+    init(_ expectedCount: Int32) {
+        guard expectedCount > 0 else {
+            assertionFailure("CountDownLatch requires a count greater than 0")
+            self.currentCount = 0
+            self.initialCount = 0
+            return
+        }
+
+        self.currentCount = expectedCount
+        self.initialCount = expectedCount
+    }
+
+    func getCurrentCount() -> Int32 {
+        return currentCount
+    }
+
+    func getInitialCount() -> Int32 {
+        return initialCount
+    }
+
+    func await(timeout: TimeInterval = 1) -> DispatchTimeoutResult {
+        return currentCount > 0 ? waitSemaphore.wait(timeout: (DispatchTime.now() + timeout)) : DispatchTimeoutResult.success
+    }
+
+    func countDown() {
+        OSAtomicDecrement32(&currentCount)
+        if currentCount == 0 {
+            waitSemaphore.signal()
+        }
+
+        if currentCount < 0 {
+            print("Count Down decreased more times than expected.")
+        }
+
+    }
+}

--- a/AEPMessaging/Tests/TestHelpers/FileManager+Test.swift .swift
+++ b/AEPMessaging/Tests/TestHelpers/FileManager+Test.swift .swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+@testable import AEPServices
+import Foundation
+
+extension FileManager {
+
+    func clearCache() {
+        let knownCacheItems: [String] = ["com.adobe.edge", "com.adobe.edge.identity", "com.adobe.edge.consent"]
+        guard let url = self.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return
+        }
+
+        for cacheItem in knownCacheItems {
+            do {
+                try self.removeItem(at: URL(fileURLWithPath: "\(url.relativePath)/\(cacheItem)"))
+                if let dqService = ServiceProvider.shared.dataQueueService as? DataQueueService {
+                    _ = dqService.threadSafeDictionary.removeValue(forKey: cacheItem)
+                }
+            } catch {
+                print("ERROR DESCRIPTION: \(error)")
+            }
+        }
+    }
+}

--- a/AEPMessaging/Tests/TestHelpers/FunctionalTestBase.swift
+++ b/AEPMessaging/Tests/TestHelpers/FunctionalTestBase.swift
@@ -1,0 +1,240 @@
+//
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+@testable import AEPCore
+import AEPServices
+import Foundation
+import XCTest
+
+/// Struct defining the event specifications - contains the event type and source
+struct EventSpec {
+    let type: String
+    let source: String
+}
+
+/// Hashable `EventSpec`, to be used as key in Dictionaries
+extension EventSpec: Hashable & Equatable {
+
+    static func == (lhs: EventSpec, rhs: EventSpec) -> Bool {
+        return lhs.source.lowercased() == rhs.source.lowercased() && lhs.type.lowercased() == rhs.type.lowercased()
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(type)
+        hasher.combine(source)
+    }
+}
+
+class FunctionalTestBase: XCTestCase {
+    
+    /// Use this property to execute code logic in the first run in this test class; this value changes to False after the parent tearDown is executed
+    private(set) static var isFirstRun: Bool = true
+    /// Use this setting to enable debug mode logging in the `FunctionalTestBase`
+    static var debugEnabled = false
+    
+    static let WAIT_EVENT_TIMEOUT: TimeInterval = 2
+    static let WAIT_SHARED_STATE_TIMEOUT: TimeInterval = 3
+    static let WAIT_NETWORK_REQUEST_TIMEOUT: TimeInterval = 2
+    static let WAIT_TIMEOUT: UInt32 = 1 // used when no expectation is set
+    
+    private enum EventType {
+        static let INSTRUMENTED_EXTENSION = "com.adobe.eventType.instrumentedExtension"
+    }
+    
+    private enum EventSource {
+        static let SHARED_STATE_REQUEST = "com.adobe.eventSource.requestState"
+        static let UNREGISTER_EXTENSION = "com.adobe.eventSource.unregisterExtension"
+    }
+
+    public class override func setUp() {
+        super.setUp()
+        UserDefaults.clearAll()
+        FileManager.default.clearCache()
+        MobileCore.setLogLevel(LogLevel.trace)
+    }
+
+    public override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        MobileCore.registerExtension(InstrumentedExtension.self)
+    }
+
+    public override func tearDown() {
+        super.tearDown()
+
+        // to revisit when AMSDK-10169 is available
+        // wait .2 seconds in case there are unexpected events that were in the dispatch process during cleanup
+        usleep(200000)
+        resetTestExpectations()
+        FunctionalTestBase.isFirstRun = false
+        EventHub.reset()
+        UserDefaults.clearAll()
+        FileManager.default.clearCache()
+    }
+
+    /// Reset event and network request expectations and drop the items received until this point
+    func resetTestExpectations() {
+        log("Resetting functional test expectations for events and network requests")
+        InstrumentedExtension.reset()
+    }
+
+    /// Unregisters the `InstrumentedExtension` from the Event Hub. This method executes asynchronous.
+    func unregisterInstrumentedExtension() {
+        let event = Event(name: "Unregister Instrumented Extension",
+                          type: EventType.INSTRUMENTED_EXTENSION,
+                          source: EventSource.UNREGISTER_EXTENSION,
+                          data: nil)
+
+        MobileCore.dispatch(event: event)
+    }
+
+    // MARK: Expected/Unexpected events assertions
+
+    /// Sets an expectation for a specific event type and source and how many times the event should be dispatched
+    /// - Parameters:
+    ///   - type: the event type as a `String`, should not be empty
+    ///   - source: the event source as a `String`, should not be empty
+    ///   - count: the number of times this event should be dispatched, but default it is set to 1
+    /// - See also:
+    ///   - assertExpectedEvents(ignoreUnexpectedEvents:)
+    func setExpectationEvent(type: String, source: String, expectedCount: Int32 = 1) {
+        guard expectedCount > 0 else {
+            assertionFailure("Expected event count should be greater than 0")
+            return
+        }
+        guard !type.isEmpty, !source.isEmpty else {
+            assertionFailure("Expected event type and source should be non-empty trings")
+            return
+        }
+
+        InstrumentedExtension.expectedEvents[EventSpec(type: type, source: source)] = CountDownLatch(expectedCount)
+    }
+
+    /// Asserts if all the expected events were received and fails if an unexpected event was seen
+    /// - Parameters:
+    ///   - ignoreUnexpectedEvents: if set on false, an assertion is made on unexpected events, otherwise the unexpected events are ignored
+    /// - See also:
+    ///   - setExpectationEvent(type: source: count:)
+    ///   - assertUnexpectedEvents()
+    func assertExpectedEvents(ignoreUnexpectedEvents: Bool = false, file: StaticString = #file, line: UInt = #line) {
+        guard InstrumentedExtension.expectedEvents.count > 0 else { // swiftlint:disable:this empty_count
+            assertionFailure("There are no event expectations set, use this API after calling setExpectationEvent", file: file, line: line)
+            return
+        }
+
+        let currentExpectedEvents = InstrumentedExtension.expectedEvents.shallowCopy
+        for expectedEvent in currentExpectedEvents {
+            let waitResult = expectedEvent.value.await(timeout: FunctionalTestBase.WAIT_EVENT_TIMEOUT)
+            let expectedCount: Int32 = expectedEvent.value.getInitialCount()
+            let receivedCount: Int32 = expectedEvent.value.getInitialCount() - expectedEvent.value.getCurrentCount()
+            XCTAssertFalse(waitResult == DispatchTimeoutResult.timedOut, "Timed out waiting for event type \(expectedEvent.key.type) and source \(expectedEvent.key.source), expected \(expectedCount), but received \(receivedCount)", file: (file), line: line)
+            XCTAssertEqual(expectedCount, receivedCount, "Expected \(expectedCount) event(s) of type \(expectedEvent.key.type) and source \(expectedEvent.key.source), but received \(receivedCount)", file: (file), line: line)
+        }
+
+        guard ignoreUnexpectedEvents == false else { return }
+        assertUnexpectedEvents(file: file, line: line)
+    }
+
+    /// Asserts if any unexpected event was received. Use this method to verify the received events are correct when setting event expectations.
+    /// - See also: setExpectationEvent(type: source: count:)
+    func assertUnexpectedEvents(file: StaticString = #file, line: UInt = #line) {
+        wait()
+        var unexpectedEventsReceivedCount = 0
+        var unexpectedEventsAsString = ""
+
+        let currentReceivedEvents = InstrumentedExtension.receivedEvents.shallowCopy
+        for receivedEvent in currentReceivedEvents {
+
+            // check if event is expected and it is over the expected count
+            if let expectedEvent = InstrumentedExtension.expectedEvents[EventSpec(type: receivedEvent.key.type, source: receivedEvent.key.source)] {
+                _ = expectedEvent.await(timeout: FunctionalTestBase.WAIT_EVENT_TIMEOUT)
+                let expectedCount: Int32 = expectedEvent.getInitialCount()
+                let receivedCount: Int32 = expectedEvent.getInitialCount() - expectedEvent.getCurrentCount()
+                XCTAssertEqual(expectedCount, receivedCount, "Expected \(expectedCount) events of type \(receivedEvent.key.type) and source \(receivedEvent.key.source), but received \(receivedCount)", file: (file), line: line)
+            }
+            // check for events that don't have expectations set
+            else {
+                unexpectedEventsReceivedCount += receivedEvent.value.count
+                unexpectedEventsAsString.append("(\(receivedEvent.key.type), \(receivedEvent.key.source), \(receivedEvent.value.count)),")
+                log("Received unexpected event with type: \(receivedEvent.key.type) source: \(receivedEvent.key.source)")
+            }
+        }
+
+        XCTAssertEqual(0, unexpectedEventsReceivedCount, "Received \(unexpectedEventsReceivedCount) unexpected event(s): \(unexpectedEventsAsString)", file: (file), line: line)
+    }
+
+    /// To be revisited once AMSDK-10169 is implemented
+    /// - Parameters:
+    ///   - timeout:how long should this method wait, in seconds; by default it waits up to 1 second
+    func wait(_ timeout: UInt32? = WAIT_TIMEOUT) {
+        if let timeout = timeout {
+            sleep(timeout)
+        }
+    }
+
+    /// Returns the `ACPExtensionEvent`(s) dispatched through the Event Hub, or empty if none was found.
+    /// Use this API after calling `setExpectationEvent(type:source:count:)` to wait for the right amount of time
+    /// - Parameters:
+    ///   - type: the event type as in the expectation
+    ///   - source: the event source as in the expectation
+    ///   - timeout: how long should this method wait for the expected event, in seconds; by default it waits up to 1 second
+    /// - Returns: list of events with the provided `type` and `source`, or empty if none was dispatched
+    func getDispatchedEventsWith(type: String, source: String, timeout: TimeInterval = WAIT_EVENT_TIMEOUT, file: StaticString = #file, line: UInt = #line) -> [Event] {
+        if InstrumentedExtension.expectedEvents[EventSpec(type: type, source: source)] != nil {
+            let waitResult = InstrumentedExtension.expectedEvents[EventSpec(type: type, source: source)]?.await(timeout: timeout)
+            XCTAssertFalse(waitResult == DispatchTimeoutResult.timedOut, "Timed out waiting for event type \(type) and source \(source)", file: file, line: line)
+        } else {
+            wait(FunctionalTestBase.WAIT_TIMEOUT)
+        }
+        return InstrumentedExtension.receivedEvents[EventSpec(type: type, source: source)] ?? []
+    }
+
+    /// Synchronous call to get the shared state for the specified `stateOwner`. This API throws an assertion failure in case of timeout.
+    /// - Parameter ownerExtension: the owner extension of the shared state (typically the name of the extension)
+    /// - Parameter timeout: how long should this method wait for the requested shared state, in seconds; by default it waits up to 3 second
+    /// - Returns: latest shared state of the given `stateOwner` or nil if no shared state was found
+    func getSharedStateFor(_ ownerExtension: String, timeout: TimeInterval = WAIT_SHARED_STATE_TIMEOUT) -> [AnyHashable: Any]? {
+        log("GetSharedState for \(ownerExtension)")
+        let event = Event(name: "Get Shared State",
+                          type: EventType.INSTRUMENTED_EXTENSION,
+                          source: EventSource.SHARED_STATE_REQUEST,
+                          data: ["stateowner": ownerExtension])
+
+        var returnedState: [AnyHashable: Any]?
+
+        let expectation = XCTestExpectation(description: "Shared state data returned")
+        MobileCore.dispatch(event: event, responseCallback: { event in
+
+            if let eventData = event?.data {
+                returnedState = eventData["state"] as? [AnyHashable: Any]
+            }
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: timeout)
+        return returnedState
+    }
+    
+    
+    /// Print message to console if `FunctionalTestBase.debug` is true
+    /// - Parameter message: message to log to console
+    func log(_ message: String) {
+        FunctionalTestBase.log(message)
+    }
+
+    /// Print message to console if `FunctionalTestBase.debug` is true
+    /// - Parameter message: message to log to console
+    static func log(_ message: String) {
+        guard !message.isEmpty && FunctionalTestBase.debugEnabled else { return }
+        print("FunctionalTestBase - \(message)")
+    }
+}

--- a/AEPMessaging/Tests/TestHelpers/IntrumentedExtension.swift
+++ b/AEPMessaging/Tests/TestHelpers/IntrumentedExtension.swift
@@ -1,0 +1,127 @@
+//
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPCore
+import AEPServices
+import XCTest
+
+/// Instrumented extension that registers a wildcard listener for intercepting events in current session. Use it along with `FunctionalTestBase`
+class InstrumentedExtension: NSObject, Extension {
+    private static let logTag = "InstrumentedExtension"
+    var name = "com.adobe.InstrumentedExtension"
+    var friendlyName = "InstrumentedExtension"
+    static var extensionVersion = "1.0.0"
+    var metadata: [String: String]?
+    var runtime: ExtensionRuntime
+    
+    enum TestEventType {
+        static let INSTRUMENTED_EXTENSION = "com.adobe.eventType.instrumentedExtension"
+    }
+    
+    enum TestEventSource {
+        static let SHARED_STATE = "com.adobe.eventSource.sharedState"
+        static let SHARED_STATE_REQUEST = "com.adobe.eventSource.requestState"
+        static let SHARED_STATE_RESPONSE = "com.adobe.eventSource.responseState"
+        static let UNREGISTER_EXTENSION = "com.adobe.eventSource.unregisterExtension"
+    }
+    
+    enum EventDataKey {
+        static let STATE_OWNER = "stateowner"
+        static let STATE = "state"
+    }
+
+    // Expected events Dictionary - key: EventSpec, value: the expected count
+    static var expectedEvents = ThreadSafeDictionary<EventSpec, CountDownLatch>()
+
+    // All the events seen by this listener that are not of type instrumentedExtension - key: EventSpec, value: received events with EventSpec type and source
+    static var receivedEvents = ThreadSafeDictionary<EventSpec, [Event]>()
+
+    func onRegistered() {
+        runtime.registerListener(type: EventType.wildcard, source: EventSource.wildcard, listener: wildcardListenerProcessor)
+    }
+
+    func onUnregistered() {}
+
+    public func readyForEvent(_ event: Event) -> Bool {
+        return true
+    }
+
+    required init?(runtime: ExtensionRuntime) {
+        self.runtime = runtime
+    }
+
+    // MARK: Event Processors
+    func wildcardListenerProcessor(_ event: Event) {
+        if event.type.lowercased() == TestEventType.INSTRUMENTED_EXTENSION.lowercased() {
+            // process the shared state request event
+            if event.source.lowercased() == TestEventSource.SHARED_STATE_REQUEST.lowercased() {
+                processSharedStateRequest(event)
+            }
+            // process the unregister extension event
+            else if event.source.lowercased() == TestEventSource.UNREGISTER_EXTENSION.lowercased() {
+                unregisterExtension()
+            }
+
+            return
+        }
+
+        // save this event in the receivedEvents dictionary
+        if InstrumentedExtension.receivedEvents[EventSpec(type: event.type, source: event.source)] != nil {
+            InstrumentedExtension.receivedEvents[EventSpec(type: event.type, source: event.source)]?.append(event)
+        } else {
+            InstrumentedExtension.receivedEvents[EventSpec(type: event.type, source: event.source)] = [event]
+        }
+
+        // count down if this is an expected event
+        if InstrumentedExtension.expectedEvents[EventSpec(type: event.type, source: event.source)] != nil {
+            InstrumentedExtension.expectedEvents[EventSpec(type: event.type, source: event.source)]?.countDown()
+        }
+
+        if event.source == EventSource.sharedState {
+            Log.debug(label: InstrumentedExtension.logTag, "Received event with type \(event.type) and source \(event.source), state owner \(event.data?["stateowner"] ?? "unknown")")
+        } else {
+            Log.debug(label: InstrumentedExtension.logTag, "Received event with type \(event.type) and source \(event.source)")
+        }
+    }
+
+    /// Process `getSharedStateFor` requests
+    /// - Parameter event: event sent from `getSharedStateFor` which specifies the shared state `stateowner` to retrieve
+    func processSharedStateRequest(_ event: Event) {
+        guard let eventData = event.data, !eventData.isEmpty  else { return }
+        guard let owner = eventData[EventDataKey.STATE_OWNER] as? String else { return }
+
+        var responseData: [String: Any?] = [EventDataKey.STATE_OWNER: owner, EventDataKey.STATE: nil]
+        if let state = runtime.getSharedState(extensionName: owner, event: event, barrier: false) {
+            responseData[EventDataKey.STATE] = state
+        }
+
+        let responseEvent = event.createResponseEvent(name: "Get Shared State Response",
+                                                      type: TestEventType.INSTRUMENTED_EXTENSION,
+                                                      source: TestEventSource.SHARED_STATE_RESPONSE,
+                                                      data: responseData as [String: Any])
+
+        Log.debug(label: InstrumentedExtension.logTag, "ProcessSharedStateRequest Responding with shared state \(String(describing: responseData))")
+
+        // dispatch paired response event with shared state data
+        MobileCore.dispatch(event: responseEvent)
+    }
+
+    func unregisterExtension() {
+        Log.debug(label: InstrumentedExtension.logTag, "Unregistering the Instrumented extension from the Event Hub")
+        runtime.unregisterExtension()
+    }
+
+    static func reset() {
+        receivedEvents = ThreadSafeDictionary<EventSpec, [Event]>()
+        expectedEvents = ThreadSafeDictionary<EventSpec, CountDownLatch>()
+    }
+}

--- a/AEPMessaging/Tests/TestHelpers/MockNotificationResponseCoder.swift
+++ b/AEPMessaging/Tests/TestHelpers/MockNotificationResponseCoder.swift
@@ -15,14 +15,20 @@ import UserNotifications
 
 class MockNotificationResponseCoder: NSCoder {
     private let request: UNNotificationRequest
+    private let actionIdentifier : String
     private let testIdentifier = "mockIdentifier"
     private enum FieldKey: String {
         case request, originIdentifier, sourceIdentifier, actionIdentifier, notification
     }
 
     override var allowsKeyedCoding: Bool { true }
-    init(with request: UNNotificationRequest) {
+    convenience init(with request: UNNotificationRequest) {
+        self.init(with: request, actionIdentifier: "mockActionIdentifier")
+    }
+    
+    init(with request: UNNotificationRequest, actionIdentifier: String) {
         self.request = request
+        self.actionIdentifier = actionIdentifier
     }
 
     override func decodeObject(forKey key: String) -> Any? {
@@ -30,8 +36,10 @@ class MockNotificationResponseCoder: NSCoder {
         switch fieldKey {
         case .request:
             return request
-        case .sourceIdentifier, .actionIdentifier, .originIdentifier:
-            return testIdentifier
+        case .actionIdentifier:
+            return actionIdentifier
+        case .sourceIdentifier, .originIdentifier:
+            return actionIdentifier
         case .notification:
             return UNNotification(coder: self)
         default:

--- a/AEPMessaging/Tests/TestHelpers/UserDefaults+Test.swift .swift
+++ b/AEPMessaging/Tests/TestHelpers/UserDefaults+Test.swift .swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import Foundation
+
+extension UserDefaults {
+
+    /// Util function to clean up all the keys from UserDefaults between tests
+    public static func clearAll() {
+        for _ in 0 ... 5 {
+            for key in UserDefaults.standard.dictionaryRepresentation().keys {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Introduced a new HandleNotificationResponse API with syntax
   static func handleNotificationResponse(_ response: UNNotificationResponse)
- This new API auto tracks `Actions` and `Application opens`


- Functional tests for the above API (
- Unit test cannot be done because we need a testing environment that runs on device to mock Notification Category registration