### PR TITLE
Add MessagingUI Target

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -222,6 +222,10 @@
 		B6389A492A9B32D400B72FB4 /* PushTrackingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6389A482A9B32D400B72FB4 /* PushTrackingStatus.swift */; };
 		B6D6A02B265FB1FA005042BE /* Dictionary+Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928639FB263757A7000AFA53 /* Dictionary+Flatten.swift */; };
 		B6E63D042A9EC71C007BB586 /* PushTrackingStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E63D032A9EC71C007BB586 /* PushTrackingStatusTests.swift */; };
+		B6F7CB502CC06AF500C35C64 /* AEPMessagingUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6F7CB4A2CC06AF500C35C64 /* AEPMessagingUI.framework */; };
+		B6F7CB512CC06AF500C35C64 /* AEPMessagingUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B6F7CB4A2CC06AF500C35C64 /* AEPMessagingUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B6F7CB632CC06CF900C35C64 /* AEPMessagingUI.h in Headers */ = {isa = PBXBuildFile; fileRef = B6F7CB5F2CC06CF900C35C64 /* AEPMessagingUI.h */; };
+		B6F7CB652CC06D6500C35C64 /* MessagingUI+PublicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F7CB642CC06D5500C35C64 /* MessagingUI+PublicAPI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -316,6 +320,20 @@
 			remoteGlobalIDString = 2469A6012759999E00E56457;
 			remoteInfo = FunctionalTestApp;
 		};
+		B6F7CB4E2CC06AF500C35C64 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 922FFCE7251B2BBA00BCE010 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B6F7CB492CC06AF500C35C64;
+			remoteInfo = AEPMessagingUI;
+		};
+		B6F7CB662CC071E300C35C64 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 922FFCE7251B2BBA00BCE010 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 925DF4A425227C4700A5DE31;
+			remoteInfo = AEPMessaging;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -372,6 +390,17 @@
 				B6165DAA29A67ADA0031B84D /* NotificationService.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6F7CB522CC06AF500C35C64 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				B6F7CB512CC06AF500C35C64 /* AEPMessagingUI.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -587,6 +616,9 @@
 		B631AE152A61336800E8B82E /* MessagingNotificationTrackingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingNotificationTrackingTests.swift; sourceTree = "<group>"; };
 		B6389A482A9B32D400B72FB4 /* PushTrackingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTrackingStatus.swift; sourceTree = "<group>"; };
 		B6E63D032A9EC71C007BB586 /* PushTrackingStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTrackingStatusTests.swift; sourceTree = "<group>"; };
+		B6F7CB4A2CC06AF500C35C64 /* AEPMessagingUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPMessagingUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B6F7CB5F2CC06CF900C35C64 /* AEPMessagingUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AEPMessagingUI.h; sourceTree = "<group>"; };
+		B6F7CB642CC06D5500C35C64 /* MessagingUI+PublicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagingUI+PublicAPI.swift"; sourceTree = "<group>"; };
 		C003D7513651C8FD2BC84411 /* Pods-AEPMessaging.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPMessaging.debug.xcconfig"; path = "Target Support Files/Pods-AEPMessaging/Pods-AEPMessaging.debug.xcconfig"; sourceTree = "<group>"; };
 		CFBC956862FD1C6747587F09 /* Pods-E2EFunctionalTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.debug.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		CFC660CD22A375E0F809B475 /* Pods-E2EFunctionalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.release.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -641,6 +673,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B6F7CB502CC06AF500C35C64 /* AEPMessagingUI.framework in Frameworks */,
 				24B071BA29072EBF00F4B18A /* AEPMessaging.framework in Frameworks */,
 				44DFBD558578CFDCD4A9A476 /* Pods_E2EFunctionalTestApp.framework in Frameworks */,
 			);
