### PR TITLE
Replace inMemoryPropositions instead of appending for every updatePropositionsForSurface call

### DIFF
--- a/AEPMessaging/Sources/Messaging+State.swift
+++ b/AEPMessaging/Sources/Messaging+State.swift
@@ -39,7 +39,7 @@ extension Messaging {
     func updatePropositions(_ newPropositions: [Surface: [Proposition]], removing surfaces: [Surface]? = nil) {
         // add new surfaces or update replace existing surfaces
         for (surface, propositionsArray) in newPropositions {
-            inMemoryPropositions.addArray(propositionsArray, forKey: surface)
+            inMemoryPropositions[surface] = propositionsArray
         }
 
         // remove any surfaces if necessary

--- a/TestApps/MessagingDemoAppObjC/ViewController.m
+++ b/TestApps/MessagingDemoAppObjC/ViewController.m
@@ -47,7 +47,7 @@
     [aepMessage handleJavascriptMessage:@"buttonClicked" withHandler:^(NSString* content) {
         NSLog(@"handling content from JS! content is: %@", content ?: @"empty");
         if (aepMessage) {
-            [aepMessage trackInteraction:content withEdgeEventType:AEPMessagingEdgeEventTypeInappInteract];
+            [aepMessage trackInteraction:content withEdgeEventType:AEPMessagingEdgeEventTypeInteract];
         }
     }];
     
@@ -66,7 +66,7 @@
     // if we're not showing the message now, we can save it for later
     if (!_showMessages) {
         _currentMessage = aepMessage;
-        [_currentMessage trackInteraction:@"message suppressed" withEdgeEventType:AEPMessagingEdgeEventTypeInappInteract];
+        [_currentMessage trackInteraction:@"message suppressed" withEdgeEventType:AEPMessagingEdgeEventTypeInteract];
     }
     
     return _showMessages;

--- a/TestApps/MessagingDemoAppSwiftUI/CodeBasedOffersView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/CodeBasedOffersView.swift
@@ -19,7 +19,7 @@ class Propositions: ObservableObject {
 
 struct CodeBasedOffersView: View {
     @StateObject var propositions = Propositions()
-    @State private var viewDidLoad = false
+    @State private var isLoading = false
     
     let surfaces: [Surface] = [
         // prod surfaces
@@ -38,7 +38,7 @@ struct CodeBasedOffersView: View {
             Text("Code Based Experiences")
                 .font(Font.title)
                 .padding(.top, 30)
-            if viewDidLoad {
+            if isLoading {
                 // Display a loading indicator or some placeholder content
                 Text("Loading...")
             } else {
@@ -69,7 +69,7 @@ struct CodeBasedOffersView: View {
             }
         }
         .onAppear {
-            viewDidLoad = true
+            isLoading = true
             Messaging.updatePropositionsForSurfaces(surfaces)
             Messaging.getPropositionsForSurfaces(surfaces) { propositionsDict, error in
                 if let error = error {
@@ -77,7 +77,7 @@ struct CodeBasedOffersView: View {
                 }
                 DispatchQueue.main.async {
                     self.propositions.propositionsDict = propositionsDict
-                    self.viewDidLoad = false
+                    self.isLoading = false
                 }
             }
         }

--- a/TestApps/MessagingDemoAppSwiftUI/CodeBasedOffersView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/CodeBasedOffersView.swift
@@ -13,8 +13,12 @@ governing permissions and limitations under the License.
 import AEPMessaging
 import SwiftUI
 
+class Propositions: ObservableObject {
+    @Published var propositionsDict: [Surface: [Proposition]]? = nil
+}
+
 struct CodeBasedOffersView: View {
-    @State var propositionsDict: [Surface: [Proposition]]? = nil
+    @StateObject var propositions = Propositions()
     @State private var viewDidLoad = false
     
     let surfaces: [Surface] = [
@@ -34,21 +38,30 @@ struct CodeBasedOffersView: View {
             Text("Code Based Experiences")
                 .font(Font.title)
                 .padding(.top, 30)
-            List {
-                if let codePropositions: [Proposition] = propositionsDict?[surfaces.first!],
-                    !codePropositions.isEmpty,
-                let propItems = codePropositions.first?.items as? [PropositionItem] {
-                    ForEach(propItems, id:\.itemId) { item in
-                        if item.schema == .htmlContent {
-                            CustomHtmlView(htmlString: item.htmlContent ?? "",
-                                           trackAction: item.track(_:withEdgeEventType:forTokens:))
-                        } else if item.schema == .jsonContent {
-                            if let jsonArray = item.jsonContentArray {
-                                CustomTextView(text: jsonArray.description,
-                                               trackAction: item.track(_:withEdgeEventType:forTokens:))
-                            } else {
-                                CustomTextView(text: item.jsonContentDictionary?.description ?? "",
-                                               trackAction: item.track(_:withEdgeEventType:forTokens:))
+            if viewDidLoad {
+                // Display a loading indicator or some placeholder content
+                Text("Loading...")
+            } else {
+                List {
+                    if let propositionsDict = propositions.propositionsDict, !propositionsDict.isEmpty {
+                        let surfacesArray = Array(propositionsDict.keys)
+                        ForEach(surfacesArray, id: \.self) { surface in
+                            if let codePropositions: [Proposition] = propositions.propositionsDict?[surface], !codePropositions.isEmpty,
+                               let propItems = codePropositions.first?.items as? [PropositionItem] {
+                                ForEach(propItems, id:\.itemId) { item in
+                                    if item.schema == .htmlContent {
+                                        CustomHtmlView(htmlString: item.htmlContent ?? "",
+                                                       trackAction: item.track(_:withEdgeEventType:forTokens:))
+                                    } else if item.schema == .jsonContent {
+                                        if let jsonArray = item.jsonContentArray {
+                                            CustomTextView(text: jsonArray.description,
+                                                           trackAction: item.track(_:withEdgeEventType:forTokens:))
+                                        } else {
+                                            CustomTextView(text: item.jsonContentDictionary?.description ?? "",
+                                                           trackAction: item.track(_:withEdgeEventType:forTokens:))
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -56,15 +69,16 @@ struct CodeBasedOffersView: View {
             }
         }
         .onAppear {
-            if viewDidLoad == false {
-                viewDidLoad = true
-                Messaging.updatePropositionsForSurfaces(surfaces)
-            }
+            viewDidLoad = true
+            Messaging.updatePropositionsForSurfaces(surfaces)
             Messaging.getPropositionsForSurfaces(surfaces) { propositionsDict, error in
-                guard error == nil else {
+                if let error = error {
                     return
                 }
-                self.propositionsDict = propositionsDict                
+                DispatchQueue.main.async {
+                    self.propositions.propositionsDict = propositionsDict
+                    self.viewDidLoad = false
+                }
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Every time `updatePropositionsForSurface` is called, logic is now changed to completely replace the propositions in `inMemoryPropositions` with the ones returned in `AEP Response Event` for each corresponding surface.
2. Changed the Swift UI test app to make it easier to test this by calling `updatePropositionsForSurface` each time the screen is loaded.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

When the content for a CBE campaign was changed server side (either manually or using ExD), the cached client side propositions would append the modified proposition while continuing to retain the old proposition with outdated content. This causes confusion on what the most current CBE content is. 

https://jira.corp.adobe.com/browse/MOB-21212

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
