### PR TITLE
Rename classes to prevent objC symbol conflict with Optimize extension classes

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -49,10 +49,10 @@
 		096E19922A758D1600D4EBCF /* FeedItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096E19912A758D1600D4EBCF /* FeedItemDetailView.swift */; };
 		09B071E62A64D3D900F259C1 /* Surface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B071E52A64D3D900F259C1 /* Surface.swift */; };
 		09B071E82A64D80E00F259C1 /* Bundle+Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B071E72A64D80E00F259C1 /* Bundle+Messaging.swift */; };
-		09B071EC2A651C7800F259C1 /* MessagingProposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B071EB2A651C7800F259C1 /* MessagingProposition.swift */; };
-		09B071EE2A651CB200F259C1 /* MessagingPropositionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B071ED2A651CB200F259C1 /* MessagingPropositionItem.swift */; };
+		09B071EC2A651C7800F259C1 /* Proposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B071EB2A651C7800F259C1 /* Proposition.swift */; };
+		09B071EE2A651CB200F259C1 /* PropositionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B071ED2A651CB200F259C1 /* PropositionItem.swift */; };
 		09B071F62A7318CB00F259C1 /* Array+Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B071F52A7318CB00F259C1 /* Array+Messaging.swift */; };
-		09F5D9402B5CF35F00117437 /* MessagingPropositionInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F5D93F2B5CF35F00117437 /* MessagingPropositionInteraction.swift */; };
+		09F5D9402B5CF35F00117437 /* PropositionInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F5D93F2B5CF35F00117437 /* PropositionInteraction.swift */; };
 		2402745C29FC424000884DFE /* TestableMessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2402745B29FC424000884DFE /* TestableMessagingDelegate.swift */; };
 		2402745D29FC424000884DFE /* TestableMessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2402745B29FC424000884DFE /* TestableMessagingDelegate.swift */; };
 		2402745E29FC424000884DFE /* TestableMessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2402745B29FC424000884DFE /* TestableMessagingDelegate.swift */; };
@@ -180,9 +180,9 @@
 		24CA4BD32B617AED00D16369 /* Cache+MessagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BD22B617AED00D16369 /* Cache+MessagingTests.swift */; };
 		24CA4BD52B6195A500D16369 /* FeedRulesEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BD42B6195A500D16369 /* FeedRulesEngineTests.swift */; };
 		24CA4BD92B6196DF00D16369 /* MessagingMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BD82B6196DF00D16369 /* MessagingMigratorTests.swift */; };
-		24CA4BDB2B61971000D16369 /* MessagingPropositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDA2B61971000D16369 /* MessagingPropositionTests.swift */; };
-		24CA4BDD2B61972500D16369 /* MessagingPropositionItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDC2B61972500D16369 /* MessagingPropositionItemTests.swift */; };
-		24CA4BDF2B61974300D16369 /* MessagingPropositionInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDE2B61974300D16369 /* MessagingPropositionInteractionTests.swift */; };
+		24CA4BDB2B61971000D16369 /* PropositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDA2B61971000D16369 /* PropositionTests.swift */; };
+		24CA4BDD2B61972500D16369 /* PropositionItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDC2B61972500D16369 /* PropositionItemTests.swift */; };
+		24CA4BDF2B61974300D16369 /* PropositionInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDE2B61974300D16369 /* PropositionInteractionTests.swift */; };
 		24CA4BE12B61977800D16369 /* SurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BE02B61977800D16369 /* SurfaceTests.swift */; };
 		24EE301E28FF61F0005E417C /* InAppMessagingEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EE301D28FF61F0005E417C /* InAppMessagingEventTests.swift */; };
 		2B2B7A6E0F7CD6312D28421A /* Pods_FunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD29CE4BC879CE75AFEFF0D5 /* Pods_FunctionalTests.framework */; };
@@ -399,10 +399,10 @@
 		096E19912A758D1600D4EBCF /* FeedItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedItemDetailView.swift; sourceTree = "<group>"; };
 		09B071E52A64D3D900F259C1 /* Surface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Surface.swift; sourceTree = "<group>"; };
 		09B071E72A64D80E00F259C1 /* Bundle+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Messaging.swift"; sourceTree = "<group>"; };
-		09B071EB2A651C7800F259C1 /* MessagingProposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingProposition.swift; sourceTree = "<group>"; };
-		09B071ED2A651CB200F259C1 /* MessagingPropositionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingPropositionItem.swift; sourceTree = "<group>"; };
+		09B071EB2A651C7800F259C1 /* Proposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Proposition.swift; sourceTree = "<group>"; };
+		09B071ED2A651CB200F259C1 /* PropositionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropositionItem.swift; sourceTree = "<group>"; };
 		09B071F52A7318CB00F259C1 /* Array+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Messaging.swift"; sourceTree = "<group>"; };
-		09F5D93F2B5CF35F00117437 /* MessagingPropositionInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingPropositionInteraction.swift; sourceTree = "<group>"; };
+		09F5D93F2B5CF35F00117437 /* PropositionInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropositionInteraction.swift; sourceTree = "<group>"; };
 		2402745B29FC424000884DFE /* TestableMessagingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestableMessagingDelegate.swift; sourceTree = "<group>"; };
 		240316B72A83DDD80016B0D9 /* Cache+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cache+Messaging.swift"; sourceTree = "<group>"; };
 		240F71FA26868F7100846587 /* SharedStateResult+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharedStateResult+Messaging.swift"; sourceTree = "<group>"; };
@@ -516,9 +516,9 @@
 		24CA4BD22B617AED00D16369 /* Cache+MessagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cache+MessagingTests.swift"; sourceTree = "<group>"; };
 		24CA4BD42B6195A500D16369 /* FeedRulesEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRulesEngineTests.swift; sourceTree = "<group>"; };
 		24CA4BD82B6196DF00D16369 /* MessagingMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingMigratorTests.swift; sourceTree = "<group>"; };
-		24CA4BDA2B61971000D16369 /* MessagingPropositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingPropositionTests.swift; sourceTree = "<group>"; };
-		24CA4BDC2B61972500D16369 /* MessagingPropositionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingPropositionItemTests.swift; sourceTree = "<group>"; };
-		24CA4BDE2B61974300D16369 /* MessagingPropositionInteractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingPropositionInteractionTests.swift; sourceTree = "<group>"; };
+		24CA4BDA2B61971000D16369 /* PropositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropositionTests.swift; sourceTree = "<group>"; };
+		24CA4BDC2B61972500D16369 /* PropositionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropositionItemTests.swift; sourceTree = "<group>"; };
+		24CA4BDE2B61974300D16369 /* PropositionInteractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropositionInteractionTests.swift; sourceTree = "<group>"; };
 		24CA4BE02B61977800D16369 /* SurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTests.swift; sourceTree = "<group>"; };
 		24EE301D28FF61F0005E417C /* InAppMessagingEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessagingEventTests.swift; sourceTree = "<group>"; };
 		28E46BC7A8F3939CF2DDDC8F /* Pods_MessagingDemoAppObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MessagingDemoAppObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -892,9 +892,9 @@
 				92315437261E3B36004AE7D3 /* MessagingConstants.swift */,
 				244C2BD726B36480008F086A /* MessagingEdgeEventType.swift */,
 				0969D63F2A7A9DC600A00BF7 /* MessagingMigrator.swift */,
-				09B071EB2A651C7800F259C1 /* MessagingProposition.swift */,
-				09B071ED2A651CB200F259C1 /* MessagingPropositionItem.swift */,
-				09F5D93F2B5CF35F00117437 /* MessagingPropositionInteraction.swift */,
+				09B071EB2A651C7800F259C1 /* Proposition.swift */,
+				09B071ED2A651CB200F259C1 /* PropositionItem.swift */,
+				09F5D93F2B5CF35F00117437 /* PropositionInteraction.swift */,
 				2450594D2671283F00CC7CA0 /* MessagingRulesEngine.swift */,
 				2469A5E2274863F600E56457 /* MessagingRulesEngine+Caching.swift */,
 				240FC42D2AA920D400AFEEEB /* ParsedPropositions.swift */,
@@ -944,9 +944,9 @@
 				242920E82AC4EE2D000DB2CD /* Messaging+StateTests.swift */,
 				243EA6D32733261E00195945 /* MessagingEdgeEventTypeTests.swift */,
 				24CA4BD82B6196DF00D16369 /* MessagingMigratorTests.swift */,
-				24CA4BDA2B61971000D16369 /* MessagingPropositionTests.swift */,
-				24CA4BDC2B61972500D16369 /* MessagingPropositionItemTests.swift */,
-				24CA4BDE2B61974300D16369 /* MessagingPropositionInteractionTests.swift */,
+				24CA4BDA2B61971000D16369 /* PropositionTests.swift */,
+				24CA4BDC2B61972500D16369 /* PropositionItemTests.swift */,
+				24CA4BDE2B61974300D16369 /* PropositionInteractionTests.swift */,
 				2450596B2673DBFE00CC7CA0 /* MessagingRulesEngineTests.swift */,
 				2469A5E6274C0FA900E56457 /* MessagingRulesEngine+CachingTests.swift */,
 				240FC42F2AAFB08E00AFEEEB /* ParsedPropositionsTests.swift */,
