### PR TITLE
Introducing AEPBundleImage 

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -218,8 +218,9 @@
 		B6165DAA29A67ADA0031B84D /* NotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B6165DA329A67AD90031B84D /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B631AE162A61336800E8B82E /* MessagingNotificationTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B631AE152A61336800E8B82E /* MessagingNotificationTrackingTests.swift */; };
 		B6389A492A9B32D400B72FB4 /* PushTrackingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6389A482A9B32D400B72FB4 /* PushTrackingStatus.swift */; };
-		B67CCF772CD08D5500CF08D1 /* AEPAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67CCF762CD08D4D00CF08D1 /* AEPAsyncImage.swift */; };
-		B67CCF792CD0BF8D00CF08D1 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67CCF782CD0BF8700CF08D1 /* ImageCache.swift */; };
+		B67CCF772CD08D5500CF08D1 /* AEPAsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67CCF762CD08D4D00CF08D1 /* AEPAsyncImageView.swift */; };
+		B67CCF792CD0BF8D00CF08D1 /* ContentCardImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67CCF782CD0BF8700CF08D1 /* ContentCardImageCache.swift */; };
+		B69573C82CD4447F0027E376 /* AEPBundleImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69573C72CD444790027E376 /* AEPBundleImageView.swift */; };
 		B6D6A02B265FB1FA005042BE /* Dictionary+Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928639FB263757A7000AFA53 /* Dictionary+Flatten.swift */; };
 		B6E63D042A9EC71C007BB586 /* PushTrackingStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E63D032A9EC71C007BB586 /* PushTrackingStatusTests.swift */; };
 		B6F7CBC92CC2089A00C35C64 /* DismissButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F7CBA72CC2089A00C35C64 /* DismissButtonStyle.swift */; };