@@ -682,6 +715,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B6165DA029A67AD90031B84D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6F7CB472CC06AF500C35C64 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -855,6 +895,7 @@
 			isa = PBXGroup;
 			children = (
 				925DF4A625227C4700A5DE31 /* AEPMessaging */,
+				B6F7CB622CC06CF900C35C64 /* AEPMessagingUI */,
 				925DF4452522785700A5DE31 /* MessagingDemoApp */,
 				2414ED802899BA080036D505 /* MessagingDemoAppObjC */,
 				B6165DA429A67ADA0031B84D /* NotificationService */,
@@ -878,6 +919,7 @@
 				24B071A529072E9800F4B18A /* E2EFunctionalTestApp.app */,
 				B6165DA329A67AD90031B84D /* NotificationService.appex */,
 				091881E42A16BAE200615481 /* MessagingDemoAppSwiftUI.app */,
+				B6F7CB4A2CC06AF500C35C64 /* AEPMessagingUI.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1082,6 +1124,31 @@
 			path = TestApps/MessagingDemoApp/NotificationService;
 			sourceTree = "<group>";
 		};
+		B6F7CB602CC06CF900C35C64 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				B6F7CB642CC06D5500C35C64 /* MessagingUI+PublicAPI.swift */,
+				B6F7CB5F2CC06CF900C35C64 /* AEPMessagingUI.h */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		B6F7CB612CC06CF900C35C64 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		B6F7CB622CC06CF900C35C64 /* AEPMessagingUI */ = {
+			isa = PBXGroup;
+			children = (
+				B6F7CB602CC06CF900C35C64 /* Sources */,
+				B6F7CB612CC06CF900C35C64 /* Tests */,
+			);
+			path = AEPMessagingUI;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1090,6 +1157,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				92315508261E444A004AE7D3 /* AEPMessaging.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6F7CB452CC06AF500C35C64 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B6F7CB632CC06CF900C35C64 /* AEPMessagingUI.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1189,11 +1264,13 @@
 				24B071A229072E9800F4B18A /* Frameworks */,
 				24B071A329072E9800F4B18A /* Resources */,
 				1128889F83791F257937AAED /* [CP] Embed Pods Frameworks */,
+				B6F7CB522CC06AF500C35C64 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				24B071BE290730C900F4B18A /* PBXTargetDependency */,
+				B6F7CB4F2CC06AF500C35C64 /* PBXTargetDependency */,
 			);
 			name = E2EFunctionalTestApp;
 			productName = E2EFunctionalTestApp;
@@ -1301,6 +1378,27 @@
 			productReference = B6165DA329A67AD90031B84D /* NotificationService.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		B6F7CB492CC06AF500C35C64 /* AEPMessagingUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B6F7CB562CC06AF500C35C64 /* Build configuration list for PBXNativeTarget "AEPMessagingUI" */;
+			buildPhases = (
+				B6F7CB452CC06AF500C35C64 /* Headers */,
+				B6F7CB462CC06AF500C35C64 /* Sources */,
+				B6F7CB472CC06AF500C35C64 /* Frameworks */,
+				B6F7CB482CC06AF500C35C64 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B6F7CB672CC071E300C35C64 /* PBXTargetDependency */,
+			);
+			name = AEPMessagingUI;
+			packageProductDependencies = (
+			);
+			productName = AEPMessagingUI;
+			productReference = B6F7CB4A2CC06AF500C35C64 /* AEPMessagingUI.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1346,6 +1444,10 @@
 					B6165DA229A67AD90031B84D = {
 						CreatedOnToolsVersion = 14.2;
 					};
+					B6F7CB492CC06AF500C35C64 = {
+						CreatedOnToolsVersion = 16.0;
+						LastSwiftMigration = 1600;
+					};
 				};
 			};
 			buildConfigurationList = 922FFCEA251B2BBA00BCE010 /* Build configuration list for PBXProject "AEPMessaging" */;
@@ -1362,6 +1464,7 @@
 			projectRoot = "";
 			targets = (
 				925DF4A425227C4700A5DE31 /* AEPMessaging */,
+				B6F7CB492CC06AF500C35C64 /* AEPMessagingUI */,
 				928D8364254225A700FD0E6D /* AEPMessagingXCF */,
 				246EFA0C27973E7400C76A6B /* E2EFunctionalTests */,
 				24B071A429072E9800F4B18A /* E2EFunctionalTestApp */,
@@ -1476,6 +1579,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B6165DA129A67AD90031B84D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6F7CB482CC06AF500C35C64 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2035,6 +2145,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B6F7CB462CC06AF500C35C64 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B6F7CB652CC06D6500C35C64 /* MessagingUI+PublicAPI.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -2104,6 +2222,16 @@
 			isa = PBXTargetDependency;
 			target = 2469A6012759999E00E56457 /* FunctionalTestApp */;
 			targetProxy = B6D6AE912BA8C48100F0E975 /* PBXContainerItemProxy */;
+		};
+		B6F7CB4F2CC06AF500C35C64 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B6F7CB492CC06AF500C35C64 /* AEPMessagingUI */;
+			targetProxy = B6F7CB4E2CC06AF500C35C64 /* PBXContainerItemProxy */;
+		};
+		B6F7CB672CC071E300C35C64 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 925DF4A425227C4700A5DE31 /* AEPMessaging */;
+			targetProxy = B6F7CB662CC071E300C35C64 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2945,6 +3073,92 @@
 			};
 			name = Release;
 		};
