### PR TITLE
Fix test persistence cleanup

### DIFF
--- a/AEPMessaging/Tests/TestHelpers/FunctionalTestBase.swift
+++ b/AEPMessaging/Tests/TestHelpers/FunctionalTestBase.swift
@@ -80,7 +80,7 @@ class FunctionalTestBase: XCTestCase {
         EventHub.reset()
         UserDefaults.clearAll()
         FileManager.default.clearCache()
-        FileManager.default.removeAdobeDirectory(appGroup: nil)
+        FileManager.default.removeAdobeCacheDirectory()
     }
 
     /// Reset event and network request expectations and drop the items received until this point

--- a/Podfile
+++ b/Podfile
@@ -73,7 +73,7 @@ end
 
 target 'FunctionalTests' do
   app_main
-  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :branch => 'persistence-cleanup-helper'
+  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :branch => 'main'
 end
 
 target 'E2EFunctionalTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,7 +34,7 @@ DEPENDENCIES:
   - AEPRulesEngine
   - AEPServices
   - AEPSignal
-  - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, branch `persistence-cleanup-helper`)
+  - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, branch `main`)
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
@@ -52,12 +52,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   AEPTestUtils:
-    :branch: persistence-cleanup-helper
+    :branch: main
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
 
 CHECKOUT OPTIONS:
   AEPTestUtils:
-    :commit: 9f13bdbb762d0ef5c07b6ad82d27788546cf555e
+    :commit: 109e389c49824b7c97467b61a0b4ea4df7238022
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
 
 SPEC CHECKSUMS:
@@ -73,6 +73,6 @@ SPEC CHECKSUMS:
   AEPTestUtils: 756e5997318be74584057d7628941c737d358640
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 650b18f08525e64ca05bf6a5f3480a8a4f44eda8
+PODFILE CHECKSUM: 36e10755de661bfe539aa1a22e4a2d2f5b67dafc
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With the recent [update to Core (v4.2.0)](https://github.com/adobe/aepsdk-core-ios/releases/tag/4.2.0) which migrated the persistence location from `UserDefaults` to the device file system, the old helper utility extension on `UserDefaults` no longer works to clear persistence correctly between test case runs. This PR updates `FunctionalTestBase` to use the new helper method in AEPTestUtils (https://github.com/adobe/aepsdk-testutils-ios/pull/2) to clear device persistence between test case runs.

> [!NOTE]
> Currently the pod dependency for AEPTestUtils points to the branch: `persistence-cleanup-helper` - this can be updated to `main` or a release version once available in the branch or released, respectively

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
