### PR TITLE
 HandleNotificationResponse API returns MessagingPushTrackingStatus enum

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -166,7 +166,7 @@
 		B631AE182A61374500E8B82E /* IntrumentedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE172A61374500E8B82E /* IntrumentedExtension.swift */; };
 		B631AE1A2A6139CE00E8B82E /* UserDefaults+Test.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE192A6139CE00E8B82E /* UserDefaults+Test.swift .swift */; };
 		B631AE1C2A613A1E00E8B82E /* FileManager+Test.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE1B2A613A1E00E8B82E /* FileManager+Test.swift .swift */; };
-		B6389A492A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6389A482A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift */; };
+		B6389A492A9B32D400B72FB4 /* PushTrackingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6389A482A9B32D400B72FB4 /* PushTrackingStatus.swift */; };
 		B6D6A02B265FB1FA005042BE /* Dictionary+Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928639FB263757A7000AFA53 /* Dictionary+Flatten.swift */; };
 /* End PBXBuildFile section */
 
@@ -438,7 +438,7 @@
 		B631AE172A61374500E8B82E /* IntrumentedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntrumentedExtension.swift; sourceTree = "<group>"; };
 		B631AE192A6139CE00E8B82E /* UserDefaults+Test.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Test.swift .swift"; sourceTree = "<group>"; };
 		B631AE1B2A613A1E00E8B82E /* FileManager+Test.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Test.swift .swift"; sourceTree = "<group>"; };
-		B6389A482A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingPushTrackingStatus.swift; sourceTree = "<group>"; };
+		B6389A482A9B32D400B72FB4 /* PushTrackingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTrackingStatus.swift; sourceTree = "<group>"; };
 		C003D7513651C8FD2BC84411 /* Pods-AEPMessaging.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPMessaging.debug.xcconfig"; path = "Target Support Files/Pods-AEPMessaging/Pods-AEPMessaging.debug.xcconfig"; sourceTree = "<group>"; };
 		CFBC956862FD1C6747587F09 /* Pods-E2EFunctionalTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.debug.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		CFC660CD22A375E0F809B475 /* Pods-E2EFunctionalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.release.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -668,7 +668,7 @@
 				92315436261E3B36004AE7D3 /* Messaging.swift */,
 				244E954A267BAEBE001DC957 /* Messaging+EdgeEvents.swift */,
 				92315434261E3B36004AE7D3 /* Messaging+PublicAPI.swift */,
-				B6389A482A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift */,
+				B6389A482A9B32D400B72FB4 /* PushTrackingStatus.swift */,
 				92315437261E3B36004AE7D3 /* MessagingConstants.swift */,
 				244C2BD726B36480008F086A /* MessagingEdgeEventType.swift */,
 				2450594D2671283F00CC7CA0 /* MessagingRulesEngine.swift */,
@@ -1572,7 +1572,7 @@
 				243B1B0028B411630074327E /* PayloadItem.swift in Sources */,
 				241B2DD42821C80C00E4FF67 /* URL+QueryParams.swift in Sources */,
 				245059A22673FAC200CC7CA0 /* Messaging.swift in Sources */,
-				B6389A492A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift in Sources */,
+				B6389A492A9B32D400B72FB4 /* PushTrackingStatus.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		B631AE182A61374500E8B82E /* IntrumentedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE172A61374500E8B82E /* IntrumentedExtension.swift */; };
 		B631AE1A2A6139CE00E8B82E /* UserDefaults+Test.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE192A6139CE00E8B82E /* UserDefaults+Test.swift .swift */; };
 		B631AE1C2A613A1E00E8B82E /* FileManager+Test.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE1B2A613A1E00E8B82E /* FileManager+Test.swift .swift */; };
+		B6389A492A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6389A482A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift */; };
 		B6D6A02B265FB1FA005042BE /* Dictionary+Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928639FB263757A7000AFA53 /* Dictionary+Flatten.swift */; };
 /* End PBXBuildFile section */
 
@@ -437,6 +438,7 @@
 		B631AE172A61374500E8B82E /* IntrumentedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntrumentedExtension.swift; sourceTree = "<group>"; };
 		B631AE192A6139CE00E8B82E /* UserDefaults+Test.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Test.swift .swift"; sourceTree = "<group>"; };
 		B631AE1B2A613A1E00E8B82E /* FileManager+Test.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Test.swift .swift"; sourceTree = "<group>"; };
+		B6389A482A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingPushTrackingStatus.swift; sourceTree = "<group>"; };
 		C003D7513651C8FD2BC84411 /* Pods-AEPMessaging.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPMessaging.debug.xcconfig"; path = "Target Support Files/Pods-AEPMessaging/Pods-AEPMessaging.debug.xcconfig"; sourceTree = "<group>"; };
 		CFBC956862FD1C6747587F09 /* Pods-E2EFunctionalTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.debug.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		CFC660CD22A375E0F809B475 /* Pods-E2EFunctionalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.release.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -666,6 +668,7 @@
 				92315436261E3B36004AE7D3 /* Messaging.swift */,
 				244E954A267BAEBE001DC957 /* Messaging+EdgeEvents.swift */,
 				92315434261E3B36004AE7D3 /* Messaging+PublicAPI.swift */,
