### PR TITLE
Added support for events ordering in the extension

### DIFF
--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -232,6 +232,7 @@ public class Messaging: NSObject, Extension {
                 let endingEventId = responseEvent.requestEventId else {
                 // response event failed or timed out, need to remove this event from the queue
                 self.requestedSurfacesForEventId.removeValue(forKey: newEvent.id.uuidString)
+                self.eventsQueue.start()
                 
                 Log.warning(label: MessagingConstants.LOG_TAG, "Unable to run completion logic for a personalization request event - unable to obtain parent event ID")
                 return


### PR DESCRIPTION
## Description

This change will ensure that the events ordering is honored despite the asynchronous nature of the APIs and workflow.
For example:
```
Messaging.updatePropositionsForSurfaces([Surface(path: <my-path>)])
Messaging.getPropositionsForSurfaces([Surface(path: <my-path>)]) { PropositionsResult, error in
    
    if let error = error {
        return
    }
    
    if let propositions = PropositionsResult?[Surface(path: <my-path>)] {
        // Use propositions
    }
    
}
```
The event ordering will ensure that the get request is processed and fulfilled with the latest cached content, once the update propositions request is completed. Any non-cached surface (content), at this point, can be _assumed_ to have not been returned from the server.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