+		B6F7CB532CC06AF500C35C64 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = FKGEE875K4;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.messagingui;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B6F7CB542CC06AF500C35C64 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = FKGEE875K4;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.messagingui;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3052,6 +3266,15 @@
 			buildConfigurations = (
 				B6165DAC29A67ADA0031B84D /* Debug */,
 				B6165DAD29A67ADA0031B84D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B6F7CB562CC06AF500C35C64 /* Build configuration list for PBXNativeTarget "AEPMessagingUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B6F7CB532CC06AF500C35C64 /* Debug */,
+				B6F7CB542CC06AF500C35C64 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AEPMessagingUI.podspec
+++ b/AEPMessagingUI.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name         = "AEPMessagingUI"
+  s.version      = "5.5.0"
+  s.summary      = "AEPMessagingUI library for Adobe Experience Cloud SDK. Written and maintained by Adobe."
+  s.description  = <<-DESC
+                   The AEPMessagingUI library offers UI for building content cards and integrates with messaging extensions.
+                   DESC
+  s.homepage     = "https://github.com/adobe/aepsdk-messaging-ios.git"
+  s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
+  s.author       = "Adobe Experience Platform SDK Team"
+  s.source       = { :git => 'https://github.com/adobe/aepsdk-messaging-ios.git', :tag => s.version.to_s }
+  
+  s.platform = :ios, "12.0"
+  s.swift_version = '5.1'
+
+  s.source_files = 'AEPMessagingUI/Sources/**/*.swift'
+
+  s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
+  s.dependency 'AEPMessaging', '>= 5.5.0', '< 6.0.0'
+
+end
+

--- a/AEPMessagingUI/Sources/AEPMessagingUI.h
+++ b/AEPMessagingUI/Sources/AEPMessagingUI.h
@@ -1,0 +1,23 @@
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for AEPMessagingUI.
+FOUNDATION_EXPORT double AEPMessagingUIVersionNumber;
+
+//! Project version string for AEPMessagingUI.
+FOUNDATION_EXPORT const unsigned char AEPMessagingUIVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <AEPMessagingUI/PublicHeader.h>
+
+

--- a/AEPMessagingUI/Sources/MessagingUI+PublicAPI.swift
+++ b/AEPMessagingUI/Sources/MessagingUI+PublicAPI.swift
@@ -1,0 +1,19 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import AEPMessaging
+import AEPServices
+import Foundation
+
+public class MessagingUI {
+    
+}

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
     name: "AEPMessaging",
     platforms: [.iOS(.v12)],
     products: [
-        .library(name: "AEPMessaging", targets: ["AEPMessaging"])
+        .library(name: "AEPMessaging", targets: ["AEPMessaging"]),
+        .library(name: "AEPMessagingUI", targets: ["AEPMessagingUI"])
     ],
     dependencies: [
         .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.3.0")),
@@ -35,5 +36,8 @@ let package = Package(
                 .product(name: "AEPEdgeIdentity", package: "aepsdk-edgeidentity-ios")
             ],
             path: "AEPMessaging/Sources")
+        .target(name: "AEPMessagingUI",
+            dependencies: ["AEPMessaging"],
+                path: "AEPMessagingUI/Sources"),
     ]
 )


### PR DESCRIPTION
AEPMessaging UI target is added to the existing project

* AEPMessagingUI has dependency on AEPMessaging
* Min Deployment version of AEPMessagingUI is iOS 12.0
* AEPMessagingUI will follow the same version as AEPMessaging

<img width="1044" alt="Screenshot 2024-10-16 at 3 47 53 PM" src="https://github.com/user-attachments/assets/f9ea18de-12f0-48c8-a3d6-e3666a6d8b2a">


PodSpec and Swift Package Managers file for MessagingUI are created