+				B6389A482A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift */,
 				92315437261E3B36004AE7D3 /* MessagingConstants.swift */,
 				244C2BD726B36480008F086A /* MessagingEdgeEventType.swift */,
 				2450594D2671283F00CC7CA0 /* MessagingRulesEngine.swift */,
@@ -1569,6 +1572,7 @@
 				243B1B0028B411630074327E /* PayloadItem.swift in Sources */,
 				241B2DD42821C80C00E4FF67 /* URL+QueryParams.swift in Sources */,
 				245059A22673FAC200CC7CA0 /* Messaging.swift in Sources */,
+				B6389A492A9B32D400B72FB4 /* MessagingPushTrackingStatus.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPMessaging/Sources/Event+Messaging.swift
+++ b/AEPMessaging/Sources/Event+Messaging.swift
@@ -303,6 +303,13 @@ extension Event {
         data?[MessagingConstants.XDM.Key.ADOBE_XDM] as? [String: Any]
     }
 
+    var pushTrackingStatus: MessagingPushTrackingStatus {
+        guard let statusInt = data?[MessagingConstants.Event.Data.Key.PUSH_NOTIFICATION_TRACKING_STATUS] as? Int else {
+            return .unknownError
+        }
+        return MessagingPushTrackingStatus(fromRawValue: statusInt)
+    }
+
     var pushClickThroughUrl: URL? {
         guard let link = data?[MessagingConstants.Event.Data.Key.PUSH_CLICK_THROUGH_URL] as? String else {
             return nil

--- a/AEPMessaging/Sources/Event+Messaging.swift
+++ b/AEPMessaging/Sources/Event+Messaging.swift
@@ -303,11 +303,11 @@ extension Event {
         data?[MessagingConstants.XDM.Key.ADOBE_XDM] as? [String: Any]
     }
 
-    var pushTrackingStatus: MessagingPushTrackingStatus {
+    var pushTrackingStatus: PushTrackingStatus {
         guard let statusInt = data?[MessagingConstants.Event.Data.Key.PUSH_NOTIFICATION_TRACKING_STATUS] as? Int else {
             return .unknownError
         }
-        return MessagingPushTrackingStatus(fromRawValue: statusInt)
+        return PushTrackingStatus(fromRawValue: statusInt)
     }
 
     var pushClickThroughUrl: URL? {

--- a/AEPMessaging/Sources/Messaging+EdgeEvents.swift
+++ b/AEPMessaging/Sources/Messaging+EdgeEvents.swift
@@ -353,7 +353,7 @@ extension Messaging {
     }
 
     private func dispatchTrackingResponseEvent(_ status: MessagingPushTrackingStatus, forEvent event: Event) {
-        let responseEvent = event.createResponseEvent(name: "Push tracking status event",
+        let responseEvent = event.createResponseEvent(name: MessagingConstants.Event.Name.PUSH_TRACKING_STATUS,
                                                       type: EventType.messaging,
                                                       source: EventSource.responseContent,
                                                       data: [MessagingConstants.Event.Data.Key.PUSH_NOTIFICATION_TRACKING_STATUS: status.rawValue,

--- a/AEPMessaging/Sources/Messaging+EdgeEvents.swift
+++ b/AEPMessaging/Sources/Messaging+EdgeEvents.swift
@@ -188,13 +188,13 @@ extension Messaging {
     /// - Returns: `[String: Any]?` which contains the xdm data
     private func getXdmData(event: Event) -> [String: Any]? {
         guard let xdmEventType = event.xdmEventType, !xdmEventType.isEmpty else {
-            Log.warning(label: MessagingConstants.LOG_TAG, "Updating xdm data for tracking failed, eventType is invalid or nil in the event '\(event.id.uuidString)'.")
+            Log.warning(label: MessagingConstants.LOG_TAG, "Ignoring to track push notification, eventType is empty or nil in the event '\(event.id.uuidString)'.")
             dispatchTrackingResponseEvent(.unknownError, forEvent: event)
             return nil
         }
 
         guard let messageId = event.messagingId, !messageId.isEmpty else {
-            Log.trace(label: MessagingConstants.LOG_TAG, "Updating xdm data for tracking failed, EventType or MessageId received in the event '\(event.id.uuidString)' is nil.")
+            Log.trace(label: MessagingConstants.LOG_TAG, "Ignoring to track push notification, messageId is empty or nil in the event '\(event.id.uuidString)'.")
             dispatchTrackingResponseEvent(.invalidMessageId, forEvent: event)
             return nil
         }
@@ -352,7 +352,7 @@ extension Messaging {
         dispatch(event: event)
     }
 
-    private func dispatchTrackingResponseEvent(_ status: MessagingPushTrackingStatus, forEvent event: Event) {
+    private func dispatchTrackingResponseEvent(_ status: PushTrackingStatus, forEvent event: Event) {
         let responseEvent = event.createResponseEvent(name: MessagingConstants.Event.Name.PUSH_TRACKING_STATUS,
                                                       type: EventType.messaging,
                                                       source: EventSource.responseContent,

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -20,7 +20,6 @@ import UserNotifications
     ///   - response: UNNotificationResponse object which contains the payload and xdm informations.
     ///   - applicationOpened: Boolean values denoting whether the application was opened when notification was clicked
     ///   - customActionId: String value of the custom action (e.g button id on the notification) which was clicked.
-    /// - Returns: boolean value that signifies whether the notification originated from AJO and whether the API has proceeded with notification tracking.
     @available(*, deprecated, message: "This method is deprecated. Use Messaging.handleNotificationResponse(:) instead to automatically track application open and handle notification actions.")
     @objc(handleNotificationResponse:applicationOpened:withCustomActionId:)
     static func handleNotificationResponse(_ response: UNNotificationResponse, applicationOpened: Bool, customActionId: String?) {
@@ -51,8 +50,11 @@ import UserNotifications
     }
 
     /// Sends the push notification interactions as an experience event to Adobe Experience Edge.
-    /// - Parameter response: UNNotificationResponse object which contains the payload and xdm informations.
-    static func handleNotificationResponse(_ response: UNNotificationResponse, closure: ((MessagingPushTrackingStatus) -> Void)? = nil) {
+    /// - Parameters:
+    ///   - response: UNNotificationResponse object which contains the payload and xdm informations.
+    ///   - closure : A callback with `PushTrackingStatus` representing the tracking status of the interacted notification
+    @objc(handleNotificationResponse:closure:)
+    static func handleNotificationResponse(_ response: UNNotificationResponse, closure: ((PushTrackingStatus) -> Void)? = nil) {
         let notificationRequest = response.notification.request
 
         // Checking if the message has the _xdm key that contains tracking information
@@ -75,13 +77,13 @@ import UserNotifications
                               source: EventSource.requestContent,
                               data: modifiedEventData)
 
-            MobileCore.dispatch(event: event, responseCallback: { responseEvent in
+            MobileCore.dispatch(event: event) { responseEvent in
                 guard let status = responseEvent?.pushTrackingStatus else {
                     closure?(.unknownError)
                     return
                 }
                 closure?(status)
-            })
+            }
         })
     }
 

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -63,7 +63,7 @@ import UserNotifications
             closure?(.noTrackingData)
             return
         }
-        
+
         // Get off the main thread to process notification response
         DispatchQueue.global().async {
             hasApplicationOpenedForResponse(response, completion: { isAppOpened in

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -23,14 +23,13 @@ import UserNotifications
     /// - Returns: boolean value that signifies whether the notification originated from AJO and whether the API has proceeded with notification tracking.
     @available(*, deprecated, message: "This method is deprecated. Use Messaging.handleNotificationResponse(:) instead to automatically track application open and handle notification actions.")
     @objc(handleNotificationResponse:applicationOpened:withCustomActionId:)
-    @discardableResult
-    static func handleNotificationResponse(_ response: UNNotificationResponse, applicationOpened: Bool, customActionId: String?) -> Bool {
+    static func handleNotificationResponse(_ response: UNNotificationResponse, applicationOpened: Bool, customActionId: String?) {
         let notificationRequest = response.notification.request
 
         // Checking if the message has the _xdm key that contains tracking information
         guard let xdm = notificationRequest.content.userInfo[MessagingConstants.XDM.AdobeKeys._XDM] as? [String: Any], !xdm.isEmpty else {
             Log.debug(label: MessagingConstants.LOG_TAG, "XDM specific fields are missing from push notification response. Ignoring to track push notification.")
-            return false
+            return
         }
 
         // Creating event data with tracking informations
@@ -49,7 +48,6 @@ import UserNotifications
                           source: EventSource.requestContent,
                           data: eventData)
         MobileCore.dispatch(event: event)
-        return true
     }
 
     /// Sends the push notification interactions as an experience event to Adobe Experience Edge.

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -223,12 +223,6 @@ public class Messaging: NSObject, Extension {
             return
         }
 
-        // hard dependency on configuration shared state
-        guard let configSharedState = getSharedState(extensionName: MessagingConstants.SharedState.Configuration.NAME, event: event)?.value else {
-            Log.debug(label: MessagingConstants.LOG_TAG, "Event processing is paused, waiting for valid configuration - '\(event.id.uuidString)'.")
-            return
-        }
-
         // handle an event for refreshing in-app messages from the remote
         if event.isRefreshMessageEvent {
             Log.debug(label: MessagingConstants.LOG_TAG, "Processing manual request to refresh In-App Message definitions from the remote.")

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -41,6 +41,7 @@ enum MessagingConstants {
             static let PUSH_TRACKING_EDGE = "Push tracking edge event"
             static let REFRESH_MESSAGES = "Refresh in-app messages"
             static let RETRIEVE_MESSAGE_DEFINITIONS = "Retrieve message definitions"
+            static let PUSH_TRACKING_STATUS = "Push tracking status event"
         }
 
         enum Source {
@@ -63,6 +64,8 @@ enum MessagingConstants {
                 static let ADOBE_XDM = "adobe_xdm"
                 static let REQUEST_EVENT_ID = "requestEventId"
                 static let IAM_HISTORY = "iam"
+                static let PUSH_NOTIFICATION_TRACKING_STATUS = "pushTrackingStatus"
+                static let PUSH_NOTIFICATION_TRACKING_MESSAGE = "pushTrackingStatusMessage"
 
                 static let TRIGGERED_CONSEQUENCE = "triggeredconsequence"
                 static let ID = "id"

--- a/AEPMessaging/Sources/MessagingPushTrackingStatus.swift
+++ b/AEPMessaging/Sources/MessagingPushTrackingStatus.swift
@@ -1,0 +1,47 @@
+/*
+ Copyright 2023 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+/// Represents a specific outcome resulting from tracking push notification interaction
+@objc(AEPMessagingPushTrackingStatus)
+public enum MessagingPushTrackingStatus: Int {
+    case trackingInitiated
+    case noDatasetConfigured
+    case noTrackingData
+    case invalidMessageId
+    case unknownError
+
+    /// Converts an `Int` to its respective `MessagingPushTrackingStatus`
+    /// If `fromRawValue` is not a valid `MessagingPushTrackingStatus`, calling this method will return `PlacesQueryResponseCode.unknownError`
+    /// - Parameter fromRawValue: an `Int` representation of a `MessagingPushTrackingStatus`
+    /// - Returns: a `MessagingPushTrackingStatus` representing the passed-in `Int`
+    init(fromRawValue: Int) {
+        self = MessagingPushTrackingStatus(rawValue: fromRawValue) ?? .unknownError
+    }
+
+    /// Returns the string description of the error
+    public func toString() -> String {
+        switch self {
+        case .trackingInitiated:
+            return "Tracking initiated"
+        case .noDatasetConfigured:
+            return "No dataset configured"
+        case .noTrackingData:
+            return "Missing tracking data in Notification Response"
+        case .invalidMessageId:
+            return "MessageId provided for tracking is empty/null"
+        case .unknownError:
+            return "Unknown error"
+        }
+    }
+}

--- a/AEPMessaging/Sources/PushTrackingStatus.swift
+++ b/AEPMessaging/Sources/PushTrackingStatus.swift
@@ -13,8 +13,8 @@
 import Foundation
 
 /// Represents a specific outcome resulting from tracking push notification interaction
-@objc(AEPMessagingPushTrackingStatus)
-public enum MessagingPushTrackingStatus: Int {
+@objc(AEPPushTrackingStatus)
+public enum PushTrackingStatus: Int {
     case trackingInitiated
     case noDatasetConfigured
     case noTrackingData
@@ -26,10 +26,10 @@ public enum MessagingPushTrackingStatus: Int {
     /// - Parameter fromRawValue: an `Int` representation of a `MessagingPushTrackingStatus`
     /// - Returns: a `MessagingPushTrackingStatus` representing the passed-in `Int`
     init(fromRawValue: Int) {
-        self = MessagingPushTrackingStatus(rawValue: fromRawValue) ?? .unknownError
+        self = PushTrackingStatus(rawValue: fromRawValue) ?? .unknownError
     }
 
-    /// Returns the string description of the error
+    /// Returns the string description of the error    
     public func toString() -> String {
         switch self {
         case .trackingInitiated:

--- a/AEPMessaging/Sources/PushTrackingStatus.swift
+++ b/AEPMessaging/Sources/PushTrackingStatus.swift
@@ -29,7 +29,7 @@ public enum PushTrackingStatus: Int {
         self = PushTrackingStatus(rawValue: fromRawValue) ?? .unknownError
     }
 
-    /// Returns the string description of the error    
+    /// Returns the string description of the error
     public func toString() -> String {
         switch self {
         case .trackingInitiated:

--- a/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
@@ -70,7 +70,7 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
     
     func test_notificationTracking_whenUser_tapsNotificationBody() {
         // setup
-        var acutalStatus : MessagingPushTrackingStatus?
+        var acutalStatus : PushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging Push Tracking Response")
         setExpectationEvent(type: EventType.edge, source: EventSource.requestContent, expectedCount: 1)
         let response = prepareNotificationResponse()!
@@ -154,7 +154,7 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
         // This test simulates the reaction of handleNotificationResponse API when the notifcation is not generated from AJO
         // "_xdm" key in userInfo contains all the tracking information from AJO. Absense of this key mean this notification is not generated from AJO
         setExpectationEvent(type: EventType.messaging, source: EventSource.requestContent, expectedCount: 1)
-        var acutalStatus : MessagingPushTrackingStatus?
+        var acutalStatus : PushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging Push Tracking Response")
         let response = prepareNotificationResponse(withUserInfo: ["nospecificAJOKey":"noAJOKey"])!
         
@@ -166,7 +166,7 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
         
         // verify the tracking status
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(acutalStatus, MessagingPushTrackingStatus.noTrackingData)
+        XCTAssertEqual(acutalStatus, PushTrackingStatus.noTrackingData)
                                              
         // verify no tracking event is dispatched
         let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
@@ -175,7 +175,7 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
     
     func test_notificationOpen_whenAJONotification_withEmptyTrackingInformation() {
         // This test simulates the reaction of handleNotificationResponse API when the notifcation from AJO contains no information in the tracking field "_xdm"
-        var acutalStatus : MessagingPushTrackingStatus?
+        var acutalStatus : PushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging Push Tracking Response")
         setExpectationEvent(type: EventType.messaging, source: EventSource.requestContent, expectedCount: 1)
         let response = prepareNotificationResponse(withUserInfo: ["_xdm": [:] as [String:Any]])!
@@ -188,7 +188,7 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
         
         // verify the tracking status
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(acutalStatus, MessagingPushTrackingStatus.noTrackingData)
+        XCTAssertEqual(acutalStatus, PushTrackingStatus.noTrackingData)
         
         // verify no tracking event is dispatched
         let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
@@ -279,7 +279,7 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
     
     func test_notificationTracking_whenNoDatasetConfigured() {
         MobileCore.clearUpdatedConfiguration()
-        var acutalStatus : MessagingPushTrackingStatus?
+        var acutalStatus : PushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging Push Tracking Response")
         setExpectationEvent(type: EventType.messaging, source: EventSource.requestContent, expectedCount: 1)
         let response = prepareNotificationResponse()!

--- a/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingNotificationTrackingTests.swift
@@ -70,20 +70,20 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
     
     func test_notificationTracking_whenUser_tapsNotificationBody() {
         // setup
-        var acutalStatus : PushTrackingStatus?
+        var actualStatus : PushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging Push Tracking Response")
         setExpectationEvent(type: EventType.edge, source: EventSource.requestContent, expectedCount: 1)
         let response = prepareNotificationResponse()!
         
         // test
         Messaging.handleNotificationResponse(response,closure: { status in
-            acutalStatus = status
+            actualStatus = status
             expectation.fulfill()
         })
         
         // verify tracking status value
         wait(for: [expectation], timeout: 2)
-        XCTAssertEqual(acutalStatus, .trackingInitiated)
+        XCTAssertEqual(actualStatus, .trackingInitiated)
         
         // verify
         let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
@@ -154,19 +154,19 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
         // This test simulates the reaction of handleNotificationResponse API when the notifcation is not generated from AJO
         // "_xdm" key in userInfo contains all the tracking information from AJO. Absense of this key mean this notification is not generated from AJO
         setExpectationEvent(type: EventType.messaging, source: EventSource.requestContent, expectedCount: 1)
-        var acutalStatus : PushTrackingStatus?
+        var actualStatus : PushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging Push Tracking Response")
         let response = prepareNotificationResponse(withUserInfo: ["nospecificAJOKey":"noAJOKey"])!
         
         // test
         Messaging.handleNotificationResponse(response,closure: { status in
-            acutalStatus = status
+            actualStatus = status
             expectation.fulfill()
         })
         
         // verify the tracking status
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(acutalStatus, PushTrackingStatus.noTrackingData)
+        XCTAssertEqual(actualStatus, PushTrackingStatus.noTrackingData)
                                              
         // verify no tracking event is dispatched
         let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
@@ -175,20 +175,20 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
     
     func test_notificationOpen_whenAJONotification_withEmptyTrackingInformation() {
         // This test simulates the reaction of handleNotificationResponse API when the notifcation from AJO contains no information in the tracking field "_xdm"
-        var acutalStatus : PushTrackingStatus?
+        var actualStatus : PushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging Push Tracking Response")
         setExpectationEvent(type: EventType.messaging, source: EventSource.requestContent, expectedCount: 1)
         let response = prepareNotificationResponse(withUserInfo: ["_xdm": [:] as [String:Any]])!
         
         // test
         Messaging.handleNotificationResponse(response,closure: { status in
-            acutalStatus = status
+            actualStatus = status
             expectation.fulfill()
         })
         
         // verify the tracking status
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(acutalStatus, PushTrackingStatus.noTrackingData)
+        XCTAssertEqual(actualStatus, PushTrackingStatus.noTrackingData)
         
         // verify no tracking event is dispatched
         let events = getDispatchedEventsWith(type: EventType.edge, source: EventSource.requestContent)
@@ -279,20 +279,20 @@ class MessagingNotificationTrackingTests: FunctionalTestBase {
     
     func test_notificationTracking_whenNoDatasetConfigured() {
         MobileCore.clearUpdatedConfiguration()
-        var acutalStatus : PushTrackingStatus?
+        var actualStatus : PushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging Push Tracking Response")
         setExpectationEvent(type: EventType.messaging, source: EventSource.requestContent, expectedCount: 1)
         let response = prepareNotificationResponse()!
         
         // test
         Messaging.handleNotificationResponse(response, closure: { status in
-            acutalStatus = status
+            actualStatus = status
             expectation.fulfill()
         })
         
         // verify tracking status
         wait(for: [expectation], timeout: 2)
-        XCTAssertEqual(acutalStatus, .noDatasetConfigured)
+        XCTAssertEqual(actualStatus, .noDatasetConfigured)
         
         // verify
         let events = getDispatchedEventsWith(type: EventType.messaging, source: EventSource.requestContent)

--- a/AEPMessaging/Tests/FunctionalTests/MessagingPublicAPITests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingPublicAPITests.swift
@@ -41,8 +41,8 @@ class MessagingPublicAPITests: XCTestCase {
         mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: mockEdgeIdentity, status: SharedStateStatus.set))
 
         mockRuntime.simulateComingEvents(event)
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let edgeEvent = mockRuntime.dispatchedEvents[0]
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let edgeEvent = mockRuntime.dispatchedEvents[1]
 
         XCTAssertEqual(edgeEvent.type, EventType.edge)
         let flattenEdgeEvent = edgeEvent.data?.flattening()
@@ -75,7 +75,7 @@ class MessagingPublicAPITests: XCTestCase {
         mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: mockEdgeIdentity, status: SharedStateStatus.set))
 
         mockRuntime.simulateComingEvents(event)
-        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         mockRuntime.resetDispatchedEventAndCreatedSharedStates()
     }
 
@@ -93,7 +93,7 @@ class MessagingPublicAPITests: XCTestCase {
         mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: mockEdgeIdentity, status: SharedStateStatus.set))
 
         mockRuntime.simulateComingEvents(event)
-        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         mockRuntime.resetDispatchedEventAndCreatedSharedStates()
     }
 
@@ -110,8 +110,8 @@ class MessagingPublicAPITests: XCTestCase {
         mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: mockEdgeIdentity, status: SharedStateStatus.set))
 
         mockRuntime.simulateComingEvents(event)
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let edgeEvent = mockRuntime.dispatchedEvents[0]
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let edgeEvent = mockRuntime.dispatchedEvents[1]
 
         XCTAssertEqual(edgeEvent.type, EventType.edge)
         let flattenEdgeEvent = edgeEvent.data?.flattening()

--- a/AEPMessaging/Tests/UnitTests/Messaging+EdgeEventsTests.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+EdgeEventsTests.swift
@@ -111,12 +111,19 @@ class MessagingEdgeEventsTests: XCTestCase {
         // test
         messaging.handleTrackingInfo(event: event)
 
-        // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let dispatchedInfoEvent = mockRuntime.firstEvent
-        XCTAssertEqual(EventType.edge, dispatchedInfoEvent?.type)
-        XCTAssertEqual(EventSource.requestContent, dispatchedInfoEvent?.source)
-        let dispatchedEventData = dispatchedInfoEvent?.data
+        // verify tracking status event
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let dispatchedStatusEvent = mockRuntime.firstEvent
+        XCTAssertEqual(EventType.messaging, dispatchedStatusEvent?.type)
+        XCTAssertEqual(EventSource.responseContent, dispatchedStatusEvent?.source)
+        XCTAssertEqual(dispatchedStatusEvent?.pushTrackingStatus, .trackingInitiated)
+        
+        
+        // verify edge request event
+        let dispatchedEdgeRequestEvent = mockRuntime.secondEvent
+        XCTAssertEqual(EventType.edge, dispatchedEdgeRequestEvent?.type)
+        XCTAssertEqual(EventSource.requestContent, dispatchedEdgeRequestEvent?.source)
+        let dispatchedEventData = dispatchedEdgeRequestEvent?.data
         XCTAssertNotNil(dispatchedEventData)
         XCTAssertEqual(2, dispatchedEventData?.count)
         let meta = dispatchedEventData?["meta"] as? [String: Any]
@@ -183,8 +190,8 @@ class MessagingEdgeEventsTests: XCTestCase {
         messaging.handleTrackingInfo(event: event)
 
         // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let dispatchedInfoEvent = mockRuntime.firstEvent
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let dispatchedInfoEvent = mockRuntime.secondEvent
         XCTAssertEqual(EventType.edge, dispatchedInfoEvent?.type)
         XCTAssertEqual(EventSource.requestContent, dispatchedInfoEvent?.source)
         let dispatchedEventData = dispatchedInfoEvent?.data
@@ -205,8 +212,12 @@ class MessagingEdgeEventsTests: XCTestCase {
         // test
         messaging.handleTrackingInfo(event: event)
 
-        // verify
-        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+        // verify tracking status event
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let dispatchedStatusEvent = mockRuntime.firstEvent
+        XCTAssertEqual(EventType.messaging, dispatchedStatusEvent?.type)
+        XCTAssertEqual(EventSource.responseContent, dispatchedStatusEvent?.source)
+        XCTAssertEqual(dispatchedStatusEvent?.pushTrackingStatus, .noDatasetConfigured)
     }
 
     func testHandleTrackingInfoEmptyDataset() throws {
@@ -218,8 +229,12 @@ class MessagingEdgeEventsTests: XCTestCase {
         // test
         messaging.handleTrackingInfo(event: event)
 
-        // verify
-        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+        // verify tracking status event
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let dispatchedStatusEvent = mockRuntime.firstEvent
+        XCTAssertEqual(EventType.messaging, dispatchedStatusEvent?.type)
+        XCTAssertEqual(EventSource.responseContent, dispatchedStatusEvent?.source)
+        XCTAssertEqual(dispatchedStatusEvent?.pushTrackingStatus, .noDatasetConfigured)
     }
 
     func testHandleTrackingInfoNoXdmMap() throws {
@@ -231,8 +246,12 @@ class MessagingEdgeEventsTests: XCTestCase {
         // test
         messaging.handleTrackingInfo(event: event)
 
-        // verify
-        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+        // verify tracking status event
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let dispatchedStatusEvent = mockRuntime.firstEvent
+        XCTAssertEqual(EventType.messaging, dispatchedStatusEvent?.type)
+        XCTAssertEqual(EventSource.responseContent, dispatchedStatusEvent?.source)
+        XCTAssertEqual(dispatchedStatusEvent?.pushTrackingStatus, .unknownError)
     }
 
     func testHandleTrackingInfoXdmMapMessageIdNil() throws {
@@ -244,8 +263,12 @@ class MessagingEdgeEventsTests: XCTestCase {
         // test
         messaging.handleTrackingInfo(event: event)
 
-        // verify
-        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+        // verify tracking status event
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let dispatchedStatusEvent = mockRuntime.firstEvent
+        XCTAssertEqual(EventType.messaging, dispatchedStatusEvent?.type)
+        XCTAssertEqual(EventSource.responseContent, dispatchedStatusEvent?.source)
+        XCTAssertEqual(dispatchedStatusEvent?.pushTrackingStatus, .invalidMessageId)
     }
 
     func testHandleTrackingInfoXdmMapMessageIdEmpty() throws {
@@ -257,8 +280,12 @@ class MessagingEdgeEventsTests: XCTestCase {
         // test
         messaging.handleTrackingInfo(event: event)
 
-        // verify
-        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+        // verify tracking status event
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let dispatchedStatusEvent = mockRuntime.firstEvent
+        XCTAssertEqual(EventType.messaging, dispatchedStatusEvent?.type)
+        XCTAssertEqual(EventSource.responseContent, dispatchedStatusEvent?.source)
+        XCTAssertEqual(dispatchedStatusEvent?.pushTrackingStatus, .invalidMessageId)
     }
 
     func testSendPushTokenHappy() throws {
@@ -304,8 +331,8 @@ class MessagingEdgeEventsTests: XCTestCase {
         messaging.handleTrackingInfo(event: event)
 
         // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let dispatchedEvent = mockRuntime.firstEvent
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.secondEvent
         let dispatchedXdmMap = dispatchedEvent?.data?[MessagingConstants.XDM.Key.XDM] as? [String: Any]
         XCTAssertEqual(4, dispatchedXdmMap?.count)
         XCTAssertNotNil(dispatchedXdmMap?[MessagingConstants.XDM.Key.PUSH_NOTIFICATION_TRACKING])
@@ -337,8 +364,8 @@ class MessagingEdgeEventsTests: XCTestCase {
         messaging.handleTrackingInfo(event: event)
 
         // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let dispatchedEvent = mockRuntime.firstEvent
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.secondEvent
         let dispatchedXdmMap = dispatchedEvent?.data?[MessagingConstants.XDM.Key.XDM] as? [String: Any]
         XCTAssertEqual(3, dispatchedXdmMap?.count)
         XCTAssertNotNil(dispatchedXdmMap?[MessagingConstants.XDM.Key.PUSH_NOTIFICATION_TRACKING])
@@ -357,8 +384,8 @@ class MessagingEdgeEventsTests: XCTestCase {
         messaging.handleTrackingInfo(event: event)
 
         // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let dispatchedEvent = mockRuntime.firstEvent
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.secondEvent
         let dispatchedXdmMap = dispatchedEvent?.data?[MessagingConstants.XDM.Key.XDM] as? [String: Any]
         XCTAssertEqual(4, dispatchedXdmMap?.count)
         XCTAssertNotNil(dispatchedXdmMap?[MessagingConstants.XDM.Key.PUSH_NOTIFICATION_TRACKING])
@@ -378,8 +405,8 @@ class MessagingEdgeEventsTests: XCTestCase {
         messaging.handleTrackingInfo(event: event)
 
         // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let dispatchedEvent = mockRuntime.firstEvent
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.secondEvent
         let dispatchedXdmMap = dispatchedEvent?.data?[MessagingConstants.XDM.Key.XDM] as? [String: Any]
         XCTAssertEqual(3, dispatchedXdmMap?.count)
         XCTAssertNotNil(dispatchedXdmMap?[MessagingConstants.XDM.Key.PUSH_NOTIFICATION_TRACKING])
@@ -398,8 +425,8 @@ class MessagingEdgeEventsTests: XCTestCase {
         messaging.handleTrackingInfo(event: event)
 
         // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let dispatchedEvent = mockRuntime.firstEvent
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.secondEvent
         let dispatchedXdmMap = dispatchedEvent?.data?[MessagingConstants.XDM.Key.XDM] as? [String: Any]
         let applicationData = dispatchedXdmMap?[MessagingConstants.XDM.AdobeKeys.APPLICATION] as? [String: Any]
         XCTAssertNotNil(applicationData)
@@ -419,8 +446,8 @@ class MessagingEdgeEventsTests: XCTestCase {
         messaging.handleTrackingInfo(event: event)
 
         // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let dispatchedEvent = mockRuntime.firstEvent
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.secondEvent
         let dispatchedXdmMap = dispatchedEvent?.data?[MessagingConstants.XDM.Key.XDM] as? [String: Any]
         let applicationData = dispatchedXdmMap?[MessagingConstants.XDM.AdobeKeys.APPLICATION] as? [String: Any]
         XCTAssertNotNil(applicationData)

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -205,10 +205,10 @@ class MessagingPublicApiTest: XCTestCase {
     }
     
     func testHandleNotificationResponse_when_emptyXdmInNotification() {
+        var acutalStatus : MessagingPushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging request event")
         let mockIdentifier = "mockIdentifier"
         expectation.assertForOverFulfill = true
-        expectation.isInverted = true
 
         EventHub.shared.getExtensionContainer(MockExtension.self)?.eventListeners.clear()
 
@@ -228,9 +228,13 @@ class MessagingPublicApiTest: XCTestCase {
             return
         }
 
-        let hasTracked = Messaging.handleNotificationResponse(response)
+        Messaging.handleNotificationResponse(response, closure: { status in
+            acutalStatus = status
+            expectation.fulfill()
+        })
+        
+        XCTAssertEqual(.noTrackingData , acutalStatus)
         wait(for: [expectation], timeout: 1)
-        XCTAssertFalse(hasTracked)
     }
     
 

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -228,8 +228,9 @@ class MessagingPublicApiTest: XCTestCase {
             return
         }
 
-        Messaging.handleNotificationResponse(response)
+        let hasTracked = Messaging.handleNotificationResponse(response)
         wait(for: [expectation], timeout: 1)
+        XCTAssertFalse(hasTracked)
     }
     
 

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -205,7 +205,7 @@ class MessagingPublicApiTest: XCTestCase {
     }
     
     func testHandleNotificationResponse_when_emptyXdmInNotification() {
-        var acutalStatus : MessagingPushTrackingStatus?
+        var acutalStatus : PushTrackingStatus?
         let expectation = XCTestExpectation(description: "Messaging request event")
         let mockIdentifier = "mockIdentifier"
         expectation.assertForOverFulfill = true

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -447,10 +447,15 @@ class MessagingTests: XCTestCase {
 
         // test
         XCTAssertNoThrow(messaging.handleProcessEvent(event))
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        let dispatchedInfoEvent = mockRuntime.firstEvent
-        XCTAssertEqual(EventType.edge, dispatchedInfoEvent?.type)
-        XCTAssertEqual(EventSource.requestContent, dispatchedInfoEvent?.source)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        
+        let dispatchedStatusEvent = mockRuntime.firstEvent
+        XCTAssertEqual(EventType.messaging, dispatchedStatusEvent?.type)
+        XCTAssertEqual(EventSource.responseContent, dispatchedStatusEvent?.source)
+        
+        let dispatchedEdgeEvent = mockRuntime.secondEvent
+        XCTAssertEqual(EventType.edge, dispatchedEdgeEvent?.type)
+        XCTAssertEqual(EventSource.requestContent, dispatchedEdgeEvent?.source)
     }
 
     func testHandleProcessEventRefreshMessageEvent() throws {

--- a/TestApps/MessagingDemoAppObjC/AppDelegate.m
+++ b/TestApps/MessagingDemoAppObjC/AppDelegate.m
@@ -75,7 +75,7 @@
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
     [AEPMobileMessaging handleNotificationResponse:response closure:^(AEPPushTrackingStatus status){
         if (status == AEPPushTrackingStatusTrackingInitiated) {
-            NSLog(@"Sucessfully started push notification tracking");
+            NSLog(@"Successfully started push notification tracking");
         }
     }];
 }

--- a/TestApps/MessagingDemoAppObjC/AppDelegate.m
+++ b/TestApps/MessagingDemoAppObjC/AppDelegate.m
@@ -73,7 +73,11 @@
 
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
-    [AEPMobileMessaging handleNotificationResponse:response];
+    [AEPMobileMessaging handleNotificationResponse:response closure:^(AEPPushTrackingStatus status){
+        if (status == AEPPushTrackingStatusTrackingInitiated) {
+            NSLog(@"Sucessfully started push notification tracking");
+        }
+    }];
 }
 
 @end


### PR DESCRIPTION
- Reverted back the deprecated API to be unchanged (handleNotificationResponse(response, applicationOpened, customID) now does not return boolean)

- Changed the new API handleNotificationResponse(response) to include another optional parameter that takes in a callback and returns MessagingPushTrackingStatus enum

- A public enum PushTrackingStaus is introduced with the following values
     * trackingInitiated               - Returned when all the required data are available and the tracking has been initiated by Messaging Extension
     * noDatasetConfigured.     - Returned when no tracking dataset is configured for Messaging Extension
     * noTrackingData                - Returned when no tracking information is found in the Notification Response
     * invalidMessageId.            - Returned when NotificationReponse has empty/null identifier.
     * unknownError                   - Returned when any other unknown errors happens within the SDK


- Updated test for the same