### PR TITLE
[MOB 18293] - Handling Notification Actions

### DIFF
--- a/AEPMessaging/Sources/Event+Messaging.swift
+++ b/AEPMessaging/Sources/Event+Messaging.swift
@@ -302,4 +302,11 @@ extension Event {
     var adobeXdm: [String: Any]? {
         data?[MessagingConstants.XDM.Key.ADOBE_XDM] as? [String: Any]
     }
+
+    var pushClickThroughUrl: URL? {
+        guard let link = data?[MessagingConstants.Event.Data.Key.PUSH_CLICK_THROUGH_URL] as? String else {
+            return nil
+        }
+        return URL(string: link)
+    }
 }

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -96,7 +96,7 @@ import UserNotifications
     }
 
     // MARK: - Private Helper Methods
-    
+
     /// Determines whether the user's response to a notification has caused the application to open
     ///
     /// This method analyzes the registered categories and notification action buttons of the application
@@ -134,7 +134,6 @@ import UserNotifications
         }
     }
 
-
     /// Modifies the provided event data based on the user's response to a notification.
     ///
     /// - Parameters:
@@ -149,8 +148,10 @@ import UserNotifications
             // This results in opening of the application.
             modifiedEventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.APPLICATION_OPENED
 
-        // Coming in next PR,
-        // TODO: add any notificaiton action url to the event data to be processed.
+            // Add actionable URL to eventData if available
+            if let clickThroughURL = response.notification.request.content.userInfo[MessagingConstants.PushNotification.UserInfoKey.ACTION_URL] {
+                modifiedEventData[MessagingConstants.Event.Data.Key.PUSH_CLICK_THROUGH_URL] = clickThroughURL
+            }
         case UNNotificationDismissActionIdentifier:
             // customActionId `UNNotificationDefaultActionIdentifier` indicates user has dismissed the notification by tapping "Clear" action button
             modifiedEventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.CUSTOM_ACTION

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -272,7 +272,12 @@ public class Messaging: NSObject, Extension {
 
         // Check if the event type is `MessagingConstants.Event.EventType.messaging` and
         // eventSource is `EventSource.requestContent` handle processing of the tracking information
-        if event.isMessagingRequestContentEvent, configSharedState.keys.contains(MessagingConstants.SharedState.Configuration.EXPERIENCE_EVENT_DATASET) {
+        if event.isMessagingRequestContentEvent {
+            if let clickThroughUrl = event.pushClickThroughUrl {
+                DispatchQueue.main.async {
+                    UIApplication.shared.open(clickThroughUrl)
+                }
+            }
             handleTrackingInfo(event: event)
             return
         }

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -275,7 +275,7 @@ public class Messaging: NSObject, Extension {
         if event.isMessagingRequestContentEvent {
             if let clickThroughUrl = event.pushClickThroughUrl {
                 DispatchQueue.main.async {
-                    UIApplication.shared.open(clickThroughUrl)
+                    ServiceProvider.shared.urlService.openUrl(clickThroughUrl)
                 }
             }
             handleTrackingInfo(event: event)

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -59,6 +59,7 @@ enum MessagingConstants {
                 static let APPLICATION_OPENED = "applicationOpened"
                 static let ACTION_ID = "actionId"
                 static let REFRESH_MESSAGES = "refreshmessages"
+                static let PUSH_CLICK_THROUGH_URL = "clickThroughUrl"
                 static let ADOBE_XDM = "adobe_xdm"
                 static let REQUEST_EVENT_ID = "requestEventId"
                 static let IAM_HISTORY = "iam"
@@ -286,6 +287,12 @@ enum MessagingConstants {
             static let IDENTITY_MAP = "identityMap"
             static let ECID = "ECID"
             static let ID = "id"
+        }
+    }
+
+    enum PushNotification {
+        enum UserInfoKey {
+            static let ACTION_URL = "adb_uri"
         }
     }
 }

--- a/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
@@ -188,13 +188,9 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
         // setup
         setExpectationEvent(type: EventType.messaging, source: EventSource.requestContent, expectedCount: 1)
         let response = prepareNotificationResponse(withUserInfo: ["adb_uri":"https://google.com"])!
-        var appSwitchExpectation = expectation(forNotification: NSNotification.Name.A, object: nil, handler: nil)
         
         // test
         Messaging.handleNotificationResponse(response)
-        
-        // verify
-        waitForExpectations(timeout: 5, handler: nil)
         
         // verify
         let events = getDispatchedEventsWith(type: EventType.messaging, source: EventSource.requestContent)

--- a/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
@@ -200,7 +200,7 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
         
         // verify push tracking information
         XCTAssertTrue(((flattenedEvent?["applicationOpened"] as? Bool) != nil))
-        XCTAssertEqual("https://google.com", flattenedEvent?["pushClickThroughUrl"] as? String)
+        XCTAssertEqual("https://google.com", flattenedEvent?["clickThroughUrl"] as? String)
         XCTAssertEqual("pushTracking.applicationOpened", flattenedEvent?["eventType"] as? String)
     }
     

--- a/TestApps/MessagingDemoApp/AppDelegate.swift
+++ b/TestApps/MessagingDemoApp/AppDelegate.swift
@@ -76,7 +76,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             guard granted else { return }
             
             center.delegate = self
-            
+                        
+            self?.registerNotificationCategories()
             DispatchQueue.main.async {
                 application.registerForRemoteNotifications()
             }
@@ -84,9 +85,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     func application(_: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
-        let token = tokenParts.joined()
-        print("Device token is - \(token)")
         MobileCore.setPushIdentifier(deviceToken)
     }
 
@@ -116,20 +114,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func userNotificationCenter(_: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
-        // Perform the task associated with the action.
-        switch response.actionIdentifier {
-        case "ACCEPT_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: "ACCEPT_ACTION")
-
-        case "DECLINE_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: false, customActionId: "DECLINE_ACTION")
-
-        // Handle other actions…
-        default:
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)
-        }
-
+        Messaging.handleNotificationResponse(response)
         // Always call the completion handler when done.
         completionHandler()
+    }
+    
+    // Register notification categories to enable different actions for notification
+    func registerNotificationCategories() {
+        // Define actions
+        let action1 = UNNotificationAction(identifier: "foreground", title: "Foreground", options: [.foreground])
+        let action2 = UNNotificationAction(identifier: "destructive", title: "Destructive", options: [.destructive])
+        let action3 = UNNotificationAction(identifier: "default", title: "Default", options: [])
+        
+        // Define category with actions
+        let category = UNNotificationCategory(identifier: "categoryId", actions: [action1, action2, action3], intentIdentifiers: [], options: [.customDismissAction])
+        
+        // Register the category
+        UNUserNotificationCenter.current().setNotificationCategories([category])
     }
 }

