### PR TITLE
[PLATO-4488] - Fix regression introduced in 5.0.0 preventing cached in-app messages from displaying on launch

### DIFF
--- a/AEPMessaging/Sources/Messaging+State.swift
+++ b/AEPMessaging/Sources/Messaging+State.swift
@@ -57,6 +57,7 @@ extension Messaging {
         if let inAppRules = parsedPropositions.surfaceRulesBySchemaType[.inapp] {
             rulesEngine.launchRulesEngine.replaceRules(with: inAppRules.flatMap { $0.value })
         }
+        updatePropositionInfo(parsedPropositions.propositionInfoToCache)
     }
 
     private func removeCachedPropositions(surfaces: [Surface]) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With the refactoring introduced in version 5.0.0, the proposition info dictionary was not being properly loaded from cache.  Without proposition info for the message, it is not being shown as expected.  

This bug effects all in-app messages loaded from persistence until an updated network response is received by the SDK.  It is mostly observed in on-launch scenarios, since the updated network response usually comes quickly after application launch.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