@@ -665,8 +666,9 @@
 		B6165DA729A67ADA0031B84D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B631AE152A61336800E8B82E /* MessagingNotificationTrackingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingNotificationTrackingTests.swift; sourceTree = "<group>"; };
 		B6389A482A9B32D400B72FB4 /* PushTrackingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTrackingStatus.swift; sourceTree = "<group>"; };
-		B67CCF762CD08D4D00CF08D1 /* AEPAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPAsyncImage.swift; sourceTree = "<group>"; };
-		B67CCF782CD0BF8700CF08D1 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
+		B67CCF762CD08D4D00CF08D1 /* AEPAsyncImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPAsyncImageView.swift; sourceTree = "<group>"; };
+		B67CCF782CD0BF8700CF08D1 /* ContentCardImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardImageCache.swift; sourceTree = "<group>"; };
+		B69573C72CD444790027E376 /* AEPBundleImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPBundleImageView.swift; sourceTree = "<group>"; };
 		B6E63D032A9EC71C007BB586 /* PushTrackingStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTrackingStatusTests.swift; sourceTree = "<group>"; };
 		B6F7CB9C2CC2089A00C35C64 /* BaseTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTemplate.swift; sourceTree = "<group>"; };
 		B6F7CB9D2CC2089A00C35C64 /* ContentCardTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardTemplate.swift; sourceTree = "<group>"; };
@@ -1274,8 +1276,9 @@
 		B6F7CBAC2CC2089A00C35C64 /* AEPImage */ = {
 			isa = PBXGroup;
 			children = (
-				B67CCF782CD0BF8700CF08D1 /* ImageCache.swift */,
-				B67CCF762CD08D4D00CF08D1 /* AEPAsyncImage.swift */,
+				B69573C72CD444790027E376 /* AEPBundleImageView.swift */,
+				B67CCF762CD08D4D00CF08D1 /* AEPAsyncImageView.swift */,
+				B67CCF782CD0BF8700CF08D1 /* ContentCardImageCache.swift */,
 				B6F7CBA92CC2089A00C35C64 /* AEPImage.swift */,
 				B6F7CBAA2CC2089A00C35C64 /* AEPImageView.swift */,
 				B6F7CBAB2CC2089A00C35C64 /* ImageSourceType.swift */,
@@ -2440,7 +2443,7 @@
 				B6F7CBCB2CC2089A00C35C64 /* AEPVStackView.swift in Sources */,
 				B6F7CBCC2CC2089A00C35C64 /* AEPVStack.swift in Sources */,
 				B6F7CBCD2CC2089A00C35C64 /* TemplateBuilder.swift in Sources */,
-				B67CCF772CD08D5500CF08D1 /* AEPAsyncImage.swift in Sources */,
+				B67CCF772CD08D5500CF08D1 /* AEPAsyncImageView.swift in Sources */,
 				B6F7CBCE2CC2089A00C35C64 /* AEPDismissButton.swift in Sources */,
 				B6F7CBCF2CC2089A00C35C64 /* ContentCardUIEventListening.swift in Sources */,
 				B6F7CBD02CC2089A00C35C64 /* ContentCardUI+EventHandler.swift in Sources */,
@@ -2481,7 +2484,7 @@
 				09B071E82A64D80E00F259C1 /* Bundle+Messaging.swift in Sources */,
 				245059A72673FAC700CC7CA0 /* Event+Messaging.swift in Sources */,
 				244E9584268262C8001DC957 /* Message.swift in Sources */,
-				B67CCF792CD0BF8D00CF08D1 /* ImageCache.swift in Sources */,
+				B67CCF792CD0BF8D00CF08D1 /* ContentCardImageCache.swift in Sources */,
 				244E955B267BB253001DC957 /* Dictionary+Messaging.swift in Sources */,
 				0969D6402A7A9DC600A00BF7 /* MessagingMigrator.swift in Sources */,
 				090290C929DD11EA00388226 /* RuleConsequence+Messaging.swift in Sources */,
@@ -2491,6 +2494,7 @@
 				242920F82AD06791000DB2CD /* RulesetSchemaData.swift in Sources */,
 				241B2DD42821C80C00E4FF67 /* URL+QueryParams.swift in Sources */,
 				245059A22673FAC200CC7CA0 /* Messaging.swift in Sources */,
+				B69573C82CD4447F0027E376 /* AEPBundleImageView.swift in Sources */,
 				B6389A492A9B32D400B72FB4 /* PushTrackingStatus.swift in Sources */,
 				09F5D9402B5CF35F00117437 /* PropositionInteraction.swift in Sources */,
 			);

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -32,7 +32,7 @@ enum MessagingConstants {
 
     enum Caches {
         static let CACHE_NAME = "com.adobe.messaging.cache"
-        static let CONTENT_CARD_CACHE = "com.adobe.messaging.contentcard.ui.cache"
+        static let CONTENT_CARD_UI_CACHE = "com.adobe.messaging.contentcard.ui.cache"
         static let PROPOSITIONS = "propositions"
         static let PATH = "PATH"
     }

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -32,7 +32,7 @@ enum MessagingConstants {
 
     enum Caches {
         static let CACHE_NAME = "com.adobe.messaging.cache"
-        static let UI_CACHE_NAME = "com.adobe.messaging.ui.cache"
+        static let CONTENT_CARD_CACHE = "com.adobe.messaging.contentcard.ui.cache"
         static let PROPOSITIONS = "propositions"
         static let PATH = "PATH"
     }

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -32,7 +32,7 @@ enum MessagingConstants {
 
     enum Caches {
         static let CACHE_NAME = "com.adobe.messaging.cache"
-        static let CONTENT_CARD_UI_CACHE = "com.adobe.messaging.contentcard.ui.cache"
+        static let CONTENT_CARD_UI_CACHE_NAME = "com.adobe.messaging.contentcard.ui.cache"
         static let PROPOSITIONS = "propositions"
         static let PATH = "PATH"
     }

--- a/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPAsyncImageView.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPAsyncImageView.swift
@@ -18,12 +18,9 @@
 /// Use this view for displaying images from remote URLs, caching them to reduce redundant network requests,
 /// and seamlessly handling dark/light mode updates.
 @available(iOS 15.0, *)
-struct AEPAsyncImage<Content>: View where Content: View {
-    /// The URL of the image to load in light mode.
-    private let lightModeURL: URL
-
-    /// The URL of the image to load in dark mode.
-    private let darkModeURL: URL?
+struct AEPAsyncImageView<Content>: View where Content: View {
+    /// The model containing the data about the image.
+    private let model: AEPImage
 
     /// A closure that takes an `AsyncImagePhase` and returns a SwiftUI `View` for each phase.
     /// This provides flexibility in displaying loading indicators, fallback images, or the downloaded image.
@@ -38,13 +35,11 @@ struct AEPAsyncImage<Content>: View where Content: View {
     /// Initializes the `AEPAsyncImage` with a URL and content closure.
     ///
     /// - Parameters:
-    ///   - url: The URL of the image to load.
+    ///   - model: The AEPImage model class that contains data to populate the image
     ///   - content: A closure that defines the view to display for each image loading phase.
-    init(lightModeURL: URL,
-         darkModeURL: URL? = nil,
+    init(_ model: AEPImage,
          @ViewBuilder content: @escaping (AsyncImagePhase) -> Content) {
-        self.lightModeURL = lightModeURL
-        self.darkModeURL = darkModeURL
+        self.model = model
         self.content = content
     }
 
@@ -65,11 +60,11 @@ struct AEPAsyncImage<Content>: View where Content: View {
     /// - Parameter colorScheme: The `ColorScheme` that determines whether to use light or dark mode URL.
     private func loadImage(for colorScheme: ColorScheme) {
         // Determine the URL to use based on color scheme, defaulting to lightModeURL if darkModeURL is nil.
-        let currentURL = (colorScheme == .dark ? darkModeURL : lightModeURL) ?? lightModeURL
-        if let cachedImage = ImageCache[currentURL] {
+        let url = themeBasedURL(colorScheme)
+        if let cachedImage = ContentCardImageCache[url] {
             phase = .success(Image(uiImage: cachedImage))
         } else {
-            downloadImage(from: currentURL)
+            downloadImage(from: url)
         }
     }
 
@@ -86,7 +81,7 @@ struct AEPAsyncImage<Content>: View where Content: View {
             }
 
             if let data = data, let image = UIImage(data: data) {
-                ImageCache[url] = image
+                ContentCardImageCache[url] = image
                 DispatchQueue.main.async {
                     phase = .success(Image(uiImage: image))
                 }
@@ -96,5 +91,17 @@ struct AEPAsyncImage<Content>: View where Content: View {
                 }
             }
         }.resume()
+    }
+
+    /// Determines the appropriate URL for the image based on the device's color scheme.
+    /// - Parameter colorScheme: The `ColorScheme` that determines whether to use light or dark mode URL.
+    ///
+    /// - Returns: The URL to be used for the image.
+    private func themeBasedURL(_ colorScheme: ColorScheme) -> URL {
+        if colorScheme == .dark {
+            return model.darkUrl ?? model.url!
+        } else {
+            return model.url!
+        }
     }
 }

--- a/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPAsyncImageView.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPAsyncImageView.swift
@@ -32,7 +32,7 @@ struct AEPAsyncImageView<Content>: View where Content: View {
     /// The color scheme environment variable to detect light/dark mode changes and reload the image if needed.
     @Environment(\.colorScheme) private var colorScheme
 
-    /// Initializes the `AEPAsyncImage` with a URL and content closure.
+    /// Initializes the `AEPAsyncImage` with a AEPImage model class  and content closure.
     ///
     /// - Parameters:
     ///   - model: The AEPImage model class that contains data to populate the image
@@ -59,7 +59,7 @@ struct AEPAsyncImageView<Content>: View where Content: View {
     ///
     /// - Parameter colorScheme: The `ColorScheme` that determines whether to use light or dark mode URL.
     private func loadImage(for colorScheme: ColorScheme) {
-        // Determine the URL to use based on color scheme, defaulting to lightModeURL if darkModeURL is nil.
+        // Determine the URL to use based on color scheme
         let url = themeBasedURL(colorScheme)
         if let cachedImage = ContentCardImageCache[url] {
             phase = .success(Image(uiImage: cachedImage))

--- a/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPBundleImageView.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPBundleImageView.swift
@@ -1,0 +1,44 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+#if canImport(SwiftUI)
+    import SwiftUI
+#endif
+
+@available(iOS 15.0, *)
+struct AEPBundleImageView: View {
+    /// The model containing the data about the image.
+    private let model: AEPImage
+
+    /// The color scheme environment variable to detect light/dark mode changes and reload the image if needed.
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(_ model: AEPImage) {
+        self.model = model
+    }
+
+    var body: some View {
+        Image(themeBasedBundledImage())
+            .resizable()
+            .aspectRatio(contentMode: model.contentMode)
+    }
+
+    /// Determines the appropriate bundle resource for the image based on the color scheme of the device.
+    /// - Returns: The name of the bundle resource to be used for the image.
+    private func themeBasedBundledImage() -> String {
+        if colorScheme == .dark {
+            return model.darkBundle ?? model.bundle!
+        } else {
+            return model.bundle!
+        }
+    }
+}

--- a/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPBundleImageView.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPBundleImageView.swift
@@ -19,7 +19,7 @@ struct AEPBundleImageView: View {
     /// The model containing the data about the image.
     private let model: AEPImage
 
-    /// The color scheme environment variable to detect light/dark mode changes and reload the image if needed.
+    /// The color scheme environment variable to detect light/dark mode changes and reload the bundled image if needed.
     @Environment(\.colorScheme) private var colorScheme
 
     init(_ model: AEPImage) {

--- a/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPImageView.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/AEPImageView.swift
@@ -23,9 +23,6 @@ struct AEPImageView: View {
     /// The model containing the data about the image.
     @ObservedObject var model: AEPImage
 
-    /// The environment’s color scheme (light or dark mode).
-    @Environment(\.colorScheme) var colorScheme
-
     /// Initializes a new instance of `AEPImageView` with the provided model
     /// - Parameter model: The `AEPImage` model containing information about the image to display.
     init(model: AEPImage) {
@@ -37,7 +34,7 @@ struct AEPImageView: View {
         Group {
             switch model.imageSourceType {
             case .url:
-                AEPAsyncImage(lightModeURL: model.url!, darkModeURL: model.darkUrl) { phase in
+                AEPAsyncImageView(model) { phase in
                     if let image = phase.image {
                         // the actual image on successful download
                         image.resizable()
@@ -52,9 +49,7 @@ struct AEPImageView: View {
                 }
 
             case .bundle:
-                Image(themeBasedBundledImage())
-                    .resizable()
-                    .aspectRatio(contentMode: model.contentMode)
+                AEPBundleImageView(model)
 
             case .icon:
                 safeIconImage(icon: model.icon)
@@ -64,26 +59,6 @@ struct AEPImageView: View {
         }.applyModifier(model.modifier)
             .accessibilityHidden(model.altText == nil)
             .accessibilityLabel(model.altText ?? "")
-    }
-
-    /// Determines the appropriate URL for the image based on the device's color scheme.
-    /// - Returns: The URL to be used for the image.
-    private func themeBasedURL() -> URL {
-        if colorScheme == .dark {
-            return model.darkUrl ?? model.url!
-        } else {
-            return model.url!
-        }
-    }
-
-    /// Determines the appropriate bundle resource for the image based on the color scheme of the device.
-    /// - Returns: The name of the bundle resource to be used for the image.
-    private func themeBasedBundledImage() -> String {
-        if colorScheme == .dark {
-            return model.darkBundle ?? model.bundle!
-        } else {
-            return model.bundle!
-        }
     }
 
     /// Returns a system icon image or an empty view.

--- a/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/ContentCardImageCache.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/ContentCardImageCache.swift
@@ -20,7 +20,7 @@
 @available(iOS 15.0, *)
 enum ContentCardImageCache {
     /// The underlying cache used for storing images.
-    private static let cache = Cache(name: MessagingConstants.Caches.CONTENT_CARD_UI_CACHE)
+    private static let cache = Cache(name: MessagingConstants.Caches.CONTENT_CARD_UI_CACHE_NAME)
 
     /// Accessor to retrieve or store images in the cache by URL.
     ///

--- a/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/ContentCardImageCache.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/ContentCardImageCache.swift
@@ -16,11 +16,11 @@
     import SwiftUI
 #endif
 
-/// A utility class that manages caching of images associated with specific URLs.
+/// A utility class that manages caching of content card images associated with specific URLs.
 @available(iOS 15.0, *)
-enum ImageCache {
+enum ContentCardImageCache {
     /// The underlying cache used for storing images.
-    private static let cache = Cache(name: MessagingConstants.Caches.CONTENT_CARD_CACHE)
+    private static let cache = Cache(name: MessagingConstants.Caches.CONTENT_CARD_UI_CACHE)
 
     /// Accessor to retrieve or store images in the cache by URL.
     ///

--- a/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/ImageCache.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/UIElement/AEPImage/ImageCache.swift
@@ -20,7 +20,7 @@
 @available(iOS 15.0, *)
 enum ImageCache {
     /// The underlying cache used for storing images.
-    private static let cache = Cache(name: MessagingConstants.Caches.UI_CACHE_NAME)
+    private static let cache = Cache(name: MessagingConstants.Caches.CONTENT_CARD_CACHE)
 
     /// Accessor to retrieve or store images in the cache by URL.
     ///


### PR DESCRIPTION
- Move all the logic behind ColorScheme from AEPImageView to AEPBundleImageView and AEPAsynImageView
- Removed ColorScheme environment var from AEPImageVIew ,hence  AEPImageView will not reload when the color scheme changes

- Renamed AEPAsynImage -> AEPAsyncImageView
- Renamed ImageCache -> ContentCardImageCache
- New cache folder  -> com.adobe.messaging.contentcard.ui.cache