--- a/TestApps/MessagingDemoApp/SceneDelegate.swift
+++ b/TestApps/MessagingDemoApp/SceneDelegate.swift
@@ -21,10 +21,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             Assurance.startSession(url: deepLinkURL)
         }
         guard let _ = (scene as? UIWindowScene) else { return }
-    }    
+    }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         guard let urlContexts = URLContexts.first else { return }
         Assurance.startSession(url: urlContexts.url)
+        
+        let alert = UIAlertController(title: "Deeplink Received", message: "\(urlContexts.url.description)", preferredStyle: UIAlertController.Style.alert)
+        alert.addAction(UIAlertAction(title: "Cool", style: UIAlertAction.Style.default, handler: nil))
+        self.window?.rootViewController?.present(alert, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
### Definition
Notification Action is defined as an action that the Messaging Extension takes in response to interacting with the notification.
Typically these actions can be to open a web URL or a deeplink associated with that application.

### How notification action is set
While designing a push notification campaign. Notification action is set by editing the click behavior field.
In iOS deeplink/ weburl action links are sent to the device through the push notification payload. They are available in a custom field "adb_uri".

![Screenshot 2023-04-11 at 11 52 56 AM](https://user-images.githubusercontent.com/8909148/231261124-49e8d8f8-9b8e-4b25-a28c-aa568864fcdf.png). 


### Notification body click action 
Notification body click action determines the action taken when clicking on the body of the notification. This will typically open the application.


###  Notification custom button click action
Notification custom button click action determines the action taken when the user clicks either of the action buttons in a notification.

`Messaging.handleNotificationResponse(response)`

![image](https://user-images.githubusercontent.com/8909148/231264345-a4a9d29d-45b3-4903-a949-dd515b236dc1.png)


### Why cant we handle notification custom button click action
 The notification custom actions along with its category is pre-created by the application and registered at launch time. Therefore AJO doesn't control the creation of action buttons from its authoring UI. The authoring UI should only ask for the categoryID of the already registered category that can be invoked. 

Since AJO doesn't have the power to define the actions of a custom notification button. So Messaging SDK would not be able to handle the custom notification action links. This has to be handled by the application as shown [here](https://github.com/adobe/aepsdk-messaging-ios/compare/main...PravinPK:aepsdk-messaging-ios:dev-v1.1.1?expand=1#diff-7b5f15992292d4c8a9c5241e39c2f11afced0fc54a089fb8d0b3492105e08c4eR184-R196).


### A Complex Scenario
Assume an AJO consumer wants to design the following notification such that

![Screenshot 2023-04-11 at 1 52 07 PM](https://user-images.githubusercontent.com/8909148/231285453-ae9bf8f7-fdc4-4824-85fd-c839df1bf105.png)

1. Clicking on the body should open a deeplink to the tutorial
2. Clicking on the custom action "Read Later" should dismiss the notification
3. Clicking on the custom action  "Show Details" should open the app with a deeplink
4. Clicking on the custom action "Unsubscribe" should open the app with deeplink to unsubscribe

To achieve this example:
1. The app should be predefined to register a notification category called "tutorial" with 3 buttons with names as shown above
2. The app should also be predefined to handle the action when each of these action buttons is clicked

3. Now the user goes to AJO UI and sets the notification content with
        Body click behavior - DEEPLINK  (with deeplink of that specific tutorial) 
        iOS categoryID - "tutorial" (this will show the 3 button that are preconfigured)
       + any custom notification payload that are necessary

4.  In this example the messaging SDK will only handle the action of the notification body but not the 3 action buttons. 
