### PR TITLE
[MOB-19374] - Do not process Push Notification tracking event if AJO tracking keys are absent

### DIFF
--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -105,7 +105,7 @@ import UserNotifications
     ///
     /// - Parameters:
     ///   - response: The user's response to a notification, represented by a `UNNotificationResponse` object.
-    ///   - completion: The completion block to be executed with a boolean value determining if application was opened because of users interaction with the notification.
+    ///   - completion: The completion block to be executed with a boolean value determining if application was opened because of user's interaction with the notification.
     ///
     /// - Note: The completion handler is invoked asynchronously, so any code relying on the result should be placed within the completion handler or called from there.
     private static func hasApplicationOpenedForResponse(_ response: UNNotificationResponse, completion: @escaping (Bool) -> Void) {

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -28,8 +28,7 @@ import UserNotifications
         let notificationRequest = response.notification.request
 
         // Checking if the message has the _xdm key that contains tracking information
-        let xdm = notificationRequest.content.userInfo[MessagingConstants.XDM.AdobeKeys._XDM] as? [String: Any]
-        if xdm == nil {
+        guard let xdm = notificationRequest.content.userInfo[MessagingConstants.XDM.AdobeKeys._XDM] as? [String: Any], !xdm.isEmpty else {
             Log.debug(label: MessagingConstants.LOG_TAG, "XDM specific fields are missing from push notification response. Ignoring to track push notification.")
             return false
         }
@@ -37,7 +36,7 @@ import UserNotifications
         // Creating event data with tracking informations
         var eventData: [String: Any] = [MessagingConstants.Event.Data.Key.MESSAGE_ID: notificationRequest.identifier,
                                         MessagingConstants.Event.Data.Key.APPLICATION_OPENED: applicationOpened,
-                                        MessagingConstants.XDM.Key.ADOBE_XDM: xdm ?? [:]] // If xdm data is nil we use empty dictionary
+                                        MessagingConstants.XDM.Key.ADOBE_XDM: xdm]
         if customActionId == nil {
             eventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] = MessagingConstants.XDM.Push.EventType.APPLICATION_OPENED
         } else {
@@ -61,8 +60,7 @@ import UserNotifications
         let notificationRequest = response.notification.request
 
         // Checking if the message has the _xdm key that contains tracking information
-        let xdm = notificationRequest.content.userInfo[MessagingConstants.XDM.AdobeKeys._XDM] as? [String: Any]
-        if xdm == nil {
+        guard let xdm = notificationRequest.content.userInfo[MessagingConstants.XDM.AdobeKeys._XDM] as? [String: Any], !xdm.isEmpty else {
             Log.debug(label: MessagingConstants.LOG_TAG, "XDM specific fields are missing from push notification response. Ignoring to track push notification.")
             return false
         }
@@ -72,7 +70,7 @@ import UserNotifications
 
                 let eventData: [String: Any] = [MessagingConstants.Event.Data.Key.MESSAGE_ID: notificationRequest.identifier,
                                                 MessagingConstants.Event.Data.Key.APPLICATION_OPENED: isAppOpened,
-                                                MessagingConstants.Event.Data.Key.ADOBE_XDM: xdm ?? [:]] // If xdm data is nil we use
+                                                MessagingConstants.Event.Data.Key.ADOBE_XDM: xdm]
 
                 let modifiedEventData = addNotificationActionToEventData(eventData, response)
 
@@ -107,7 +105,7 @@ import UserNotifications
     ///
     /// - Parameters:
     ///   - response: The user's response to a notification, represented by a `UNNotificationResponse` object.
-    ///   - completion: A closure that takes a `Bool` parameter indicating whether the application was opened or not. This closure is invoked asynchronously once the determination is made.
+    ///   - completion: The completion block to be executed with a boolean value determining if application was opened because of users interaction with the notification.
     ///
     /// - Note: The completion handler is invoked asynchronously, so any code relying on the result should be placed within the completion handler or called from there.
     private static func hasApplicationOpenedForResponse(_ response: UNNotificationResponse, completion: @escaping (Bool) -> Void) {

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -25,7 +25,6 @@ import UserNotifications
     @objc(handleNotificationResponse:applicationOpened:withCustomActionId:)
     @discardableResult
     static func handleNotificationResponse(_ response: UNNotificationResponse, applicationOpened: Bool, customActionId: String?) -> Bool {
-        
         let notificationRequest = response.notification.request
 
         // Checking if the message has the _xdm key that contains tracking information
@@ -34,7 +33,7 @@ import UserNotifications
             Log.debug(label: MessagingConstants.LOG_TAG, "XDM specific fields are missing from push notification response. Ignoring to track push notification.")
             return false
         }
-        
+
         // Creating event data with tracking informations
         var eventData: [String: Any] = [MessagingConstants.Event.Data.Key.MESSAGE_ID: notificationRequest.identifier,
                                         MessagingConstants.Event.Data.Key.APPLICATION_OPENED: applicationOpened,
@@ -67,7 +66,7 @@ import UserNotifications
             Log.debug(label: MessagingConstants.LOG_TAG, "XDM specific fields are missing from push notification response. Ignoring to track push notification.")
             return false
         }
-        
+
         DispatchQueue.global().async {
             hasApplicationOpenedForResponse(response, completion: { isAppOpened in
 
@@ -84,7 +83,7 @@ import UserNotifications
                 MobileCore.dispatch(event: event)
             })
         }
-        
+
         return true
     }
 

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -285,12 +285,12 @@ public class Messaging: NSObject, Extension {
 
     #if DEBUG
         /// Used for testing only
-        internal func setMessagesRequestEventId(_ newId: String?) {
+        func setMessagesRequestEventId(_ newId: String?) {
             messagesRequestEventId = newId
         }
 
         /// Used for testing only
-        internal func setLastProcessedRequestEventId(_ newId: String?) {
+        func setLastProcessedRequestEventId(_ newId: String?) {
             lastProcessedRequestEventId = newId
         }
     #endif

--- a/AEPMessaging/Sources/MessagingRulesEngine.swift
+++ b/AEPMessaging/Sources/MessagingRulesEngine.swift
@@ -108,12 +108,12 @@ class MessagingRulesEngine {
 
     #if DEBUG
         /// For testing purposes only
-        internal func propositionInfoCount() -> Int {
+        func propositionInfoCount() -> Int {
             propositionInfo.count
         }
 
         /// For testing purposes only
-        internal func inMemoryPropositionsCount() -> Int {
+        func inMemoryPropositionsCount() -> Int {
             inMemoryPropositions.count
         }
     #endif

--- a/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
@@ -155,6 +155,19 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
         XCTAssertEqual(0, events.count)
     }
     
+    func test_notificationOpen_whenAJONotification_withEmptyTrackingInformation() {
+        // This test simulates the reaction of handleNotificationResponse API when the notifcation from AJO contains no information in the tracking field "_xdm"
+        setExpectationEvent(type: EventType.messaging, source: EventSource.requestContent, expectedCount: 1)
+        let response = prepareNotificationResponse(withUserInfo: ["_xdm": [:] as [String:Any]])!
+        
+        // test
+        XCTAssertFalse(Messaging.handleNotificationResponse(response))
+        
+        // verify no tracking event is dispatched
+        let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
+        XCTAssertEqual(0, events.count)
+    }
+
     
     func test_notificationTracking_whenUser_tapsNotificationActionThatDoNotOpenTheApp() {
         // setup

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -126,32 +126,12 @@ class MessagingPublicApiTest: XCTestCase {
         let mockCustomActionId = "mockCustomActionId"
         let mockIdentifier = "mockIdentifier"
         expectation.assertForOverFulfill = true
+        expectation.isInverted = true
 
         EventHub.shared.getExtensionContainer(MockExtension.self)?.eventListeners.clear()
 
+        
         EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MessagingConstants.Event.EventType.messaging, source: EventSource.requestContent) { event in
-            XCTAssertEqual(MessagingConstants.Event.Name.PUSH_NOTIFICATION_INTERACTION, event.name)
-            XCTAssertEqual(MessagingConstants.Event.EventType.messaging, event.type)
-            XCTAssertEqual(EventSource.requestContent, event.source)
-
-            guard let eventData = event.data,
-                  let applicationOpened = eventData[MessagingConstants.Event.Data.Key.APPLICATION_OPENED] as? Bool,
-                  let eventDataType = eventData[MessagingConstants.Event.Data.Key.EVENT_TYPE] as? String,
-                  let actionId = eventData[MessagingConstants.Event.Data.Key.ACTION_ID] as? String,
-                  let messageId = eventData[MessagingConstants.Event.Data.Key.MESSAGE_ID] as? String,
-                  let xdm = eventData[MessagingConstants.Event.Data.Key.ADOBE_XDM] as? [String: Any]
-            else {
-                XCTFail()
-                expectation.fulfill()
-                return
-            }
-
-            XCTAssertTrue(applicationOpened)
-            XCTAssertEqual(MessagingConstants.XDM.Push.EventType.CUSTOM_ACTION, eventDataType)
-            XCTAssertEqual(actionId, mockCustomActionId)
-            XCTAssertEqual(messageId, mockIdentifier)
-            XCTAssertEqual(0, xdm.count)
-
             expectation.fulfill()
         }
 
@@ -166,7 +146,7 @@ class MessagingPublicApiTest: XCTestCase {
         }
 
         Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: mockCustomActionId)
-        wait(for: [expectation], timeout: ASYNC_TIMEOUT)
+        wait(for: [expectation], timeout: 1)
     }
 
     func testHandleNotificationResponseEmptyMessageId() {

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -35,7 +35,7 @@ class MessagingPublicApiTest: XCTestCase {
         semaphore.wait()
     }
 
-    func testHandleNotificationResponse() {
+    func testHandleNotificationResponse_happy() {
         let expectation = XCTestExpectation(description: "Messaging request event")
         let mockCustomActionId = "mockCustomActionId"
         let mockIdentifier = "mockIdentifier"
@@ -86,7 +86,7 @@ class MessagingPublicApiTest: XCTestCase {
         wait(for: [expectation], timeout: ASYNC_TIMEOUT)
     }
 
-    func testHandleNotificationResponse_whenApplicationOpenedFalse_AndNilCustomActionID() {
+    func testHandleNotificationResponse_when_applicationOpenedFalse_andNilCustomActionID() {
         let expectation = XCTestExpectation(description: "Messaging request event")
         expectation.assertForOverFulfill = true
 
@@ -121,7 +121,7 @@ class MessagingPublicApiTest: XCTestCase {
         wait(for: [expectation], timeout: ASYNC_TIMEOUT)
     }
 
-    func testHandleNotificationResponseNoXdmInNotification() {
+    func testHandleNotificationResponse_when_noXdmInNotification() {
         let expectation = XCTestExpectation(description: "Messaging request event")
         let mockCustomActionId = "mockCustomActionId"
         let mockIdentifier = "mockIdentifier"
@@ -149,7 +149,7 @@ class MessagingPublicApiTest: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    func testHandleNotificationResponseEmptyMessageId() {
+    func testHandleNotificationResponse_when_emptyMessageId() {
         let expectation = XCTestExpectation(description: "Messaging request event")
         let mockCustomActionId = "mockCustomActionId"
         let mockIdentifier = ""
@@ -175,6 +175,63 @@ class MessagingPublicApiTest: XCTestCase {
         Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: mockCustomActionId)
         wait(for: [expectation], timeout: ASYNC_TIMEOUT)
     }
+    
+    func testHandleNotificationResponseWithParametersAPI_when_emptyXdmInNotification() {
+        let expectation = XCTestExpectation(description: "Messaging request event")
+        let mockIdentifier = "mockIdentifier"
+        expectation.assertForOverFulfill = true
+        expectation.isInverted = true
+
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.eventListeners.clear()
+
+        
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MessagingConstants.Event.EventType.messaging, source: EventSource.requestContent) { event in
+            expectation.fulfill()
+        }
+
+        let dateInfo = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: Date())
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateInfo, repeats: false)
+        let notificationContent = UNMutableNotificationContent()
+        notificationContent.userInfo = ["_xdm" : [:] as [String:Any]]
+
+        let request = UNNotificationRequest(identifier: mockIdentifier, content: notificationContent, trigger: trigger)
+        guard let response = UNNotificationResponse(coder: MockNotificationResponseCoder(with: request)) else {
+            XCTFail()
+            return
+        }
+
+        Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: "customActionId")
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    func testHandleNotificationResponse_when_emptyXdmInNotification() {
+        let expectation = XCTestExpectation(description: "Messaging request event")
+        let mockIdentifier = "mockIdentifier"
+        expectation.assertForOverFulfill = true
+        expectation.isInverted = true
+
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.eventListeners.clear()
+
+        
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MessagingConstants.Event.EventType.messaging, source: EventSource.requestContent) { event in
+            expectation.fulfill()
+        }
+
+        let dateInfo = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: Date())
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateInfo, repeats: false)
+        let notificationContent = UNMutableNotificationContent()
+        notificationContent.userInfo = ["_xdm" : [:] as [String:Any]]
+
+        let request = UNNotificationRequest(identifier: mockIdentifier, content: notificationContent, trigger: trigger)
+        guard let response = UNNotificationResponse(coder: MockNotificationResponseCoder(with: request)) else {
+            XCTFail()
+            return
+        }
+
+        Messaging.handleNotificationResponse(response)
+        wait(for: [expectation], timeout: 1)
+    }
+    
 
     func testRefreshInAppMessages() throws {
         // setup

--- a/TestApps/MessagingDemoAppObjC/AppDelegate.h
+++ b/TestApps/MessagingDemoAppObjC/AppDelegate.h
@@ -11,7 +11,8 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, UNUserNotificationCenterDelegate>
 
 @end

--- a/TestApps/MessagingDemoAppObjC/AppDelegate.m
+++ b/TestApps/MessagingDemoAppObjC/AppDelegate.m
@@ -66,4 +66,14 @@
     // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
 }
 
+
+-(void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+
+}
+
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
+    [AEPMobileMessaging handleNotificationResponse:response];
+}
+
 @end


### PR DESCRIPTION
Two changes are made to handleNotificationResponse API

- The API stops processing the notification response. If no tracking key "_xdm" is found in the notification response
- handleNotificationResponse returns a boolean value representing if it has proceeded with tracking that notification