@@ -1896,10 +1896,10 @@
 				09B071E62A64D3D900F259C1 /* Surface.swift in Sources */,
 				240FC42E2AA920D400AFEEEB /* ParsedPropositions.swift in Sources */,
 				245059982673F94D00CC7CA0 /* MessagingConstants.swift in Sources */,
-				09B071EE2A651CB200F259C1 /* MessagingPropositionItem.swift in Sources */,
+				09B071EE2A651CB200F259C1 /* PropositionItem.swift in Sources */,
 				246FD07226B9F86F00FD130B /* FullscreenMessage+Message.swift in Sources */,
 				242920ED2ACF7760000DB2CD /* SchemaType.swift in Sources */,
-				09B071EC2A651C7800F259C1 /* MessagingProposition.swift in Sources */,
+				09B071EC2A651C7800F259C1 /* Proposition.swift in Sources */,
 				243B1AFC28AD7FCE0074327E /* PropositionPayload.swift in Sources */,
 				24569A8F2AE2CD6E00FC356F /* ContentType.swift in Sources */,
 				243B1AFE28AEB1E60074327E /* PropositionInfo.swift in Sources */,
@@ -1929,7 +1929,7 @@
 				241B2DD42821C80C00E4FF67 /* URL+QueryParams.swift in Sources */,
 				245059A22673FAC200CC7CA0 /* Messaging.swift in Sources */,
 				B6389A492A9B32D400B72FB4 /* PushTrackingStatus.swift in Sources */,
-				09F5D9402B5CF35F00117437 /* MessagingPropositionInteraction.swift in Sources */,
+				09F5D9402B5CF35F00117437 /* PropositionInteraction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1963,10 +1963,10 @@
 				243EA6CF273325CC00195945 /* Message+FullscreenMessageDelegateTests.swift in Sources */,
 				245059712673DBFE00CC7CA0 /* MessagingTests.swift in Sources */,
 				2469A5EB274D49B100E56457 /* JSONFileLoader.swift in Sources */,
-				24CA4BDB2B61971000D16369 /* MessagingPropositionTests.swift in Sources */,
-				24CA4BDF2B61974300D16369 /* MessagingPropositionInteractionTests.swift in Sources */,
+				24CA4BDB2B61971000D16369 /* PropositionTests.swift in Sources */,
+				24CA4BDF2B61974300D16369 /* PropositionInteractionTests.swift in Sources */,
 				24CA4BC92B617A3F00D16369 /* JsonContentSchemaDataTests.swift in Sources */,
-				24CA4BDD2B61972500D16369 /* MessagingPropositionItemTests.swift in Sources */,
+				24CA4BDD2B61972500D16369 /* PropositionItemTests.swift in Sources */,
 				245059762673DBFE00CC7CA0 /* MessagingRulesEngineTests.swift in Sources */,
 				24CA4BD52B6195A500D16369 /* FeedRulesEngineTests.swift in Sources */,
 				24CA4BE12B61977800D16369 /* SurfaceTests.swift in Sources */,

