### PR TITLE
Use rank to order Propositions and expose priority property

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -106,6 +106,9 @@
 		243EA6DE2739D4A400195945 /* MockFullscreenMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243EA6DD2739D4A400195945 /* MockFullscreenMessage.swift */; };
 		243EA6E02739D9D700195945 /* TestableMessagingMobileParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243EA6DF2739D9D700195945 /* TestableMessagingMobileParameters.swift */; };
 		243EA6E2273B436400195945 /* MockMessagingRulesEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243EA6E1273B436400195945 /* MockMessagingRulesEngine.swift */; };
+		243EC1EB2CD036C600BD546E /* inAppMessagePriority100.json in Resources */ = {isa = PBXBuildFile; fileRef = 243EC1EA2CD036A200BD546E /* inAppMessagePriority100.json */; };
+		243EC1EE2CD0387100BD546E /* inAppMessagePriority20.json in Resources */ = {isa = PBXBuildFile; fileRef = 243EC1EC2CD0387100BD546E /* inAppMessagePriority20.json */; };
+		243EC1EF2CD0387100BD546E /* inAppMessagePriority60.json in Resources */ = {isa = PBXBuildFile; fileRef = 243EC1ED2CD0387100BD546E /* inAppMessagePriority60.json */; };
 		244C2BD826B36480008F086A /* MessagingEdgeEventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244C2BD726B36480008F086A /* MessagingEdgeEventType.swift */; };
 		244C2BDE26B36A4B008F086A /* Message+FullscreenMessageDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244C2BDD26B36A4B008F086A /* Message+FullscreenMessageDelegate.swift */; };
 		244E954B267BAEBE001DC957 /* Messaging+EdgeEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244E954A267BAEBE001DC957 /* Messaging+EdgeEvents.swift */; };
@@ -542,6 +545,9 @@
 		243EA6DD2739D4A400195945 /* MockFullscreenMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFullscreenMessage.swift; sourceTree = "<group>"; };
 		243EA6DF2739D9D700195945 /* TestableMessagingMobileParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestableMessagingMobileParameters.swift; sourceTree = "<group>"; };
 		243EA6E1273B436400195945 /* MockMessagingRulesEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMessagingRulesEngine.swift; sourceTree = "<group>"; };
+		243EC1EA2CD036A200BD546E /* inAppMessagePriority100.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = inAppMessagePriority100.json; sourceTree = "<group>"; };
+		243EC1EC2CD0387100BD546E /* inAppMessagePriority20.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = inAppMessagePriority20.json; sourceTree = "<group>"; };
+		243EC1ED2CD0387100BD546E /* inAppMessagePriority60.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = inAppMessagePriority60.json; sourceTree = "<group>"; };
 		244C2BD726B36480008F086A /* MessagingEdgeEventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingEdgeEventType.swift; sourceTree = "<group>"; };
 		244C2BDD26B36A4B008F086A /* Message+FullscreenMessageDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+FullscreenMessageDelegate.swift"; sourceTree = "<group>"; };
 		244E954A267BAEBE001DC957 /* Messaging+EdgeEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Messaging+EdgeEvents.swift"; sourceTree = "<group>"; };
@@ -920,6 +926,9 @@
 				240FC43E2AB0B8A300AFEEEB /* inappPropositionV2Content.json */,
 				2438B92E29C12179001D6F3A /* malformedContentRule.json */,
 				240BDFF52B72E83E00AE8547 /* mockPropositionItem.json */,
+				243EC1EC2CD0387100BD546E /* inAppMessagePriority20.json */,
+				243EC1ED2CD0387100BD546E /* inAppMessagePriority60.json */,
+				243EC1EA2CD036A200BD546E /* inAppMessagePriority100.json */,
 				242920D32ABCA559000DB2CD /* ruleWithNoConsequence.json */,
 				242920D52ABCD8A6000DB2CD /* ruleWithUnknownConsequenceSchema.json */,
 				2469A5DE274465C900E56457 /* showOnceRule.json */,
@@ -1895,6 +1904,8 @@
 				B6F7CC252CC2EFE400C35C64 /* SmallImageTemplate_noTitle.json in Resources */,
 				B6F7CC262CC2EFE400C35C64 /* SmallImageTemplate.json in Resources */,
 				B6F7CC272CC2EFE400C35C64 /* SmallImageTemplate_validTitle_invalidOther.json in Resources */,
+				243EC1EE2CD0387100BD546E /* inAppMessagePriority20.json in Resources */,
+				243EC1EF2CD0387100BD546E /* inAppMessagePriority60.json in Resources */,
 				B6F7CC2A2CC2EFE400C35C64 /* InvalidTemplate.json in Resources */,
 				2469A5DF274465C900E56457 /* showOnceRule.json in Resources */,
 				240FC4362AAFCBE500AFEEEB /* feedProposition.json in Resources */,
@@ -1910,6 +1921,7 @@
 				240BDFF72B72F10000AE8547 /* mockPropositionItem.json in Resources */,
 				242920D62ABCD8A6000DB2CD /* ruleWithUnknownConsequenceSchema.json in Resources */,
 				09265D602B74497E0085D825 /* codeBasedPropositionHtml.json in Resources */,
+				243EC1EB2CD036C600BD546E /* inAppMessagePriority100.json in Resources */,
 				09265D612B74497E0085D825 /* codeBasedPropositionHtmlContent.json in Resources */,
 				2469A5E12744696400E56457 /* eventSequenceRule.json in Resources */,
 				09265D632B74497E0085D825 /* codeBasedPropositionJson.json in Resources */,