--- a/AEPMessaging.xcodeproj/xcshareddata/xcschemes/AEPMessaging.xcscheme
+++ b/AEPMessaging.xcodeproj/xcshareddata/xcschemes/AEPMessaging.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AEPMessaging.xcodeproj/xcshareddata/xcschemes/AEPMessaging.xcscheme
+++ b/AEPMessaging.xcodeproj/xcshareddata/xcschemes/AEPMessaging.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AEPMessaging/Sources/Cache+Messaging.swift
+++ b/AEPMessaging/Sources/Cache+Messaging.swift
@@ -16,19 +16,19 @@ import Foundation
 extension Cache {
     // MARK: - getters
 
-    var propositions: [Surface: [MessagingProposition]]? {
+    var propositions: [Surface: [Proposition]]? {
         guard let cachedPropositions = get(key: MessagingConstants.Caches.PROPOSITIONS) else {
             Log.trace(label: MessagingConstants.LOG_TAG, "Unable to load cached messages, cache file not found.")
             return nil
         }
 
         let decoder = JSONDecoder()
-        guard let propositionsDict: [String: [MessagingProposition]] = try? decoder.decode([String: [MessagingProposition]].self, from: cachedPropositions.data) else {
+        guard let propositionsDict: [String: [Proposition]] = try? decoder.decode([String: [Proposition]].self, from: cachedPropositions.data) else {
             Log.debug(label: MessagingConstants.LOG_TAG, "No message definitions found in cache.")
             return nil
         }
 
-        var retrievedPropositions: [Surface: [MessagingProposition]] = [:]
+        var retrievedPropositions: [Surface: [Proposition]] = [:]
         for (key, value) in propositionsDict {
             retrievedPropositions[Surface(uri: key)] = value
         }
@@ -40,7 +40,7 @@ extension Cache {
     // update entries for surfaces already existing
     // remove surfaces listed by `surfaces`
     // write or remove cache file based on result
-    func updatePropositions(_ newPropositions: [Surface: [MessagingProposition]]?, removing surfaces: [Surface]? = nil) {
+    func updatePropositions(_ newPropositions: [Surface: [Proposition]]?, removing surfaces: [Surface]? = nil) {
         let existingPropositions = propositions ?? [:]
         var updatedPropositions = existingPropositions.merging(newPropositions ?? [:]) { _, new in new }
         if let surfaces = surfaces {
@@ -54,7 +54,7 @@ extension Cache {
             return
         }
 
-        var propositionsToCache: [String: [MessagingProposition]] = [:]
+        var propositionsToCache: [String: [Proposition]] = [:]
         for (key, value) in updatedPropositions {
             propositionsToCache[key.uri] = value
         }

--- a/AEPMessaging/Sources/Event+Messaging.swift
+++ b/AEPMessaging/Sources/Event+Messaging.swift
@@ -46,13 +46,13 @@ extension Event {
         parentID?.uuidString as? String ?? data?[MessagingConstants.Event.Data.Key.REQUEST_EVENT_ID] as? String
     }
 
-    /// payload is an array of `MessagingProposition` objects, each containing inbound content and related tracking information
-    var payload: [MessagingProposition]? {
+    /// payload is an array of `Proposition` objects, each containing inbound content and related tracking information
+    var payload: [Proposition]? {
         guard let payloadMap = data?[MessagingConstants.Event.Data.Key.Personalization.PAYLOAD] as? [[String: Any]] else {
             return nil
         }
 
-        var returnablePayloads: [MessagingProposition] = []
+        var returnablePayloads: [Proposition] = []
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()
         for thisPayloadAny in payloadMap {
@@ -61,7 +61,7 @@ extension Event {
                 let payloadData = try? encoder.encode(thisPayload)
             {
                 do {
-                    let payloadObject = try decoder.decode(MessagingProposition.self, from: payloadData)
+                    let payloadObject = try decoder.decode(Proposition.self, from: payloadData)
                     returnablePayloads.append(payloadObject)
                 } catch {
                     Log.warning(label: MessagingConstants.LOG_TAG, "Failed to decode an invalid personalization response: \(error)")
@@ -154,7 +154,7 @@ extension Event {
         data?[MessagingConstants.Event.Data.Key.GET_PROPOSITIONS] as? Bool ?? false
     }
 
-    var propositions: [MessagingProposition]? {
+    var propositions: [Proposition]? {
         guard
             let propositionsData = data?[MessagingConstants.Event.Data.Key.PROPOSITIONS] as? [[String: Any]],
             let jsonData = try? JSONSerialization.data(withJSONObject: propositionsData)
@@ -162,7 +162,7 @@ extension Event {
             return nil
         }
 
-        return try? JSONDecoder().decode([MessagingProposition].self, from: jsonData)
+        return try? JSONDecoder().decode([Proposition].self, from: jsonData)
     }
 
     var responseError: AEPError? {

--- a/AEPMessaging/Sources/FeedRulesEngine.swift
+++ b/AEPMessaging/Sources/FeedRulesEngine.swift
@@ -34,15 +34,15 @@ class FeedRulesEngine {
     }
 
     /// if we have rules loaded, then we simply process the event.
-    func evaluate(event: Event) -> [Surface: [MessagingPropositionItem]]? {
+    func evaluate(event: Event) -> [Surface: [PropositionItem]]? {
         let consequences = launchRulesEngine.evaluate(event: event)
         guard let consequences = consequences else {
             return nil
         }
 
-        var propositionItemsBySurface: [Surface: [MessagingPropositionItem]] = [:]
+        var propositionItemsBySurface: [Surface: [PropositionItem]] = [:]
         for consequence in consequences {
-            guard let propositionItem = MessagingPropositionItem.fromRuleConsequence(consequence),
+            guard let propositionItem = PropositionItem.fromRuleConsequence(consequence),
                   let propositionAsFeedItem = propositionItem.feedItemSchemaData
             else {
                 continue

--- a/AEPMessaging/Sources/Message.swift
+++ b/AEPMessaging/Sources/Message.swift
@@ -95,7 +95,7 @@ public class Message: NSObject {
             return
         }
 
-        let propositionInteractionXdm = MessagingPropositionInteraction(eventType: eventType, interaction: interaction ?? "", propositionInfo: propInfo, itemId: nil).xdm
+        let propositionInteractionXdm = PropositionInteraction(eventType: eventType, interaction: interaction ?? "", propositionInfo: propInfo, itemId: nil).xdm
         parent?.sendPropositionInteraction(withXdm: propositionInteractionXdm)
     }
 
@@ -202,7 +202,7 @@ public class Message: NSObject {
 }
 
 extension Message {
-    static func fromPropositionItem(_ propositionItem: MessagingPropositionItem, with parent: Messaging, triggeringEvent event: Event) -> Message? {
+    static func fromPropositionItem(_ propositionItem: PropositionItem, with parent: Messaging, triggeringEvent event: Event) -> Message? {
         guard let iamSchemaData = propositionItem.inappSchemaData,
               let htmlContent = iamSchemaData.content as? String
         else {

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -134,7 +134,7 @@ import UserNotifications
     /// - Parameters:
     ///   - surfacePaths: An array of surface objects.
     ///   - completion: The completion handler to be invoked with a dictionary containing the surface objects and the corresponding array of Proposition objects.
-    static func getPropositionsForSurfaces(_ surfacePaths: [Surface], _ completion: @escaping ([Surface: [MessagingProposition]]?, Error?) -> Void) {
+    static func getPropositionsForSurfaces(_ surfacePaths: [Surface], _ completion: @escaping ([Surface: [Proposition]]?, Error?) -> Void) {
         let validSurfaces = surfacePaths
             .filter { $0.isValid }
 

--- a/AEPMessaging/Sources/Messaging+State.swift
+++ b/AEPMessaging/Sources/Messaging+State.swift
@@ -36,7 +36,7 @@ extension Messaging {
         }
     }
 
-    func updatePropositions(_ newPropositions: [Surface: [MessagingProposition]], removing surfaces: [Surface]? = nil) {
+    func updatePropositions(_ newPropositions: [Surface: [Proposition]], removing surfaces: [Surface]? = nil) {
         // add new surfaces or update replace existing surfaces
         for (surface, propositionsArray) in newPropositions {
             propositions.addArray(propositionsArray, forKey: surface)

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -44,8 +44,8 @@ public class Messaging: NSObject, Extension {
     private let queue: DispatchQueue = .init(label: "com.adobe.messaging.containers.queue")
 
     /// stores CBE propositions (json-content, html-content, default-content)
-    private var _propositions: [Surface: [MessagingProposition]] = [:]
-    var propositions: [Surface: [MessagingProposition]] {
+    private var _propositions: [Surface: [Proposition]] = [:]
+    var propositions: [Surface: [Proposition]] {
         get { queue.sync { self._propositions } }
         set { queue.async { self._propositions = newValue } }
     }
@@ -65,8 +65,8 @@ public class Messaging: NSObject, Extension {
     }
 
     /// used while processing streaming payloads for a single request
-    private var _inProgressPropositions: [Surface: [MessagingProposition]] = [:]
-    private var inProgressPropositions: [Surface: [MessagingProposition]] {
+    private var _inProgressPropositions: [Surface: [Proposition]] = [:]
+    private var inProgressPropositions: [Surface: [Proposition]] {
         get { queue.sync { self._inProgressPropositions } }
         set { queue.async { self._inProgressPropositions = newValue } }
     }
@@ -303,19 +303,19 @@ public class Messaging: NSObject, Extension {
         dispatchNotificationEventFor(event, requestedSurfaces: requestedSurfaces)
     }
 
-    private func getPropositionsFromFeedRulesEngine(_ event: Event) -> [Surface: [MessagingProposition]] {
-        var surfacePropositions: [Surface: [MessagingProposition]] = [:]
+    private func getPropositionsFromFeedRulesEngine(_ event: Event) -> [Surface: [Proposition]] {
+        var surfacePropositions: [Surface: [Proposition]] = [:]
 
         if let propositionItemsBySurface = feedRulesEngine.evaluate(event: event) {
             for (surface, propositionItemsArray) in propositionItemsBySurface {
-                var tempPropositions: [MessagingProposition] = []
+                var tempPropositions: [Proposition] = []
                 for propositionItem in propositionItemsArray {
                     guard let propositionInfo = propositionInfo[propositionItem.itemId] else {
                         continue
                     }
 
                     // get proposition that this item belongs to
-                    let proposition = MessagingProposition(
+                    let proposition = Proposition(
                         uniqueId: propositionInfo.id,
                         scope: propositionInfo.scope,
                         scopeDetails: propositionInfo.scopeDetails,
@@ -513,7 +513,7 @@ public class Messaging: NSObject, Extension {
     }
 
     /// Returns propositions by surface from `propositions` matching the provided `surfaces`
-    private func retrieveCachedPropositions(for surfaces: [Surface]) -> [Surface: [MessagingProposition]] {
+    private func retrieveCachedPropositions(for surfaces: [Surface]) -> [Surface: [Proposition]] {
         propositions.filter { surface, _ in
             surfaces.contains(where: { $0.uri == surface.uri })
         }
@@ -530,7 +530,7 @@ public class Messaging: NSObject, Extension {
     }
 
     private func handleSchemaConsequence(_ event: Event) {
-        guard let propositionItem = MessagingPropositionItem.fromRuleConsequenceEvent(event) else {
+        guard let propositionItem = PropositionItem.fromRuleConsequenceEvent(event) else {
             return
         }
 

--- a/AEPMessaging/Sources/ParsedPropositions.swift
+++ b/AEPMessaging/Sources/ParsedPropositions.swift
@@ -20,16 +20,16 @@ struct ParsedPropositions {
     var propositionInfoToCache: [String: PropositionInfo] = [:]
 
     // non-in-app propositions should be cached and not persisted
-    var propositionsToCache: [Surface: [MessagingProposition]] = [:]
+    var propositionsToCache: [Surface: [Proposition]] = [:]
 
     // in-app propositions don't need to stay in cache, but must be persisted
     // also need to store tracking info for in-app propositions as `PropositionInfo`
-    var propositionsToPersist: [Surface: [MessagingProposition]] = [:]
+    var propositionsToPersist: [Surface: [Proposition]] = [:]
 
     // in-app and feed rules that need to be applied to their respective rules engines
     var surfaceRulesBySchemaType: [SchemaType: [Surface: [LaunchRule]]] = [:]
 
-    init(with propositions: [Surface: [MessagingProposition]], requestedSurfaces: [Surface], runtime: ExtensionRuntime) {
+    init(with propositions: [Surface: [Proposition]], requestedSurfaces: [Surface], runtime: ExtensionRuntime) {
         self.runtime = runtime
         for propositionsArray in propositions.values {
             for proposition in propositionsArray {
@@ -39,7 +39,7 @@ struct ParsedPropositions {
                     continue
                 }
 
-                // handle schema consequences which are representable as MessagingPropositionItems
+                // handle schema consequences which are representable as PropositionItems
                 guard let firstPropositionItem = proposition.items.first else {
                     continue
                 }
@@ -51,7 +51,7 @@ struct ParsedPropositions {
                         continue
                     }
                     guard let consequence = parsedRules.first?.consequences.first,
-                          let schemaConsequence = MessagingPropositionItem.fromRuleConsequence(consequence)
+                          let schemaConsequence = PropositionItem.fromRuleConsequence(consequence)
                     else {
                         continue
                     }

--- a/AEPMessaging/Sources/Proposition.swift
+++ b/AEPMessaging/Sources/Proposition.swift
@@ -13,9 +13,9 @@
 import AEPServices
 import Foundation
 
-@objc(AEPMessagingProposition)
+@objc(AEPProposition)
 @objcMembers
-public class MessagingProposition: NSObject, Codable {
+public class Proposition: NSObject, Codable {
     /// Unique proposition identifier
     public let uniqueId: String
 
@@ -26,9 +26,9 @@ public class MessagingProposition: NSObject, Codable {
     var scopeDetails: [String: Any]
 
     /// Array containing proposition decision items
-    private let propositionItems: [MessagingPropositionItem]
+    private let propositionItems: [PropositionItem]
 
-    public lazy var items: [MessagingPropositionItem] = {
+    public lazy var items: [PropositionItem] = {
         for item in propositionItems {
             item.proposition = self
         }
@@ -42,7 +42,7 @@ public class MessagingProposition: NSObject, Codable {
         case items
     }
 
-    init(uniqueId: String, scope: String, scopeDetails: [String: Any], items: [MessagingPropositionItem]) {
+    init(uniqueId: String, scope: String, scopeDetails: [String: Any], items: [PropositionItem]) {
         self.uniqueId = uniqueId
         self.scope = scope
         self.scopeDetails = scopeDetails
@@ -59,7 +59,7 @@ public class MessagingProposition: NSObject, Codable {
         guard !scopeDetails.isEmpty else {
             throw DecodingError.dataCorruptedError(forKey: CodingKeys.scopeDetails, in: container, debugDescription: "Scope details is corrupted and cannot be decoded.")
         }
-        let tempItems = (try? container.decode([MessagingPropositionItem].self, forKey: .items))
+        let tempItems = (try? container.decode([PropositionItem].self, forKey: .items))
         propositionItems = tempItems ?? []
     }
 

--- a/AEPMessaging/Sources/PropositionInfo.swift
+++ b/AEPMessaging/Sources/PropositionInfo.swift
@@ -31,7 +31,7 @@ extension PropositionInfo {
         return activity[MessagingConstants.Event.Data.Key.Personalization.ID] as? String ?? ""
     }
 
-    static func fromProposition(_ proposition: MessagingProposition) -> PropositionInfo {
+    static func fromProposition(_ proposition: Proposition) -> PropositionInfo {
         PropositionInfo(id: proposition.uniqueId,
                         scope: proposition.scope,
                         scopeDetails: AnyCodable.from(dictionary: proposition.scopeDetails) ?? [:])

--- a/AEPMessaging/Sources/PropositionInteraction.swift
+++ b/AEPMessaging/Sources/PropositionInteraction.swift
@@ -13,7 +13,7 @@
 import AEPServices
 import Foundation
 
-struct MessagingPropositionInteraction: Codable {
+struct PropositionInteraction: Codable {
     var eventType: MessagingEdgeEventType
     var interaction: String?
     var propositionInfo: PropositionInfo

--- a/AEPMessaging/Sources/PropositionItem.swift
+++ b/AEPMessaging/Sources/PropositionItem.swift
@@ -14,30 +14,30 @@ import AEPCore
 import AEPServices
 import Foundation
 
-/// A `MessagingPropositionItem` object represents a personalization JSON object returned by Konductor
+/// A `PropositionItem` object represents a personalization JSON object returned by Konductor
 /// In its JSON form, it has the following properties:
 /// - `id`
 /// - `schema`
 /// - `data`
 /// This contents of `data` will be determined by the provided `schema`.
 /// This class provides helper access to get strongly typed content - e.g. `getTypedData`
-@objc(AEPMessagingPropositionItem)
+@objc(AEPPropositionItem)
 @objcMembers
-public class MessagingPropositionItem: NSObject, Codable {
-    /// Unique identifier for this `MessagingPropositionItem`
+public class PropositionItem: NSObject, Codable {
+    /// Unique identifier for this `PropositionItem`
     /// contains value for `id` in JSON
     public let itemId: String
 
-    /// `MessagingPropositionItem` schema string
+    /// `PropositionItem` schema string
     /// contains value for `schema` in JSON
     public let schema: SchemaType
 
-    /// `MessagingPropositionItem` data as dictionary
+    /// `PropositionItem` data as dictionary
     /// contains value for `data` in JSON
     public let itemData: [String: Any]
 
     /// Weak reference to Proposition instance
-    weak var proposition: MessagingProposition?
+    weak var proposition: Proposition?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -69,7 +69,7 @@ public class MessagingPropositionItem: NSObject, Codable {
     }
 }
 
-public extension MessagingPropositionItem {
+public extension PropositionItem {
     /// Tracks interaction with the given proposition item.
     ///
     /// - Parameter eventType: an enum specifying event type for the interaction.
@@ -106,22 +106,22 @@ public extension MessagingPropositionItem {
             return nil
         }
 
-        return MessagingPropositionInteraction(eventType: eventType, interaction: nil, propositionInfo: PropositionInfo.fromProposition(proposition), itemId: itemId).xdm
+        return PropositionInteraction(eventType: eventType, interaction: nil, propositionInfo: PropositionInfo.fromProposition(proposition), itemId: itemId).xdm
     }
 
-    static func fromRuleConsequence(_ consequence: RuleConsequence) -> MessagingPropositionItem? {
+    static func fromRuleConsequence(_ consequence: RuleConsequence) -> PropositionItem? {
         guard let detailsData = try? JSONSerialization.data(withJSONObject: consequence.details, options: .prettyPrinted) else {
             return nil
         }
-        return try? JSONDecoder().decode(MessagingPropositionItem.self, from: detailsData)
+        return try? JSONDecoder().decode(PropositionItem.self, from: detailsData)
     }
 
-    static func fromRuleConsequenceEvent(_ event: Event) -> MessagingPropositionItem? {
+    static func fromRuleConsequenceEvent(_ event: Event) -> PropositionItem? {
         guard let id = event.schemaId, let schema = event.schemaType, let schemaData = event.schemaData else {
             return nil
         }
 
-        return MessagingPropositionItem(itemId: id, schema: schema, itemData: schemaData)
+        return PropositionItem(itemId: id, schema: schema, itemData: schemaData)
     }
 
     var jsonContentDictionary: [String: Any]? {

--- a/AEPMessaging/Sources/PropositionPayload.swift
+++ b/AEPMessaging/Sources/PropositionPayload.swift
@@ -54,8 +54,8 @@ struct PropositionPayload: Codable {
             propItems.append(PropositionItem(itemId: item.itemId, schema: item.schema, itemData: item.itemData))
         }
         return Proposition(uniqueId: propositionInfo.id,
-                                    scope: propositionInfo.scope,
-                                    scopeDetails: AnyCodable.toAnyDictionary(dictionary: propositionInfo.scopeDetails) ?? [:],
-                                    items: propItems)
+                           scope: propositionInfo.scope,
+                           scopeDetails: AnyCodable.toAnyDictionary(dictionary: propositionInfo.scopeDetails) ?? [:],
+                           items: propItems)
     }
 }

--- a/AEPMessaging/Sources/PropositionPayload.swift
+++ b/AEPMessaging/Sources/PropositionPayload.swift
@@ -15,7 +15,7 @@ import Foundation
 
 struct PropositionPayload: Codable {
     var propositionInfo: PropositionInfo
-    var items: [MessagingPropositionItem]
+    var items: [PropositionItem]
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -31,7 +31,7 @@ struct PropositionPayload: Codable {
         let scopeDetails = try values.decode([String: AnyCodable].self, forKey: .scopeDetails)
 
         propositionInfo = PropositionInfo(id: id, scope: scope, scopeDetails: scopeDetails)
-        items = try values.decode([MessagingPropositionItem].self, forKey: .items)
+        items = try values.decode([PropositionItem].self, forKey: .items)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -43,17 +43,17 @@ struct PropositionPayload: Codable {
     }
 
     /// internal use only for testing
-    init(propositionInfo: PropositionInfo, items: [MessagingPropositionItem]) {
+    init(propositionInfo: PropositionInfo, items: [PropositionItem]) {
         self.propositionInfo = propositionInfo
         self.items = items
     }
 
-    func convertToProposition() -> MessagingProposition {
-        var propItems: [MessagingPropositionItem] = []
+    func convertToProposition() -> Proposition {
+        var propItems: [PropositionItem] = []
         for item in items {
-            propItems.append(MessagingPropositionItem(itemId: item.itemId, schema: item.schema, itemData: item.itemData))
+            propItems.append(PropositionItem(itemId: item.itemId, schema: item.schema, itemData: item.itemData))
         }
-        return MessagingProposition(uniqueId: propositionInfo.id,
+        return Proposition(uniqueId: propositionInfo.id,
                                     scope: propositionInfo.scope,
                                     scopeDetails: AnyCodable.toAnyDictionary(dictionary: propositionInfo.scopeDetails) ?? [:],
                                     items: propItems)

--- a/AEPMessaging/Tests/UnitTests/Cache+MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/Cache+MessagingTests.swift
@@ -21,17 +21,17 @@ class CacheMessagingTests: XCTestCase {
     let mockCache = MockCache(name: "mockCache")
     var mockSurface: Surface!
     
-    var mockProposition: MessagingProposition!
-    var mockPropositionItem: MessagingPropositionItem!
+    var mockProposition: Proposition!
+    var mockPropositionItem: PropositionItem!
         
     override func setUp() {
         let propositionContent = JSONFileLoader.getRulesJsonFromFile("inappPropositionV2Content")
-        mockPropositionItem = MessagingPropositionItem(itemId: "inapp2", schema: .ruleset, itemData: propositionContent)
-        mockProposition = MessagingProposition(uniqueId: "inapp2", scope: "inapp2", scopeDetails: ["key": "value"], items: [mockPropositionItem])
+        mockPropositionItem = PropositionItem(itemId: "inapp2", schema: .ruleset, itemData: propositionContent)
+        mockProposition = Proposition(uniqueId: "inapp2", scope: "inapp2", scopeDetails: ["key": "value"], items: [mockPropositionItem])
         mockSurface = Surface(uri: "inapp2")
     }
         
-    func getPropositionCacheEntry(_ seededPropositions: [String: [MessagingProposition]]? = nil) -> CacheEntry? {
+    func getPropositionCacheEntry(_ seededPropositions: [String: [Proposition]]? = nil) -> CacheEntry? {
         let seededPropositions = seededPropositions ?? [
             mockSurface.uri: [mockProposition]
         ]
@@ -97,9 +97,9 @@ class CacheMessagingTests: XCTestCase {
         // setup
         let newSurface = Surface(uri: "inapp4")
         let newPropositionContent = JSONFileLoader.getRulesJsonFromFile("inappPropositionV2Content")
-        let newPropositionItem = MessagingPropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
-        let newProposition = MessagingProposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
-        let newProps: [Surface: [MessagingProposition]] = [
+        let newPropositionItem = PropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
+        let newProposition = Proposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
+        let newProps: [Surface: [Proposition]] = [
             newSurface: [newProposition]
         ]
         
@@ -114,7 +114,7 @@ class CacheMessagingTests: XCTestCase {
             return
         }
         let decoder = JSONDecoder()
-        guard let decodedSetParam = try? decoder.decode([String: [MessagingProposition]].self, from: setParamCache.data) else {
+        guard let decodedSetParam = try? decoder.decode([String: [Proposition]].self, from: setParamCache.data) else {
             XCTFail("failed to decode cache parameter sent during 'set' call")
             return
         }
@@ -130,9 +130,9 @@ class CacheMessagingTests: XCTestCase {
         mockCache.getReturnValue = getPropositionCacheEntry()
         let newSurface = Surface(uri: "inapp4")
         let newPropositionContent = JSONFileLoader.getRulesJsonFromFile("inappPropositionV2Content")
-        let newPropositionItem = MessagingPropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
-        let newProposition = MessagingProposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
-        let newProps: [Surface: [MessagingProposition]] = [
+        let newPropositionItem = PropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
+        let newProposition = Proposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
+        let newProps: [Surface: [Proposition]] = [
             newSurface: [newProposition]
         ]
         
@@ -147,7 +147,7 @@ class CacheMessagingTests: XCTestCase {
             return
         }
         let decoder = JSONDecoder()
-        guard let decodedSetParam = try? decoder.decode([String: [MessagingProposition]].self, from: setParamCache.data) else {
+        guard let decodedSetParam = try? decoder.decode([String: [Proposition]].self, from: setParamCache.data) else {
             XCTFail("failed to decode cache parameter sent during 'set' call")
             return
         }
@@ -159,9 +159,9 @@ class CacheMessagingTests: XCTestCase {
         mockCache.getReturnValue = getPropositionCacheEntry()
         let newSurface = Surface(uri: "inapp4")
         let newPropositionContent = JSONFileLoader.getRulesJsonFromFile("inappPropositionV2Content")
-        let newPropositionItem = MessagingPropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
-        let newProposition = MessagingProposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
-        let newProps: [Surface: [MessagingProposition]] = [
+        let newPropositionItem = PropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
+        let newProposition = Proposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
+        let newProps: [Surface: [Proposition]] = [
             newSurface: [newProposition]
         ]
         
@@ -176,7 +176,7 @@ class CacheMessagingTests: XCTestCase {
             return
         }
         let decoder = JSONDecoder()
-        guard let decodedSetParam = try? decoder.decode([String: [MessagingProposition]].self, from: setParamCache.data) else {
+        guard let decodedSetParam = try? decoder.decode([String: [Proposition]].self, from: setParamCache.data) else {
             XCTFail("failed to decode cache parameter sent during 'set' call")
             return
         }
@@ -204,9 +204,9 @@ class CacheMessagingTests: XCTestCase {
         mockCache.getReturnValue = getPropositionCacheEntry()
         let newSurface = mockSurface
         let newPropositionContent = JSONFileLoader.getRulesJsonFromFile("inappPropositionV2Content")
-        let newPropositionItem = MessagingPropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
-        let newProposition = MessagingProposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
-        let newProps: [Surface: [MessagingProposition]] = [
+        let newPropositionItem = PropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
+        let newProposition = Proposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
+        let newProps: [Surface: [Proposition]] = [
             newSurface!: [newProposition]
         ]
         
@@ -221,7 +221,7 @@ class CacheMessagingTests: XCTestCase {
             return
         }
         let decoder = JSONDecoder()
-        guard let decodedSetParam = try? decoder.decode([String: [MessagingProposition]].self, from: setParamCache.data) else {
+        guard let decodedSetParam = try? decoder.decode([String: [Proposition]].self, from: setParamCache.data) else {
             XCTFail("failed to decode cache parameter sent during 'set' call")
             return
         }
@@ -236,8 +236,8 @@ class CacheMessagingTests: XCTestCase {
     func testUpdatePropositionsBadFormatEncodeFailure() throws {
         // setup
         let newSurface = Surface(uri: "inapp4")
-        let newProposition = MessagingProposition(uniqueId: "", scope: "", scopeDetails: ["": ""], items: [])
-        let newProps: [Surface: [MessagingProposition]] = [
+        let newProposition = Proposition(uniqueId: "", scope: "", scopeDetails: ["": ""], items: [])
+        let newProps: [Surface: [Proposition]] = [
             newSurface: [newProposition]
         ]
         
@@ -255,9 +255,9 @@ class CacheMessagingTests: XCTestCase {
         mockCache.setShouldThrow = true
         let newSurface = Surface(uri: "inapp4")
         let newPropositionContent = JSONFileLoader.getRulesJsonFromFile("inappPropositionV2Content")
-        let newPropositionItem = MessagingPropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
-        let newProposition = MessagingProposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
-        let newProps: [Surface: [MessagingProposition]] = [
+        let newPropositionItem = PropositionItem(itemId: "inapp4", schema: .ruleset, itemData: newPropositionContent)
+        let newProposition = Proposition(uniqueId: "inapp4", scope: "inapp4", scopeDetails: ["key": "value"], items: [newPropositionItem])
+        let newProps: [Surface: [Proposition]] = [
             newSurface: [newProposition]
         ]
         
@@ -272,7 +272,7 @@ class CacheMessagingTests: XCTestCase {
             return
         }
         let decoder = JSONDecoder()
-        guard let decodedSetParam = try? decoder.decode([String: [MessagingProposition]].self, from: setParamCache.data) else {
+        guard let decodedSetParam = try? decoder.decode([String: [Proposition]].self, from: setParamCache.data) else {
             XCTFail("failed to decode cache parameter sent during 'set' call")
             return
         }

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -25,9 +25,13 @@ class MessagingPublicApiTest: XCTestCase {
     
     override func setUp() {
         notificationContent = [MessagingConstants.XDM.AdobeKeys._XDM: mockXdmData]
-        MockExtension.reset()
         EventHub.shared.start()
         registerMockExtension(MockExtension.self)
+    }
+    
+    override func tearDown() {
+        MockExtension.reset()
+        EventHub.reset()
     }
 
     private func registerMockExtension<T: Extension>(_ type: T.Type) {

--- a/AEPMessaging/Tests/UnitTests/Messaging+StateTests.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+StateTests.swift
@@ -25,8 +25,8 @@ class MessagingPlusStateTests: XCTestCase {
     var mockLaunchRulesEngineForFeeds: MockLaunchRulesEngine!
     var mockCache: MockCache!
     let mockIamSurface = Surface(uri: "mobileapp://com.apple.dt.xctest.tool")
-    var mockProposition: MessagingProposition!
-    var mockPropositionItem: MessagingPropositionItem!
+    var mockProposition: Proposition!
+    var mockPropositionItem: PropositionItem!
     var mockPropositionInfo: PropositionInfo!
 
     // Mock constants
@@ -45,8 +45,8 @@ class MessagingPlusStateTests: XCTestCase {
         mockFeedRulesEngine = MockFeedRulesEngine(extensionRuntime: mockRuntime, launchRulesEngine: mockLaunchRulesEngineForFeeds)
         messaging = Messaging(runtime: mockRuntime, rulesEngine: mockMessagingRulesEngine, feedRulesEngine: mockFeedRulesEngine, expectedSurfaceUri: mockIamSurface.uri, cache: mockCache)
         
-        mockPropositionItem = MessagingPropositionItem(itemId: "propItemId", schema: .defaultContent, itemData: [:])
-        mockProposition = MessagingProposition(uniqueId: "propId", scope: mockIamSurface.uri, scopeDetails: [:], items: [mockPropositionItem])
+        mockPropositionItem = PropositionItem(itemId: "propItemId", schema: .defaultContent, itemData: [:])
+        mockProposition = Proposition(uniqueId: "propId", scope: mockIamSurface.uri, scopeDetails: [:], items: [mockPropositionItem])
         mockPropositionInfo = PropositionInfo(id: "propInfoId", scope: mockIamSurface.uri, scopeDetails: [:])
     }
 
@@ -118,7 +118,7 @@ class MessagingPlusStateTests: XCTestCase {
     func testUpdatePropositions() throws {
         // setup
         messaging.propositions = [ mockIamSurface: [mockProposition] ]
-        let newProp = MessagingProposition(uniqueId: "newId", scope: "newScope", scopeDetails: [:], items: [])
+        let newProp = Proposition(uniqueId: "newId", scope: "newScope", scopeDetails: [:], items: [])
         let newPropositions = [Surface(uri: "newScope"): [newProp]]
         
         // test
@@ -131,7 +131,7 @@ class MessagingPlusStateTests: XCTestCase {
     func testUpdatePropositionsRemovingSurfaces() throws {
         // setup
         messaging.propositions = [ mockIamSurface: [mockProposition] ]
-        let newProp = MessagingProposition(uniqueId: "newId", scope: "newScope", scopeDetails: [:], items: [])
+        let newProp = Proposition(uniqueId: "newId", scope: "newScope", scopeDetails: [:], items: [])
         let newPropositions = [Surface(uri: "newScope"): [newProp]]
         
         // test

--- a/AEPMessaging/Tests/UnitTests/ParsedPropositionsTests.swift
+++ b/AEPMessaging/Tests/UnitTests/ParsedPropositionsTests.swift
@@ -24,19 +24,19 @@ class ParsedPropositionTests: XCTestCase {
     let jsonSchema: SchemaType = .jsonContent
     let htmlSchema: SchemaType = .htmlContent
     
-    var mockInAppPropositionItemv2: MessagingPropositionItem!
-    var mockInAppPropositionv2: MessagingProposition!
+    var mockInAppPropositionItemv2: PropositionItem!
+    var mockInAppPropositionv2: Proposition!
     var mockInAppSurfacev2: Surface!
     let mockInAppMessageIdv2 = "6ac78390-84e3-4d35-b798-8e7080e69a67"
     
-    var mockFeedPropositionItem: MessagingPropositionItem!
-    var mockFeedProposition: MessagingProposition!
+    var mockFeedPropositionItem: PropositionItem!
+    var mockFeedProposition: Proposition!
     var mockFeedSurface: Surface!
     let mockFeedMessageId = "183639c4-cb37-458e-a8ef-4e130d767ebf"
     var mockFeedContent: [String: Any]!
     
-    var mockCodeBasedPropositionItem: MessagingPropositionItem!
-    var mockCodeBasedProposition: MessagingProposition!
+    var mockCodeBasedPropositionItem: PropositionItem!
+    var mockCodeBasedProposition: Proposition!
     var mockCodeBasedSurface: Surface!
     var mockCodeBasedContent: [String: Any]!
         
@@ -45,24 +45,24 @@ class ParsedPropositionTests: XCTestCase {
         mockRuntime = TestableExtensionRuntime()
         
         let inappPropositionV2Content = JSONFileLoader.getRulesJsonFromFile("inappPropositionV2Content")
-        mockInAppPropositionItemv2 = MessagingPropositionItem(itemId: "inapp2", schema: rulesetSchema, itemData: inappPropositionV2Content)
-        mockInAppPropositionv2 = MessagingProposition(uniqueId: "inapp2", scope: "inapp2", scopeDetails: ["key": "value"], items: [mockInAppPropositionItemv2])
+        mockInAppPropositionItemv2 = PropositionItem(itemId: "inapp2", schema: rulesetSchema, itemData: inappPropositionV2Content)
+        mockInAppPropositionv2 = Proposition(uniqueId: "inapp2", scope: "inapp2", scopeDetails: ["key": "value"], items: [mockInAppPropositionItemv2])
         mockInAppSurfacev2 = Surface(uri: "inapp2")
         
         mockFeedContent = JSONFileLoader.getRulesJsonFromFile("feedPropositionContent")
-        mockFeedPropositionItem = MessagingPropositionItem(itemId: "feed", schema: rulesetSchema, itemData: mockFeedContent)
-        mockFeedProposition = MessagingProposition(uniqueId: "feed", scope: "feed", scopeDetails: ["key":"value"], items: [mockFeedPropositionItem])
+        mockFeedPropositionItem = PropositionItem(itemId: "feed", schema: rulesetSchema, itemData: mockFeedContent)
+        mockFeedProposition = Proposition(uniqueId: "feed", scope: "feed", scopeDetails: ["key":"value"], items: [mockFeedPropositionItem])
         mockFeedSurface = Surface(uri: "feed")
         
         mockCodeBasedContent = JSONFileLoader.getRulesJsonFromFile("codeBasedPropositionHtmlContent")
-        mockCodeBasedPropositionItem = MessagingPropositionItem(itemId: "codebased", schema: htmlSchema, itemData: mockCodeBasedContent)
-        mockCodeBasedProposition = MessagingProposition(uniqueId: "codebased", scope: "codebased", scopeDetails: ["key":"value"], items: [mockCodeBasedPropositionItem])
+        mockCodeBasedPropositionItem = PropositionItem(itemId: "codebased", schema: htmlSchema, itemData: mockCodeBasedContent)
+        mockCodeBasedProposition = Proposition(uniqueId: "codebased", scope: "codebased", scopeDetails: ["key":"value"], items: [mockCodeBasedPropositionItem])
         mockCodeBasedSurface = Surface(uri: "codebased")
     }
     
     func testInitWithEmptyPropositions() throws {
         // setup
-        let propositions: [Surface: [MessagingProposition]] = [mockSurface: []]
+        let propositions: [Surface: [Proposition]] = [mockSurface: []]
         
         // test
         let result = ParsedPropositions(with: propositions, requestedSurfaces: [mockSurface], runtime: mockRuntime)
@@ -77,7 +77,7 @@ class ParsedPropositionTests: XCTestCase {
     
     func testInitWithPropositionScopeNotMatchingRequestedSurfaces() throws {
         // setup
-        let propositions: [Surface: [MessagingProposition]] = [
+        let propositions: [Surface: [Proposition]] = [
             mockFeedSurface: [mockFeedProposition],
             mockCodeBasedSurface: [mockCodeBasedProposition]
         ]
@@ -95,7 +95,7 @@ class ParsedPropositionTests: XCTestCase {
     
     func testInitWithInAppPropositionV2() throws {
         // setup
-        let propositions: [Surface: [MessagingProposition]] = [
+        let propositions: [Surface: [Proposition]] = [
             mockInAppSurfacev2: [mockInAppPropositionv2]
         ]
         
@@ -117,7 +117,7 @@ class ParsedPropositionTests: XCTestCase {
         XCTAssertEqual(1, iamRules?.count)
         let firstConsequence = iamRules?.first?.value.first?.consequences.first
         XCTAssertNotNil(firstConsequence)
-        let consequenceAsPropositionItem = MessagingPropositionItem.fromRuleConsequence(firstConsequence!)
+        let consequenceAsPropositionItem = PropositionItem.fromRuleConsequence(firstConsequence!)
         let inappSchemaData = consequenceAsPropositionItem?.inappSchemaData
         XCTAssertEqual("text/html", inappSchemaData?.contentType.toString())
         XCTAssertEqual("<html><body>Is this thing even on?</body></html>", inappSchemaData?.content as? String)
@@ -134,7 +134,7 @@ class ParsedPropositionTests: XCTestCase {
     
     func testInitWithFeedProposition() throws {
         // setup
-        let propositions: [Surface: [MessagingProposition]] = [
+        let propositions: [Surface: [Proposition]] = [
             mockFeedSurface: [mockFeedProposition]
         ]
         
@@ -157,7 +157,7 @@ class ParsedPropositionTests: XCTestCase {
     
     func testInitWithCodeBasedProposition() throws {
         // setup
-        let propositions: [Surface: [MessagingProposition]] = [
+        let propositions: [Surface: [Proposition]] = [
             mockCodeBasedSurface: [mockCodeBasedProposition]
         ]
         
@@ -180,9 +180,9 @@ class ParsedPropositionTests: XCTestCase {
     
     func testInitPropositionItemEmptyContentString() throws {
         // setup
-        mockInAppPropositionItemv2 = MessagingPropositionItem(itemId: "inapp", schema: .inapp, itemData: [:])
-        mockInAppPropositionv2 = MessagingProposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [mockInAppPropositionItemv2])
-        let propositions: [Surface: [MessagingProposition]] = [
+        mockInAppPropositionItemv2 = PropositionItem(itemId: "inapp", schema: .inapp, itemData: [:])
+        mockInAppPropositionv2 = Proposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [mockInAppPropositionItemv2])
+        let propositions: [Surface: [Proposition]] = [
             mockInAppSurfacev2: [mockInAppPropositionv2]
         ]
         
@@ -200,9 +200,9 @@ class ParsedPropositionTests: XCTestCase {
     func testInitPropositionRuleHasNoConsequence() throws {
         // setup
         let noConsequenceRule = JSONFileLoader.getRulesJsonFromFile("ruleWithNoConsequence")
-        let pi = MessagingPropositionItem(itemId: "inapp", schema: .ruleset, itemData: noConsequenceRule)
-        let prop = MessagingProposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [pi])
-        let propositions: [Surface: [MessagingProposition]] = [
+        let pi = PropositionItem(itemId: "inapp", schema: .ruleset, itemData: noConsequenceRule)
+        let prop = Proposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [pi])
+        let propositions: [Surface: [Proposition]] = [
             mockInAppSurfacev2: [prop]
         ]
         
@@ -220,9 +220,9 @@ class ParsedPropositionTests: XCTestCase {
     func testInitPropositionRulesetConsequenceHasUnknownSchema() throws {
         // setup
         let content = JSONFileLoader.getRulesJsonFromFile("ruleWithUnknownConsequenceSchema")
-        let pi = MessagingPropositionItem(itemId: "inapp", schema: .ruleset, itemData: content)
-        let prop = MessagingProposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [pi])
-        let propositions: [Surface: [MessagingProposition]] = [
+        let pi = PropositionItem(itemId: "inapp", schema: .ruleset, itemData: content)
+        let prop = Proposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [pi])
+        let propositions: [Surface: [Proposition]] = [
             mockInAppSurfacev2: [prop]
         ]
         
@@ -239,9 +239,9 @@ class ParsedPropositionTests: XCTestCase {
     
     func testInitPropositionUnknownSchema() throws {
         // setup
-        let pi = MessagingPropositionItem(itemId: "inapp", schema: .unknown, itemData: [:])
-        let prop = MessagingProposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [pi])
-        let propositions: [Surface: [MessagingProposition]] = [
+        let pi = PropositionItem(itemId: "inapp", schema: .unknown, itemData: [:])
+        let prop = Proposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [pi])
+        let propositions: [Surface: [Proposition]] = [
             mockInAppSurfacev2: [prop]
         ]
         
@@ -258,8 +258,8 @@ class ParsedPropositionTests: XCTestCase {
     
     func testInitPropositionConsequenceNoPropositionItem() throws {
         // setup
-        let prop = MessagingProposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [])
-        let propositions: [Surface: [MessagingProposition]] = [
+        let prop = Proposition(uniqueId: "inapp", scope: "inapp", scopeDetails: ["key": "value"], items: [])
+        let propositions: [Surface: [Proposition]] = [
             mockInAppSurfacev2: [prop]
         ]
         

--- a/AEPMessaging/Tests/UnitTests/PropositionInfoTests.swift
+++ b/AEPMessaging/Tests/UnitTests/PropositionInfoTests.swift
@@ -182,8 +182,8 @@ class PropositionInfoTests: XCTestCase, AnyCodableAsserts {
     
     func testFromProposition() throws {
         // setup
-        let propItem = MessagingPropositionItem(itemId: "itemId", schema: .defaultContent, itemData: [:])
-        let proposition = MessagingProposition(uniqueId: mockId, scope: mockScope, scopeDetails: mockScopeDetails, items: [propItem])
+        let propItem = PropositionItem(itemId: "itemId", schema: .defaultContent, itemData: [:])
+        let proposition = Proposition(uniqueId: mockId, scope: mockScope, scopeDetails: mockScopeDetails, items: [propItem])
         
         // test
         let propositionInfo = PropositionInfo.fromProposition(proposition)

--- a/AEPMessaging/Tests/UnitTests/PropositionInteractionTests.swift
+++ b/AEPMessaging/Tests/UnitTests/PropositionInteractionTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import AEPServices
 import AEPTestUtils
 
-class MessagingPropositionInteractionTests: XCTestCase, AnyCodableAsserts {
+class PropositionInteractionTests: XCTestCase, AnyCodableAsserts {
 
     let mockDisplayEventType: MessagingEdgeEventType = .display
     let mockInteractEventType: MessagingEdgeEventType = .interact
@@ -28,18 +28,18 @@ class MessagingPropositionInteractionTests: XCTestCase, AnyCodableAsserts {
         mockPropositionInfo = PropositionInfo(id: "mockPropositionId", scope: "mockScope", scopeDetails: AnyCodable.from(dictionary: ["key": "value"]) ?? [:])
     }
     
-    func getDecodedObject(fromString: String) -> MessagingPropositionInteraction? {
+    func getDecodedObject(fromString: String) -> PropositionInteraction? {
         let decoder = JSONDecoder()
         let objectData = fromString.data(using: .utf8)!
-        guard let propositionInteraction = try? decoder.decode(MessagingPropositionInteraction.self, from: objectData) else {
+        guard let propositionInteraction = try? decoder.decode(PropositionInteraction.self, from: objectData) else {
             return nil
         }
         return propositionInteraction
     }
     
-    func testMessagingPropositionInteractionInit() {
+    func testPropositionInteractionInit() {
         // test
-        let propositionInteraction = MessagingPropositionInteraction(eventType: mockDisplayEventType, interaction: "", propositionInfo: mockPropositionInfo, itemId: mockItemId)
+        let propositionInteraction = PropositionInteraction(eventType: mockDisplayEventType, interaction: "", propositionInfo: mockPropositionInfo, itemId: mockItemId)
         
         // verify
         XCTAssertNotNil(propositionInteraction)
@@ -51,7 +51,7 @@ class MessagingPropositionInteractionTests: XCTestCase, AnyCodableAsserts {
         XCTAssertEqual(mockItemId, propositionInteraction.itemId)
     }
     
-    func testMessagingPropositionInteractionIsDecodable() {
+    func testPropositionInteractionIsDecodable() {
         // setup
         let propositionInteractionJsonString = #"""
         {
@@ -84,7 +84,7 @@ class MessagingPropositionInteractionTests: XCTestCase, AnyCodableAsserts {
         XCTAssertEqual(mockItemId, propositionInteraction.itemId)
     }
     
-    func testMessagingPropositionInteractionIsEncodable() {
+    func testPropositionInteractionIsEncodable() {
         // setup
         let propositionInteractionJsonString = #"""
         {
@@ -120,7 +120,7 @@ class MessagingPropositionInteractionTests: XCTestCase, AnyCodableAsserts {
         assertExactMatch(expected: expected, actual: actual)
     }
     
-    func testMessagingPropositionInteractionDecodeInvalidEventType() {
+    func testPropositionInteractionDecodeInvalidEventType() {
         // setup
         let propositionInteractionJsonString = #"""
         {
@@ -144,10 +144,10 @@ class MessagingPropositionInteractionTests: XCTestCase, AnyCodableAsserts {
         XCTAssertNil(propositionInteraction)
     }
 
-    func testMessagingPropositionInteractionXdmForInteract() throws {
+    func testPropositionInteractionXdmForInteract() throws {
         // setup
         let mockInteraction = "mockInteraction"
-        let propositionInteraction = MessagingPropositionInteraction(eventType: mockInteractEventType, interaction: mockInteraction, propositionInfo: mockPropositionInfo, itemId: mockItemId)
+        let propositionInteraction = PropositionInteraction(eventType: mockInteractEventType, interaction: mockInteraction, propositionInfo: mockPropositionInfo, itemId: mockItemId)
         
         // test
         let xdm = propositionInteraction.xdm
@@ -176,10 +176,10 @@ class MessagingPropositionInteractionTests: XCTestCase, AnyCodableAsserts {
         XCTAssertEqual(mockInteraction, propositionAction["label"] as? String)
     }
     
-    func testMessagingPropositionInteractionXdmForDisplay() throws {
+    func testPropositionInteractionXdmForDisplay() throws {
         // setup
         let mockInteraction = ""
-        let propositionInteraction = MessagingPropositionInteraction(eventType: mockDisplayEventType, interaction: mockInteraction, propositionInfo: mockPropositionInfo, itemId: mockItemId)
+        let propositionInteraction = PropositionInteraction(eventType: mockDisplayEventType, interaction: mockInteraction, propositionInfo: mockPropositionInfo, itemId: mockItemId)
         
         // test
         let xdm = propositionInteraction.xdm

--- a/AEPMessaging/Tests/UnitTests/PropositionItemTests.swift
+++ b/AEPMessaging/Tests/UnitTests/PropositionItemTests.swift
@@ -18,7 +18,7 @@ import XCTest
 import AEPServices
 import AEPTestUtils
 
-class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
+class PropositionItemTests: XCTestCase, AnyCodableAsserts {
     let ASYNC_TIMEOUT = 5.0
     let mockPropositionId = "mockPropositionId"
     let mockScope = "mockScope"
@@ -41,10 +41,10 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
         EventHub.reset()
     }
 
-    func getDecodedObject(fromString: String) -> MessagingPropositionItem? {
+    func getDecodedObject(fromString: String) -> PropositionItem? {
         let decoder = JSONDecoder()
         let objectData = fromString.data(using: .utf8)!
-        guard let propositionItem = try? decoder.decode(MessagingPropositionItem.self, from: objectData) else {
+        guard let propositionItem = try? decoder.decode(PropositionItem.self, from: objectData) else {
             return nil
         }
         return propositionItem
@@ -64,7 +64,7 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
         let mockCodeBasedContent = JSONFileLoader.getRulesJsonFromFile("codeBasedPropositionHtmlContent")
         
         // test
-        let propositionItem = MessagingPropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
+        let propositionItem = PropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
 
         // verify
         XCTAssertEqual(mockItemId, propositionItem.itemId)
@@ -77,7 +77,7 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
         let mockCodeBasedContent = JSONFileLoader.getRulesJsonFromFile("codeBasedPropositionJsonContent")
         
         // test
-        let propositionItem = MessagingPropositionItem(itemId: mockItemId, schema: .jsonContent, itemData: mockCodeBasedContent)
+        let propositionItem = PropositionItem(itemId: mockItemId, schema: .jsonContent, itemData: mockCodeBasedContent)
 
         // verify
         XCTAssertEqual(mockItemId, propositionItem.itemId)
@@ -182,7 +182,7 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
         }
         
         // test
-        let propositionItem = MessagingPropositionItem.fromRuleConsequence(feedConsequence)
+        let propositionItem = PropositionItem.fromRuleConsequence(feedConsequence)
         
         let expectedData = #"""
         {
@@ -246,7 +246,7 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
                               data: testEventData)
         
         // test
-        let propositionItem = MessagingPropositionItem.fromRuleConsequenceEvent(testEvent)
+        let propositionItem = PropositionItem.fromRuleConsequenceEvent(testEvent)
         
         let expectedData = #"""
         {
@@ -285,7 +285,7 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
         }
         
         // test
-        let propositionItem = MessagingPropositionItem.fromRuleConsequence(inappConsequence)
+        let propositionItem = PropositionItem.fromRuleConsequence(inappConsequence)
         let inappSchemaData = propositionItem?.inappSchemaData
         
         let expectedMobileParameters = #"""
@@ -327,7 +327,7 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
             return
         }
         
-        let propositionItem = MessagingPropositionItem.fromRuleConsequence(feedConsequence)
+        let propositionItem = PropositionItem.fromRuleConsequence(feedConsequence)
         
         // test
         let feedItemSchemaData = propositionItem?.feedItemSchemaData
@@ -362,8 +362,8 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
    func testPropositionItemGenerateInteractionXdm() throws {
        // setup
        let mockCodeBasedContent = JSONFileLoader.getRulesJsonFromFile("codeBasedPropositionHtmlContent")
-       let propositionItem = MessagingPropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
-       let proposition = MessagingProposition(uniqueId: mockPropositionId, scope: mockScope, scopeDetails: mockScopeDetails, items: [propositionItem])
+       let propositionItem = PropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
+       let proposition = Proposition(uniqueId: mockPropositionId, scope: mockScope, scopeDetails: mockScopeDetails, items: [propositionItem])
 
        // test
        guard let xdm = proposition.items[0].generateInteractionXdm(forEventType: MessagingEdgeEventType.interact) else {
@@ -392,7 +392,7 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
     func testPropositionItemGenerateInteractionXdmNoPropositionRef() throws {
         // setup
         let mockCodeBasedContent = JSONFileLoader.getRulesJsonFromFile("codeBasedPropositionHtmlContent")
-        let propositionItem = MessagingPropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
+        let propositionItem = PropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
 
         // test
         let xdm = propositionItem.generateInteractionXdm(forEventType: MessagingEdgeEventType.interact)
@@ -450,8 +450,8 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
         }
         
         let mockCodeBasedContent = JSONFileLoader.getRulesJsonFromFile("codeBasedPropositionHtmlContent")
-        let propositionItem = MessagingPropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
-        let proposition = MessagingProposition(uniqueId: mockPropositionId, scope: mockScope, scopeDetails: mockScopeDetails, items: [propositionItem])
+        let propositionItem = PropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
+        let proposition = Proposition(uniqueId: mockPropositionId, scope: mockScope, scopeDetails: mockScopeDetails, items: [propositionItem])
 
         // test
         proposition.items[0].track(eventType: MessagingEdgeEventType.display)
@@ -503,7 +503,7 @@ class MessagingPropositionItemTests: XCTestCase, AnyCodableAsserts {
         }
         
         let mockCodeBasedContent = JSONFileLoader.getRulesJsonFromFile("codeBasedPropositionHtmlContent")
-        let propositionItem = MessagingPropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
+        let propositionItem = PropositionItem(itemId: mockItemId, schema: .htmlContent, itemData: mockCodeBasedContent)
 
         // test
         propositionItem.track(eventType: MessagingEdgeEventType.display)

--- a/AEPMessaging/Tests/UnitTests/PropositionPayloadTests.swift
+++ b/AEPMessaging/Tests/UnitTests/PropositionPayloadTests.swift
@@ -29,14 +29,14 @@ class PropositionPayloadTests: XCTestCase, AnyCodableAsserts {
     
     let mockItemId = "mockItemId"
     let mockItemSchema: SchemaType = .htmlContent
-    var mockPropositionItem: MessagingPropositionItem!
-    var mockItems: [MessagingPropositionItem]!
+    var mockPropositionItem: PropositionItem!
+    var mockItems: [PropositionItem]!
     
     override func setUp() {
         mockScopeDetails = [
             "correlationID": AnyCodable(mockCorrelationId)
         ]
-        mockPropositionItem = MessagingPropositionItem(itemId: mockItemId, schema: mockItemSchema, itemData: ["content": mockDataContent])
+        mockPropositionItem = PropositionItem(itemId: mockItemId, schema: mockItemSchema, itemData: ["content": mockDataContent])
         
         mockItems = [mockPropositionItem]
     }

--- a/AEPMessaging/Tests/UnitTests/PropositionTests.swift
+++ b/AEPMessaging/Tests/UnitTests/PropositionTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import AEPServices
 import AEPTestUtils
 
-class MessagingPropositionTests: XCTestCase, AnyCodableAsserts {
+class PropositionTests: XCTestCase, AnyCodableAsserts {
     
     let mockScope = "mockScope"
     let mockPropositionId = "mockPropositionId"
@@ -26,10 +26,10 @@ class MessagingPropositionTests: XCTestCase, AnyCodableAsserts {
     let mockJsonSchema: SchemaType = .jsonContent
     let mockScopeDetails: [String: Any] = ["key":"value"]
     
-    func getDecodedObject(fromString: String) -> MessagingProposition? {
+    func getDecodedObject(fromString: String) -> Proposition? {
         let decoder = JSONDecoder()
         let objectData = fromString.data(using: .utf8)!
-        guard let proposition = try? decoder.decode(MessagingProposition.self, from: objectData) else {
+        guard let proposition = try? decoder.decode(Proposition.self, from: objectData) else {
             return nil
         }
         return proposition
@@ -40,8 +40,8 @@ class MessagingPropositionTests: XCTestCase, AnyCodableAsserts {
         let mockCodeBasedContent = JSONFileLoader.getRulesJsonFromFile("codeBasedPropositionJsonContent")
         
         // test
-        let propositionItem = MessagingPropositionItem(itemId: mockItemId, schema: .jsonContent, itemData: mockCodeBasedContent)
-        let proposition = MessagingProposition(uniqueId: mockPropositionId, scope: mockScope, scopeDetails: mockScopeDetails, items: [propositionItem])
+        let propositionItem = PropositionItem(itemId: mockItemId, schema: .jsonContent, itemData: mockCodeBasedContent)
+        let proposition = Proposition(uniqueId: mockPropositionId, scope: mockScope, scopeDetails: mockScopeDetails, items: [propositionItem])
         
         // verify
         XCTAssertEqual(mockPropositionId, proposition.uniqueId)

--- a/TestApps/MessagingDemoAppSwiftUI/CodeBasedOffersView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/CodeBasedOffersView.swift
@@ -14,7 +14,7 @@ import AEPMessaging
 import SwiftUI
 
 struct CodeBasedOffersView: View {
-    @State var propositionsDict: [Surface: [MessagingProposition]]? = nil
+    @State var propositionsDict: [Surface: [Proposition]]? = nil
     @State private var viewDidLoad = false
     
     // prod surfaces
@@ -30,8 +30,8 @@ struct CodeBasedOffersView: View {
                 .font(Font.title)
                 .padding(.top, 30)
             List {
-                if let codePropositions: [MessagingProposition] = propositionsDict?[testSurface], !codePropositions.isEmpty {
-                    ForEach(codePropositions.first?.items as? [MessagingPropositionItem] ?? [], id:\.itemId) { item in
+                if let codePropositions: [Proposition] = propositionsDict?[testSurface], !codePropositions.isEmpty {
+                    ForEach(codePropositions.first?.items as? [PropositionItem] ?? [], id:\.itemId) { item in
                         if item.schema == .htmlContent {
                             CustomHtmlView(htmlString: item.htmlContent ?? "",
                                            trackAction: item.track(eventType:))

--- a/TestApps/MessagingDemoAppSwiftUI/FeedsView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/FeedsView.swift
@@ -14,7 +14,7 @@ import AEPMessaging
 import SwiftUI
 
 struct FeedsView: View {
-    @State var propositionsDict: [Surface: [MessagingProposition]]? = nil
+    @State var propositionsDict: [Surface: [Proposition]]? = nil
     @State private var propositionsHaveBeenFetched = false
     @State private var feedName: String = "API feed"
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When registering both Messaging and Optimize extensions in the mobile app, we need to have distinct class names to prevent symbol name conflicts in objC. We plan to keep normal (shorter) class names in Messaging extension and update conflicting class names in Optimize extension with prefix "Optimize".

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