@@ -2773,7 +2785,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.MessagingDemoAppSwiftUI;
+				PRODUCT_BUNDLE_IDENTIFIER = com.steveb.priorityTester;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -2806,7 +2818,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.MessagingDemoAppSwiftUI;
+				PRODUCT_BUNDLE_IDENTIFIER = com.steveb.priorityTester;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/AEPMessaging/Sources/Messaging+State.swift
+++ b/AEPMessaging/Sources/Messaging+State.swift
@@ -55,10 +55,7 @@ extension Messaging {
     private func hydratePropositionsRulesEngine() {
         let parsedPropositions = ParsedPropositions(with: inMemoryPropositions, requestedSurfaces: inMemoryPropositions.map { $0.key }, runtime: runtime)
         if let inAppRules = parsedPropositions.surfaceRulesBySchemaType[.inapp] {
-            /// MOB-21852 - iam items are returned in reverse priority order, so we need to flip the
-            /// order of the array prior to saving them and hydrating the rules engine.  this allows the
-            /// highest priority item to be shown first when rules engine evaluates top-down
-            rulesEngine.launchRulesEngine.replaceRules(with: inAppRules.flatMap { $0.value.reversed() })
+            rulesEngine.launchRulesEngine.replaceRules(with: inAppRules.flatMap { $0.value })
         }
         updatePropositionInfo(parsedPropositions.propositionInfoToCache)
     }

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -617,16 +617,8 @@ public class Messaging: NSObject, Extension {
             case .inapp:
                 Log.trace(label: MessagingConstants.LOG_TAG, "Updating in-app message definitions for surfaces \(newRules.compactMap { $0.key.uri }).")
 
-                /// MOB-21852 - iam items are returned in reverse priority order, so we need to flip the
-                /// order of the array prior to saving them and hydrating the rules engine.  this allows the
-                /// highest priority item to be shown first when rules engine evaluates top-down
-                var newRulesReordered: [Surface: [LaunchRule]] = [:]
-                for (surface, surfaceRules) in newRules {
-                    newRulesReordered[surface] = surfaceRules.reversed()
-                }
-
                 // replace rules for each in-app surface we got back
-                inAppRulesBySurface.merge(newRulesReordered) { _, new in new }
+                inAppRulesBySurface.merge(newRules) { _, new in new }
 
                 // remove any surfaces that were requested but had no in-app content returned
                 for surface in surfacesToRemove {

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -138,6 +138,8 @@ enum MessagingConstants {
                     static let PAYLOAD = "payload"
                     static let CORRELATION_ID = "correlationID"
                     static let ACTIVITY = "activity"
+                    static let RANK = "rank"
+                    static let PRIORITY = "priority"
                     static let ID = "id"
                 }
             }

--- a/AEPMessaging/Sources/ParsedPropositions.swift
+++ b/AEPMessaging/Sources/ParsedPropositions.swift
@@ -32,7 +32,11 @@ struct ParsedPropositions {
 
     init(with propositions: [Surface: [Proposition]], requestedSurfaces: [Surface], runtime: ExtensionRuntime) {
         self.runtime = runtime
-        for propositionsArray in propositions.values {
+
+        // sort these propositions by ordinal rank before processing them
+        let sortedPropositionsBySurface = sortByRank(propositions)
+
+        for propositionsArray in sortedPropositionsBySurface.values {
             for proposition in propositionsArray {
                 guard let surface = requestedSurfaces.first(where: { $0.uri == proposition.scope }) else {
                     Log.debug(label: MessagingConstants.LOG_TAG,
@@ -105,5 +109,15 @@ struct ParsedPropositions {
 
         // apply up to surfaceRulesBySchemaType
         surfaceRulesBySchemaType[schemaType] = tempRulesBySchemaType
+    }
+
+    private func sortByRank(_ propositionsBySurface: [Surface: [Proposition]]) -> [Surface: [Proposition]] {
+        var propositionsSortedByRank: [Surface: [Proposition]] = [:]
+
+        for (surface, propositions) in propositionsBySurface {
+            propositionsSortedByRank[surface] = propositions.sorted { $0.rank < $1.rank }
+        }
+
+        return propositionsSortedByRank
     }
 }

--- a/AEPMessaging/Sources/Proposition.swift
+++ b/AEPMessaging/Sources/Proposition.swift
@@ -25,6 +25,20 @@ public class Proposition: NSObject, Codable {
     /// Scope details dictionary
     var scopeDetails: [String: Any]
 
+    /// Priority of the `Proposition` entered in the AJO UI for the corresponding campaign
+    public var priority: Int {
+        if let scopeDetails = scopeDetails as? [String: AnyCodable] {
+            guard let activity = scopeDetails[MessagingConstants.Event.Data.Key.Personalization.ACTIVITY]?.dictionaryValue else {
+                return 0
+            }
+            return activity[MessagingConstants.Event.Data.Key.Personalization.PRIORITY] as? Int ?? 0
+        } else if let activity = scopeDetails[MessagingConstants.Event.Data.Key.Personalization.ACTIVITY] as? [String: Any] {
+            return activity[MessagingConstants.Event.Data.Key.Personalization.PRIORITY] as? Int ?? 0
+        } else {
+            return 0
+        }
+    }
+
     /// Array containing proposition decision items
     private let propositionItems: [PropositionItem]
 

--- a/AEPMessaging/Sources/Proposition.swift
+++ b/AEPMessaging/Sources/Proposition.swift
@@ -91,4 +91,15 @@ extension Proposition {
             return ""
         }
     }
+
+    /// rank is an ordinal value computed by IDS, used for prioritization
+    /// it is expected that IDS will always return a value for rank
+    /// a default value of -1 is used in the absense of rank in the IDS response and should be considered an error state
+    var rank: Int {
+        if let scopeDetails = scopeDetails as? [String: AnyCodable] {
+            return scopeDetails[MessagingConstants.Event.Data.Key.Personalization.RANK]?.intValue ?? -1
+        } else {
+            return scopeDetails[MessagingConstants.Event.Data.Key.Personalization.RANK] as? Int ?? -1
+        }
+    }
 }

--- a/AEPMessaging/Sources/UI/ContentCards/ContentCardUI.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/ContentCardUI.swift
@@ -23,6 +23,11 @@ public class ContentCardUI: Identifiable {
     /// The underlying data model for the content card.
     let proposition: Proposition
 
+    /// Priority of the `Proposition` entered in the AJO UI for the corresponding campaign
+    public var priority: Int {
+        proposition.priority
+    }
+
     /// The template that defines the content card
     public let template: any ContentCardTemplate
 

--- a/AEPMessaging/Tests/Resources/cachedProposition.json
+++ b/AEPMessaging/Tests/Resources/cachedProposition.json
@@ -4,12 +4,14 @@
             "id": "c2aa4a73-a534-44c2-baa4-a12980e4bb9e",
             "scope": "mobileapp://com.ajo.testing/iam/",
             "scopeDetails": {
+                "rank": 1,
                 "decisionProvider": "AJO",
                 "correlationID": "b5095046-7fd7-4961-871f-9d68f2ac335f",
                 "characteristics": {
                     "eventToken": "eyJtZXNzYWdlRXhlY3V0aW9uIjp7Im1lc3NhZ2VFeGVjdXRpb25JRCI6Ik5BIiwibWVzc2FnZUlEIjoiYjUwOTUwNDYtN2ZkNy00OTYxLTg3MWYtOWQ2OGYyZGMzMzVmIiwibWVzc2FnZVB1YmxpY2F0aW9uSUQiOiJiNzFlNDhiYS1mNzY3LTQ5NWItOWQxMS01YzA3MTg4NWNkODkiLCJtZXNzYWdlVHlwZSI6Im1hcmtldGluZyIsImNhbXBhaWduSUQiOiI5YzhlYzAzNS02YjNiLTQ3MGUtOGFlNS1lNTM5YzcxMjM4MDkiLCJjYW1wYWlnblZlcnNpb25JRCI6IjdkZGEyZGM2LTE5MjMtNGU2My1iZWFjLTU0ZGM3ODczNjFlYiIsImNhbXBhaWduQWN0aW9uSUQiOiJjN2MxNDk3ZS1lNWEzLTQ0MjMtYWUzNy1iYTc2ZTFlNDQzNDIifSwibWVzc2FnZVByb2ZpbGUiOnsibWVzc2FnZVByb2ZpbGVJRCI6IjQ0YWQ1NTA3LTZlODItNGY2MS05N2U1LTUzMmNhNmZkMDhhOCIsImNoYW5uZWwiOnsiX2lkIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWxzL3dlYiIsIl90eXBlIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWwtdHlwZXMvd2ViIn19fQ=="
                 },
                 "activity": {
+                    "priority": 100,
                     "id": "9c8ec035-6b3b-470e-8ae5-e539c7123809#c7c1497e-e5a3-4423-ae37-ba76e1e44342"
                 }
             },
@@ -124,12 +126,14 @@
             "id": "c2aa4a73-a534-44c2-baa4-a12980e4bb9f",
             "scope": "mobileapp://com.ajo.testing/iam/",
             "scopeDetails": {
+                "rank": 2,
                 "decisionProvider": "AJO",
                 "correlationID": "b5095046-7fd7-4961-871f-9d68f2ac335e",
                 "characteristics": {
                     "eventToken": "eyJtZXNzYWdlRXhlY3V0aW9uIjp7Im1lc3NhZ2VFeGVjdXRpb25JRCI6Ik5BIiwibWVzc2FnZUlEIjoiYjUwOTUwNDYtN2ZkNy00OTYxLTg3MWYtOWQ2OGYyZGMzMzVmIiwibWVzc2FnZVB1YmxpY2F0aW9uSUQiOiJiNzFlNDhiYS1mNzY3LTQ5NWItOWQxMS01YzA3MTg4NWNkODkiLCJtZXNzYWdlVHlwZSI6Im1hcmtldGluZyIsImNhbXBhaWduSUQiOiI5YzhlYzAzNS02YjNiLTQ3MGUtOGFlNS1lNTM5YzcxMjM4MDkiLCJjYW1wYWlnblZlcnNpb25JRCI6IjdkZGEyZGM2LTE5MjMtNGU2My1iZWFjLTU0ZGM3ODczNjFlYiIsImNhbXBhaWduQWN0aW9uSUQiOiJjN2MxNDk3ZS1lNWEzLTQ0MjMtYWUzNy1iYTc2ZTFlNDQzNDIifSwibWVzc2FnZVByb2ZpbGUiOnsibWVzc2FnZVByb2ZpbGVJRCI6IjQ0YWQ1NTA3LTZlODItNGY2MS05N2U1LTUzMmNhNmZkMDhhOCIsImNoYW5uZWwiOnsiX2lkIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWxzL3dlYiIsIl90eXBlIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWwtdHlwZXMvd2ViIn19fR=="
                 },
                 "activity": {
+                    "priority": 50,
                     "id": "9c8ec035-6b3b-470e-8ae5-e539c7123809#c7c1497e-e5a3-4423-ae37-ba76e1e44343"
                 }
             },

--- a/AEPMessaging/Tests/Resources/inAppMessagePriority100.json
+++ b/AEPMessaging/Tests/Resources/inAppMessagePriority100.json
@@ -1,0 +1,98 @@
+{
+    "version": 1,
+    "rules": [
+        {
+            "condition": {
+                "definition": {
+                    "conditions": [
+                        {
+                            "definition": {
+                                "conditions": [
+                                    {
+                                        "definition": {
+                                            "key": "~type",
+                                            "matcher": "eq",
+                                            "values": [
+                                                "com.adobe.eventType.generic.track"
+                                            ]
+                                        },
+                                        "type": "matcher"
+                                    },
+                                    {
+                                        "definition": {
+                                            "key": "~source",
+                                            "matcher": "eq",
+                                            "values": [
+                                                "com.adobe.eventSource.requestContent"
+                                            ]
+                                        },
+                                        "type": "matcher"
+                                    },
+                                    {
+                                        "definition": {
+                                            "key": "action",
+                                            "matcher": "ex"
+                                        },
+                                        "type": "matcher"
+                                    }
+                                ],
+                                "logic": "and"
+                            },
+                            "type": "group"
+                        },
+                        {
+                            "definition": {
+                                "key": "action",
+                                "matcher": "eq",
+                                "values": [
+                                    "fullscreen"
+                                ]
+                            },
+                            "type": "matcher"
+                        }
+                    ],
+                    "logic": "and"
+                },
+                "type": "group"
+            },
+            "consequences": [
+                {
+                    "id": "priority100",
+                    "type": "schema",
+                    "detail": {
+                        "id": "priority100",
+                        "schema": "https://ns.adobe.com/personalization/message/in-app",
+                        "data": {
+                            "publishedDate": 1691541497,
+                            "expiryDate": 1723163897,
+                            "meta": {
+                                "metaKey": "metaValue"
+                            },
+                            "mobileParameters": {
+                                "verticalAlign": "center",
+                                "dismissAnimation": "bottom",
+                                "verticalInset": 0,
+                                "backdropOpacity": 0.2,
+                                "cornerRadius": 15,
+                                "gestures": {},
+                                "horizontalInset": 0,
+                                "uiTakeover": true,
+                                "horizontalAlign": "center",
+                                "width": 100,
+                                "displayAnimation": "bottom",
+                                "backdropColor": "#000000",
+                                "height": 100
+                            },
+                            "webParameters": {
+                                "webParamKey": "webParamValue"
+                            },
+                            "remoteAssets": [ "urlToAnImage" ],
+                            "contentType": "text/html",
+                            "content": "<html><body>Is this thing even on?</body></html>"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/AEPMessaging/Tests/Resources/inAppMessagePriority20.json
+++ b/AEPMessaging/Tests/Resources/inAppMessagePriority20.json
@@ -1,0 +1,98 @@
+{
+    "version": 1,
+    "rules": [
+        {
+            "condition": {
+                "definition": {
+                    "conditions": [
+                        {
+                            "definition": {
+                                "conditions": [
+                                    {
+                                        "definition": {
+                                            "key": "~type",
+                                            "matcher": "eq",
+                                            "values": [
+                                                "com.adobe.eventType.generic.track"
+                                            ]
+                                        },
+                                        "type": "matcher"
+                                    },
+                                    {
+                                        "definition": {
+                                            "key": "~source",
+                                            "matcher": "eq",
+                                            "values": [
+                                                "com.adobe.eventSource.requestContent"
+                                            ]
+                                        },
+                                        "type": "matcher"
+                                    },
+                                    {
+                                        "definition": {
+                                            "key": "action",
+                                            "matcher": "ex"
+                                        },
+                                        "type": "matcher"
+                                    }
+                                ],
+                                "logic": "and"
+                            },
+                            "type": "group"
+                        },
+                        {
+                            "definition": {
+                                "key": "action",
+                                "matcher": "eq",
+                                "values": [
+                                    "fullscreen"
+                                ]
+                            },
+                            "type": "matcher"
+                        }
+                    ],
+                    "logic": "and"
+                },
+                "type": "group"
+            },
+            "consequences": [
+                {
+                    "id": "priority20",
+                    "type": "schema",
+                    "detail": {
+                        "id": "priority20",
+                        "schema": "https://ns.adobe.com/personalization/message/in-app",
+                        "data": {
+                            "publishedDate": 1691541497,
+                            "expiryDate": 1723163897,
+                            "meta": {
+                                "metaKey": "metaValue"
+                            },
+                            "mobileParameters": {
+                                "verticalAlign": "center",
+                                "dismissAnimation": "bottom",
+                                "verticalInset": 0,
+                                "backdropOpacity": 0.2,
+                                "cornerRadius": 15,
+                                "gestures": {},
+                                "horizontalInset": 0,
+                                "uiTakeover": true,
+                                "horizontalAlign": "center",
+                                "width": 100,
+                                "displayAnimation": "bottom",
+                                "backdropColor": "#000000",
+                                "height": 100
+                            },
+                            "webParameters": {
+                                "webParamKey": "webParamValue"
+                            },
+                            "remoteAssets": [ "urlToAnImage" ],
+                            "contentType": "text/html",
+                            "content": "<html><body>Is this thing even on?</body></html>"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/AEPMessaging/Tests/Resources/inAppMessagePriority60.json
+++ b/AEPMessaging/Tests/Resources/inAppMessagePriority60.json
@@ -1,0 +1,98 @@
+{
+    "version": 1,
+    "rules": [
+        {
+            "condition": {
+                "definition": {
+                    "conditions": [
+                        {
+                            "definition": {
+                                "conditions": [
+                                    {
+                                        "definition": {
+                                            "key": "~type",
+                                            "matcher": "eq",
+                                            "values": [
+                                                "com.adobe.eventType.generic.track"
+                                            ]
+                                        },
+                                        "type": "matcher"
+                                    },
+                                    {
+                                        "definition": {
+                                            "key": "~source",
+                                            "matcher": "eq",
+                                            "values": [
+                                                "com.adobe.eventSource.requestContent"
+                                            ]
+                                        },
+                                        "type": "matcher"
+                                    },
+                                    {
+                                        "definition": {
+                                            "key": "action",
+                                            "matcher": "ex"
+                                        },
+                                        "type": "matcher"
+                                    }
+                                ],
+                                "logic": "and"
+                            },
+                            "type": "group"
+                        },
+                        {
+                            "definition": {
+                                "key": "action",
+                                "matcher": "eq",
+                                "values": [
+                                    "fullscreen"
+                                ]
+                            },
+                            "type": "matcher"
+                        }
+                    ],
+                    "logic": "and"
+                },
+                "type": "group"
+            },
+            "consequences": [
+                {
+                    "id": "priority60",
+                    "type": "schema",
+                    "detail": {
+                        "id": "priority60",
+                        "schema": "https://ns.adobe.com/personalization/message/in-app",
+                        "data": {
+                            "publishedDate": 1691541497,
+                            "expiryDate": 1723163897,
+                            "meta": {
+                                "metaKey": "metaValue"
+                            },
+                            "mobileParameters": {
+                                "verticalAlign": "center",
+                                "dismissAnimation": "bottom",
+                                "verticalInset": 0,
+                                "backdropOpacity": 0.2,
+                                "cornerRadius": 15,
+                                "gestures": {},
+                                "horizontalInset": 0,
+                                "uiTakeover": true,
+                                "horizontalAlign": "center",
+                                "width": 100,
+                                "displayAnimation": "bottom",
+                                "backdropColor": "#000000",
+                                "height": 100
+                            },
+                            "webParameters": {
+                                "webParamKey": "webParamValue"
+                            },
+                            "remoteAssets": [ "urlToAnImage" ],
+                            "contentType": "text/html",
+                            "content": "<html><body>Is this thing even on?</body></html>"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/AEPMessaging/Tests/TestHelpers/UITestUtils/ContentCardTestUtil.swift
+++ b/AEPMessaging/Tests/TestHelpers/UITestUtils/ContentCardTestUtil.swift
@@ -30,9 +30,9 @@ class ContentCardTestUtil {
         let propositionItem = PropositionItem(itemId: "mockItemId", schema: .contentCard, itemData: itemData!)
         var scopeDetails: [String: Any] = [:]
         if let prio = priority {
-            scopeDetails["activity"] = ["priority": 50] 
+            scopeDetails["activity"] = ["priority": prio]
         }
-        let proposition = Proposition(uniqueId: "mockID", scope: "mockScope", scopeDetails: [:], items: [propositionItem])
+        let proposition = Proposition(uniqueId: "mockID", scope: "mockScope", scopeDetails: scopeDetails, items: [propositionItem])
         return proposition
     }
 }

--- a/AEPMessaging/Tests/TestHelpers/UITestUtils/ContentCardTestUtil.swift
+++ b/AEPMessaging/Tests/TestHelpers/UITestUtils/ContentCardTestUtil.swift
@@ -23,11 +23,15 @@ class ContentCardTestUtil {
         return contentCardSchemaData
     }
     
-    static func createProposition(fromFile file : String ) -> Proposition {
+    static func createProposition(fromFile file : String, priority: Int? = nil ) -> Proposition {
         let jsonString = FileReader.readFromFile(file)
         let data = jsonString.data(using: .utf8)
         let itemData = try! JSONSerialization.jsonObject(with: data!, options: []) as? [String: Any]
         let propositionItem = PropositionItem(itemId: "mockItemId", schema: .contentCard, itemData: itemData!)
+        var scopeDetails: [String: Any] = [:]
+        if let prio = priority {
+            scopeDetails["activity"] = ["priority": 50] 
+        }
         let proposition = Proposition(uniqueId: "mockID", scope: "mockScope", scopeDetails: [:], items: [propositionItem])
         return proposition
     }

--- a/AEPMessaging/Tests/UnitTests/Event+MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/Event+MessagingTests.swift
@@ -573,7 +573,7 @@ class EventPlusMessagingTests: XCTestCase {
     
     func testPropositions() throws {
         // setup
-        let propositionJson = JSONFileLoader.getRulesJsonFromFile("inappPropositionV2")
+        let propositionJson = JSONFileLoader.getRulesJsonFromFile("inappPropositionV2")        
         let event = Event(name: "name", type: "type", source: "source", data: ["propositions": [ propositionJson ]])
         
         // verify

--- a/AEPMessaging/Tests/UnitTests/Messaging+StateTests.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+StateTests.swift
@@ -62,10 +62,10 @@ class MessagingPlusStateTests: XCTestCase {
         XCTAssertTrue(mockLaunchRulesEngineForIAM.replaceRulesCalled)
         XCTAssertNotNil(mockLaunchRulesEngineForIAM.paramReplaceRulesRules)
         XCTAssertEqual(2, mockLaunchRulesEngineForIAM.paramReplaceRulesRules?.count)
-        let firstRule = mockLaunchRulesEngineForIAM.paramReplaceRulesRules?.first
-        XCTAssertEqual("6ac78390-84e3-4d35-b798-8e7080e69a68", firstRule?.consequences.first?.id, "last rule in the source json should be first in the array of rules.")
+        let firstRule = mockLaunchRulesEngineForIAM.paramReplaceRulesRules?.first        
+        XCTAssertEqual("6ac78390-84e3-4d35-b798-8e7080e69a67", firstRule?.consequences.first?.id, "rule with higher rank should be first.")
         let lastRule = mockLaunchRulesEngineForIAM.paramReplaceRulesRules?.last
-        XCTAssertEqual("6ac78390-84e3-4d35-b798-8e7080e69a67", lastRule?.consequences.first?.id, "first rule in the source json should be last in the array of rules.")
+        XCTAssertEqual("6ac78390-84e3-4d35-b798-8e7080e69a68", lastRule?.consequences.first?.id, "rule with lower rank should be second.")
     }
     
     func testLoadCachedPropositionsCacheDoesNotContainPropositions() throws {

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1078,37 +1078,6 @@ class MessagingTests: XCTestCase {
         let propsForMockSurfaceAfter = messaging.qualifiedContentCardsBySurface[mockSurface]
         XCTAssertEqual(1, propsForMockSurfaceAfter?.count)
     }
-    
-    /// MOB-21456
-    func testUpdateRulesEnginesReversesOrderOfRulesBeforeHydratingRulesEngine() throws {
-        // setup
-        let assetString = "https://blog.adobe.com/en/publish/2020/05/28/media_1cc0fcc19cf0e64decbceb3a606707a3ad23f51dd.png"
-        let consequence = RuleConsequence(id: "552", type: "cjmiam", details: [
-            "remoteAssets": [assetString]
-        ])
-        let consequence2 = RuleConsequence(id: "553", type: "cjmiam", details: [
-            "remoteAssets": [assetString]
-        ])
-        let mockEvaluable = MockEvaluable()
-        let rule1 = LaunchRule(condition: mockEvaluable, consequences: [consequence])
-        let rule2 = LaunchRule(condition: mockEvaluable, consequences: [consequence2])
-        
-        var rules: [SchemaType: [Surface: [LaunchRule]]] = [:]
-        rules[.inapp] = [
-            mockSurface: [rule1, rule2]
-        ]
-        
-        // test
-        messaging.callUpdateRulesEngines(with: rules, requestedSurfaces: [mockSurface])
-        
-        // verify
-        XCTAssertTrue(mockLaunchRulesEngine.replaceRulesCalled)
-        XCTAssertEqual(2, mockLaunchRulesEngine.paramReplaceRulesRules?.count)
-        let firstRule = mockLaunchRulesEngine.paramReplaceRulesRules?.first
-        XCTAssertEqual("553", firstRule?.consequences.first?.id, "last rule in the source json should be first in the array of rules.")
-        let lastRule = mockLaunchRulesEngine.paramReplaceRulesRules?.last
-        XCTAssertEqual("552", lastRule?.consequences.first?.id, "first rule in the source json should be last in the array of rules.")
-    }
             
     // MARK: - Helpers
     

--- a/AEPMessaging/Tests/UnitTests/ParsedPropositionsTests.swift
+++ b/AEPMessaging/Tests/UnitTests/ParsedPropositionsTests.swift
@@ -281,4 +281,126 @@ class ParsedPropositionTests: XCTestCase {
     func testInitPropositionRulesetConsequenceIsNotSchemaType() throws {
         
     }
+    
+    func testSortByRankSourceIsReverseOrder() throws {
+        // setup
+        let propRank1Priority100 = Proposition(uniqueId: "rank1", scope: "inapp2", scopeDetails: ["rank": 1, "activity": [ "priority": 100 ]], items: [ getPropItemFile("inAppMessagePriority100")])
+        let propRank2Priority60 = Proposition(uniqueId: "rank2", scope: "inapp2", scopeDetails: ["rank": 2, "activity": [ "priority": 60 ]], items: [getPropItemFile("inAppMessagePriority60")])
+        let propRank3Priority20 = Proposition(uniqueId: "rank3", scope: "inapp2", scopeDetails: ["rank": 3, "activity": [ "priority": 20 ]], items: [getPropItemFile("inAppMessagePriority20")])
+        let propsPerSurface = [mockInAppSurfacev2!: [propRank3Priority20, propRank2Priority60, propRank1Priority100]]
+        
+        // test
+        let result = ParsedPropositions(with: propsPerSurface, requestedSurfaces: [mockInAppSurfacev2], runtime: mockRuntime)
+        
+        // verify
+        XCTAssertNotNil(result)
+        
+        // surfaceRulesBySchemaType is sorted properly
+        guard let inAppRules = result.surfaceRulesBySchemaType[.inapp],
+              let inAppRulesForSurface = inAppRules[mockInAppSurfacev2] else {
+            XCTFail("Unable to get rules for the requested surface.")
+            return
+        }
+        let firstRule = inAppRulesForSurface[0]
+        XCTAssertEqual("priority100", firstRule.consequences.first?.id)
+        let secondRule = inAppRulesForSurface[1]
+        XCTAssertEqual("priority60", secondRule.consequences.first?.id)
+        let thirdRule = inAppRulesForSurface[2]
+        XCTAssertEqual("priority20", thirdRule.consequences.first?.id)
+        
+        // propositionsToPersist is sorted properly
+        guard let propsForSurface = result.propositionsToPersist[mockInAppSurfacev2] else {
+            XCTFail("Unable to get propositions to persist for the requested surface.")
+            return
+        }
+        let firstProp = propsForSurface[0]
+        XCTAssertEqual(1, firstProp.rank)
+        let secondProp = propsForSurface[1]
+        XCTAssertEqual(2, secondProp.rank)
+        let thirdProp = propsForSurface[2]
+        XCTAssertEqual(3, thirdProp.rank)
+    }
+    
+    func testSortByRankSourceIsCorrectOrder() throws {
+        // setup
+        let propRank1Priority100 = Proposition(uniqueId: "rank1", scope: "inapp2", scopeDetails: ["rank": 1, "activity": [ "priority": 100 ]], items: [ getPropItemFile("inAppMessagePriority100")])
+        let propRank2Priority60 = Proposition(uniqueId: "rank2", scope: "inapp2", scopeDetails: ["rank": 2, "activity": [ "priority": 60 ]], items: [getPropItemFile("inAppMessagePriority60")])
+        let propRank3Priority20 = Proposition(uniqueId: "rank3", scope: "inapp2", scopeDetails: ["rank": 3, "activity": [ "priority": 20 ]], items: [getPropItemFile("inAppMessagePriority20")])
+        let propsPerSurface = [mockInAppSurfacev2!: [propRank1Priority100, propRank2Priority60, propRank3Priority20]]
+        
+        // test
+        let result = ParsedPropositions(with: propsPerSurface, requestedSurfaces: [mockInAppSurfacev2], runtime: mockRuntime)
+        
+        // verify
+        XCTAssertNotNil(result)
+        
+        // surfaceRulesBySchemaType is sorted properly
+        guard let inAppRules = result.surfaceRulesBySchemaType[.inapp],
+              let inAppRulesForSurface = inAppRules[mockInAppSurfacev2] else {
+            XCTFail("Unable to get rules for the requested surface.")
+            return
+        }
+        let firstRule = inAppRulesForSurface[0]
+        XCTAssertEqual("priority100", firstRule.consequences.first?.id)
+        let secondRule = inAppRulesForSurface[1]
+        XCTAssertEqual("priority60", secondRule.consequences.first?.id)
+        let thirdRule = inAppRulesForSurface[2]
+        XCTAssertEqual("priority20", thirdRule.consequences.first?.id)
+        
+        // propositionsToPersist is sorted properly
+        guard let propsForSurface = result.propositionsToPersist[mockInAppSurfacev2] else {
+            XCTFail("Unable to get propositions to persist for the requested surface.")
+            return
+        }
+        let firstProp = propsForSurface[0]
+        XCTAssertEqual(1, firstProp.rank)
+        let secondProp = propsForSurface[1]
+        XCTAssertEqual(2, secondProp.rank)
+        let thirdProp = propsForSurface[2]
+        XCTAssertEqual(3, thirdProp.rank)
+    }
+    
+    func testSortByRankSourceIsRandomOrder() throws {
+        // setup
+        let propRank1Priority100 = Proposition(uniqueId: "rank1", scope: "inapp2", scopeDetails: ["rank": 1, "activity": [ "priority": 100 ]], items: [ getPropItemFile("inAppMessagePriority100")])
+        let propRank2Priority60 = Proposition(uniqueId: "rank2", scope: "inapp2", scopeDetails: ["rank": 2, "activity": [ "priority": 60 ]], items: [getPropItemFile("inAppMessagePriority60")])
+        let propRank3Priority20 = Proposition(uniqueId: "rank3", scope: "inapp2", scopeDetails: ["rank": 3, "activity": [ "priority": 20 ]], items: [getPropItemFile("inAppMessagePriority20")])
+        let propsPerSurface = [mockInAppSurfacev2!: [propRank2Priority60, propRank1Priority100, propRank3Priority20]]
+        
+        // test
+        let result = ParsedPropositions(with: propsPerSurface, requestedSurfaces: [mockInAppSurfacev2], runtime: mockRuntime)
+        
+        // verify
+        XCTAssertNotNil(result)
+        
+        // surfaceRulesBySchemaType is sorted properly
+        guard let inAppRules = result.surfaceRulesBySchemaType[.inapp],
+              let inAppRulesForSurface = inAppRules[mockInAppSurfacev2] else {
+            XCTFail("Unable to get rules for the requested surface.")
+            return
+        }
+        let firstRule = inAppRulesForSurface[0]
+        XCTAssertEqual("priority100", firstRule.consequences.first?.id)
+        let secondRule = inAppRulesForSurface[1]
+        XCTAssertEqual("priority60", secondRule.consequences.first?.id)
+        let thirdRule = inAppRulesForSurface[2]
+        XCTAssertEqual("priority20", thirdRule.consequences.first?.id)
+        
+        // propositionsToPersist is sorted properly
+        guard let propsForSurface = result.propositionsToPersist[mockInAppSurfacev2] else {
+            XCTFail("Unable to get propositions to persist for the requested surface.")
+            return
+        }
+        let firstProp = propsForSurface[0]
+        XCTAssertEqual(1, firstProp.rank)
+        let secondProp = propsForSurface[1]
+        XCTAssertEqual(2, secondProp.rank)
+        let thirdProp = propsForSurface[2]
+        XCTAssertEqual(3, thirdProp.rank)
+    }
+    
+    private func getPropItemFile(_ fileName: String) -> PropositionItem {
+        let itemData = JSONFileLoader.getRulesJsonFromFile(fileName)
+        return PropositionItem(itemId: "inapp2", schema: rulesetSchema, itemData: itemData)
+    }
 }

--- a/AEPMessaging/Tests/UnitTests/PropositionTests.swift
+++ b/AEPMessaging/Tests/UnitTests/PropositionTests.swift
@@ -112,4 +112,60 @@ class PropositionTests: XCTestCase, AnyCodableAsserts {
         // verify
         XCTAssertNil(proposition)
     }
+    
+    func testPriorityIsAccessible() throws {
+        let mockCodeBasedContent = "<html><body>My custom content</body></html>"
+        let mockHtmlFormat: ContentType = .textHtml
+        let mockScopeDetailsString = "{\"activity\":{\"priority\":50}}"
+        let propositionJsonString = "{\"id\":\"\(mockPropositionId)\",\"scope\":\"\(mockScope)\",\"scopeDetails\":\(mockScopeDetailsString),\"items\":[{\"id\":\"\(mockItemId)\",\"schema\":\"\(mockHtmlSchema.toString())\",\"data\":{\"content\":\"\(mockCodeBasedContent)\",\"format\":\"\(mockHtmlFormat)\"}}]}"
+
+        // test
+       let proposition = getDecodedObject(fromString: propositionJsonString)
+        
+        // verify
+        XCTAssertNotNil(proposition)
+        XCTAssertEqual(50, proposition?.priority)
+    }
+    
+    func testPriorityDefaultValueZero() throws {
+        let mockCodeBasedContent = "<html><body>My custom content</body></html>"
+        let mockHtmlFormat: ContentType = .textHtml
+        let mockScopeDetailsString = "{\"key\":\"value\"}"
+        let propositionJsonString = "{\"id\":\"\(mockPropositionId)\",\"scope\":\"\(mockScope)\",\"scopeDetails\":\(mockScopeDetailsString),\"items\":[{\"id\":\"\(mockItemId)\",\"schema\":\"\(mockHtmlSchema.toString())\",\"data\":{\"content\":\"\(mockCodeBasedContent)\",\"format\":\"\(mockHtmlFormat)\"}}]}"
+
+        // test
+       let proposition = getDecodedObject(fromString: propositionJsonString)
+        
+        // verify
+        XCTAssertNotNil(proposition)
+        XCTAssertEqual(0, proposition?.priority)
+    }
+    
+    func testRankIsAccessible() throws {
+        let mockCodeBasedContent = "<html><body>My custom content</body></html>"
+        let mockHtmlFormat: ContentType = .textHtml
+        let mockScopeDetailsString = "{\"rank\":1}"
+        let propositionJsonString = "{\"id\":\"\(mockPropositionId)\",\"scope\":\"\(mockScope)\",\"scopeDetails\":\(mockScopeDetailsString),\"items\":[{\"id\":\"\(mockItemId)\",\"schema\":\"\(mockHtmlSchema.toString())\",\"data\":{\"content\":\"\(mockCodeBasedContent)\",\"format\":\"\(mockHtmlFormat)\"}}]}"
+
+        // test
+       let proposition = getDecodedObject(fromString: propositionJsonString)
+        
+        // verify
+        XCTAssertNotNil(proposition)
+        XCTAssertEqual(1, proposition?.rank)
+    }
+    
+    func testRankDefaultValueNegativeOne() throws {
+        let mockCodeBasedContent = "<html><body>My custom content</body></html>"
+        let mockHtmlFormat: ContentType = .textHtml
+        let mockScopeDetailsString = "{\"norank\":\"foundhere\"}"
+        let propositionJsonString = "{\"id\":\"\(mockPropositionId)\",\"scope\":\"\(mockScope)\",\"scopeDetails\":\(mockScopeDetailsString),\"items\":[{\"id\":\"\(mockItemId)\",\"schema\":\"\(mockHtmlSchema.toString())\",\"data\":{\"content\":\"\(mockCodeBasedContent)\",\"format\":\"\(mockHtmlFormat)\"}}]}"
+
+        // test
+       let proposition = getDecodedObject(fromString: propositionJsonString)
+        
+        // verify
+        XCTAssertNotNil(proposition)
+        XCTAssertEqual(-1, proposition?.rank)
+    }
 }

--- a/AEPMessaging/Tests/UnitTests/UITests/ContentCardUITests.swift
+++ b/AEPMessaging/Tests/UnitTests/UITests/ContentCardUITests.swift
@@ -38,6 +38,17 @@ class ContentCardUITests : XCTestCase, ContentCardUIEventListening {
         XCTAssertNil(contentCardUI?.listener)
     }
     
+    func test_contentCardUI_createInstance_priority() throws {
+        // setup
+        let proposition =  ContentCardTestUtil.createProposition(fromFile: "SmallImageTemplate", priority: 37)
+        
+        // test
+        let contentCardUI = ContentCardUI.createInstance(with: proposition, customizer: nil , listener: nil)
+        
+        // verify        
+        XCTAssertEqual(37, contentCardUI?.priority)
+    }
+    
     func test_contentCardUI_verifyMeta() throws {
         // setup
         let proposition =  ContentCardTestUtil.createProposition(fromFile: "SmallImageTemplate")

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/CardsView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/CardsView.swift
@@ -71,7 +71,8 @@ struct CardsView: View, ContentCardUIEventListening {
             showLoadingIndicator = false
             switch result {
             case .success(let cards):
-                savedCards = cards
+                // sort the cards by priority order and save them to our state property
+                savedCards = cards.sorted { $0.priority < $1.priority }
             case .failure(let error):
                 print(error)
             }

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/CardsView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/CardsView.swift
@@ -72,7 +72,7 @@ struct CardsView: View, ContentCardUIEventListening {
             switch result {
             case .success(let cards):
                 // sort the cards by priority order and save them to our state property
-                savedCards = cards.sorted { $0.priority < $1.priority }
+                savedCards = cards.sorted { $0.priority > $1.priority }
             case .failure(let error):
                 print(error)
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- MOB-22213 - Responses from IDS are now sorted by their `rank` values in the Proposition item
- MOB-22248 - `scopeDetails.activity.priority` field now exposed in `Proposition` and `ContentCardUI` classes

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
