### PR TITLE
Push to inapp support - new public api for closure on updatePropositions call

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		24CA4BDD2B61972500D16369 /* PropositionItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDC2B61972500D16369 /* PropositionItemTests.swift */; };
 		24CA4BDF2B61974300D16369 /* PropositionInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDE2B61974300D16369 /* PropositionInteractionTests.swift */; };
 		24CA4BE12B61977800D16369 /* SurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BE02B61977800D16369 /* SurfaceTests.swift */; };
+		24FD5F752CEEA50F00AE4567 /* CompletionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FD5F742CEEA50400AE4567 /* CompletionHandler.swift */; };
 		2B2B7A6E0F7CD6312D28421A /* Pods_FunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD29CE4BC879CE75AFEFF0D5 /* Pods_FunctionalTests.framework */; };
 		44DFBD558578CFDCD4A9A476 /* Pods_E2EFunctionalTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A44BD44CB3A7DA5EBB972652 /* Pods_E2EFunctionalTestApp.framework */; };
 		56B08B522365B6DC2B556B40 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D685E0AE5C614B4788DE869A /* Pods_UnitTests.framework */; };
@@ -621,6 +622,7 @@
 		24CA4BDE2B61974300D16369 /* PropositionInteractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropositionInteractionTests.swift; sourceTree = "<group>"; };
 		24CA4BE02B61977800D16369 /* SurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTests.swift; sourceTree = "<group>"; };
 		24EE301D28FF61F0005E417C /* InAppMessagingEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessagingEventTests.swift; sourceTree = "<group>"; };
+		24FD5F742CEEA50400AE4567 /* CompletionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionHandler.swift; sourceTree = "<group>"; };
 		28E46BC7A8F3939CF2DDDC8F /* Pods_MessagingDemoAppObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MessagingDemoAppObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		38F4A4735D3FB26229C244BC /* Pods-MessagingDemoApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MessagingDemoApp.release.xcconfig"; path = "Target Support Files/Pods-MessagingDemoApp/Pods-MessagingDemoApp.release.xcconfig"; sourceTree = "<group>"; };
 		3908C9B2C6C8F309DF735FAF /* Pods-MessagingDemoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MessagingDemoApp.debug.xcconfig"; path = "Target Support Files/Pods-MessagingDemoApp/Pods-MessagingDemoApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1063,6 +1065,7 @@
 				B6F7CBC82CC2089A00C35C64 /* UI */,
 				242920F62AD0628B000DB2CD /* Schemas */,
 				92315435261E3B36004AE7D3 /* AEPMessaging.h */,
+				24FD5F742CEEA50400AE4567 /* CompletionHandler.swift */,
 				246EF0632C013DED002A9B22 /* ContentCard.swift */,
 				090290C429DCED0B00388226 /* ContentCardRulesEngine.swift */,
 				244FEA4729B8E2950058FA1C /* Feed.swift */,
@@ -2488,6 +2491,7 @@
 				244E954B267BAEBE001DC957 /* Messaging+EdgeEvents.swift in Sources */,
 				09B071F62A7318CB00F259C1 /* Array+Messaging.swift in Sources */,
 				244FEA4829B8E2950058FA1C /* Feed.swift in Sources */,
+				24FD5F752CEEA50F00AE4567 /* CompletionHandler.swift in Sources */,
 				246EF0642C013DED002A9B22 /* ContentCard.swift in Sources */,
 				240316B82A83DDD80016B0D9 /* Cache+Messaging.swift in Sources */,
 				245059522671283F00CC7CA0 /* MessagingRulesEngine.swift in Sources */,

--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		244E9555267BB018001DC957 /* String+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244E9554267BB018001DC957 /* String+JSON.swift */; };
 		244E955B267BB253001DC957 /* Dictionary+Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244E955A267BB253001DC957 /* Dictionary+Messaging.swift */; };
 		244E9584268262C8001DC957 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244E9583268262C7001DC957 /* Message.swift */; };
+		244F19052D0106C2009F0209 /* CompletionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244F19042D0106BA009F0209 /* CompletionHandlerTests.swift */; };
 		244FEA4429B6A1060058FA1C /* FeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244FEA4329B6A1060058FA1C /* FeedItem.swift */; };
 		244FEA4629B6A5D30058FA1C /* FeedItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244FEA4529B6A5D30058FA1C /* FeedItemTests.swift */; };
 		244FEA4829B8E2950058FA1C /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244FEA4729B8E2950058FA1C /* Feed.swift */; };
@@ -558,6 +559,7 @@
 		244E9554267BB018001DC957 /* String+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+JSON.swift"; sourceTree = "<group>"; };
 		244E955A267BB253001DC957 /* Dictionary+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Messaging.swift"; sourceTree = "<group>"; };
 		244E9583268262C7001DC957 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		244F19042D0106BA009F0209 /* CompletionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionHandlerTests.swift; sourceTree = "<group>"; };
 		244FEA4329B6A1060058FA1C /* FeedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedItem.swift; sourceTree = "<group>"; };
 		244FEA4529B6A5D30058FA1C /* FeedItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedItemTests.swift; sourceTree = "<group>"; };
 		244FEA4729B8E2950058FA1C /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
@@ -1060,10 +1062,10 @@
 		92315433261E3B36004AE7D3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				B6F7CC5F2CC7089200C35C64 /* Enum */,
 				B6F7CC5E2CC7081E00C35C64 /* ClassExtensions */,
-				B6F7CBC82CC2089A00C35C64 /* UI */,
+				B6F7CC5F2CC7089200C35C64 /* Enum */,
 				242920F62AD0628B000DB2CD /* Schemas */,
+				B6F7CBC82CC2089A00C35C64 /* UI */,
 				92315435261E3B36004AE7D3 /* AEPMessaging.h */,
 				24FD5F742CEEA50400AE4567 /* CompletionHandler.swift */,
 				246EF0632C013DED002A9B22 /* ContentCard.swift */,
@@ -1115,6 +1117,7 @@
 				24CA4BCE2B617AA900D16369 /* Array+MessagingTests.swift */,
 				24CA4BD02B617AC800D16369 /* Bundle+MessagingTests.swift */,
 				24CA4BD22B617AED00D16369 /* Cache+MessagingTests.swift */,
+				244F19042D0106BA009F0209 /* CompletionHandlerTests.swift */,
 				246EF0652C06803B002A9B22 /* ContentCardTests.swift */,
 				24CA4BD42B6195A500D16369 /* ContentCardRulesEngineTests.swift */,
 				243EA6C82733258600195945 /* Dictionary+MessagingTests.swift */,
@@ -1454,15 +1457,15 @@
 		B6F7CC5E2CC7081E00C35C64 /* ClassExtensions */ = {
 			isa = PBXGroup;
 			children = (
-				241B2DD32821C80C00E4FF67 /* URL+QueryParams.swift */,
-				240316B72A83DDD80016B0D9 /* Cache+Messaging.swift */,
 				09B071F52A7318CB00F259C1 /* Array+Messaging.swift */,
 				09B071E72A64D80E00F259C1 /* Bundle+Messaging.swift */,
+				240316B72A83DDD80016B0D9 /* Cache+Messaging.swift */,
 				244E955A267BB253001DC957 /* Dictionary+Messaging.swift */,
+				923155762620FC53004AE7D3 /* Event+Messaging.swift */,
 				090290C829DD11EA00388226 /* RuleConsequence+Messaging.swift */,
 				240F71FA26868F7100846587 /* SharedStateResult+Messaging.swift */,
-				923155762620FC53004AE7D3 /* Event+Messaging.swift */,
 				244E9554267BB018001DC957 /* String+JSON.swift */,
+				241B2DD32821C80C00E4FF67 /* URL+QueryParams.swift */,
 			);
 			path = ClassExtensions;
 			sourceTree = "<group>";
@@ -1470,8 +1473,8 @@
 		B6F7CC5F2CC7089200C35C64 /* Enum */ = {
 			isa = PBXGroup;
 			children = (
-				B6389A482A9B32D400B72FB4 /* PushTrackingStatus.swift */,
 				244C2BD726B36480008F086A /* MessagingEdgeEventType.swift */,
+				B6389A482A9B32D400B72FB4 /* PushTrackingStatus.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -2546,6 +2549,7 @@
 				240436CE2C76685C008CCD6D /* MockProposition.swift in Sources */,
 				243EA6D42733261E00195945 /* MessagingEdgeEventTypeTests.swift in Sources */,
 				24CA4BD32B617AED00D16369 /* Cache+MessagingTests.swift in Sources */,
+				244F19052D0106C2009F0209 /* CompletionHandlerTests.swift in Sources */,
 				2402745E29FC424000884DFE /* TestableMessagingDelegate.swift in Sources */,
 				243EA6CF273325CC00195945 /* Message+FullscreenMessageDelegateTests.swift in Sources */,
 				245059712673DBFE00CC7CA0 /* MessagingTests.swift in Sources */,

--- a/AEPMessaging/Sources/CompletionHandler.swift
+++ b/AEPMessaging/Sources/CompletionHandler.swift
@@ -16,7 +16,7 @@ struct CompletionHandler {
     var originatingEventId: UUID?
     var edgeRequestEventId: UUID?
     var handle: ((Bool) -> Void)?
-    
+
     init(originatingEvent: Event, handler: @escaping ((Bool) -> Void)) {
         originatingEventId = originatingEvent.id
         handle = handler

--- a/AEPMessaging/Sources/CompletionHandler.swift
+++ b/AEPMessaging/Sources/CompletionHandler.swift
@@ -1,0 +1,24 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import AEPCore
+
+struct CompletionHandler {
+    var originatingEventId: UUID?
+    var edgeRequestEventId: UUID?
+    var handle: ((Bool) -> Void)?
+    
+    init(originatingEvent: Event, handler: @escaping ((Bool) -> Void)) {
+        originatingEventId = originatingEvent.id
+        handle = handler
+    }
+}

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -48,14 +48,11 @@ import UserNotifications
                 Messaging.updatePropositionsForSurfaces([iamSurface]) { success in
                     if success {
                         // send the event to trigger the in-app notification
-                        
-                        let event = Event(name: "Push to in-app",
-                                          type: EventType.edge,
+                        let event = Event(name: MessagingConstants.Event.Name.PUSH_TO_IN_APP,
+                                          type: EventType.rulesEngine,
                                           source: EventSource.requestContent,
                                           data: [
-                                              MessagingConstants.XDM.Key.XDM: [
-                                                  MessagingConstants.XDM.Key.PUSH_TO_INAPP: pushToInappIdentifier
-                                              ]
+                                              MessagingConstants.XDM.Key.PUSH_TO_INAPP: pushToInappIdentifier
                                           ])
                         
                         MobileCore.dispatch(event: event)

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -38,7 +38,7 @@ import UserNotifications
             closure?(.noTrackingData)
             return
         }
-        
+
         // check for a deeplink to an in-app message
         let pushToInappIdentifier = notificationRequest.content.userInfo[MessagingConstants.XDM.Key.PUSH_TO_INAPP] as? String
         if let pushToInappIdentifier = pushToInappIdentifier {
@@ -54,7 +54,7 @@ import UserNotifications
                                           data: [
                                               MessagingConstants.XDM.Key.PUSH_TO_INAPP: pushToInappIdentifier
                                           ])
-                        
+
                         MobileCore.dispatch(event: event)
                     }
                 }
@@ -99,20 +99,28 @@ import UserNotifications
     }
 
     // MARK: Personalization via Surfaces
-    
+
     /// Dispatches an event to fetch propositions for the provided surfaces from remote.
-    /// If provided, `completion` will be called once the Messaging extension has fully processed the network response from Konductor.
     /// - Parameters:
     ///   - surfaces: An array of `Surface` objects.
-    ///   - completion: An optional completion handler to be called once the proposition response has been processed by the Messaging extension
-    static func updatePropositionsForSurfaces(_ surfaces: [Surface], _ completion: ((Bool) -> Void)? = nil) {
+    static func updatePropositionsForSurfaces(_ surfaces: [Surface]) {
+        updatePropositionsForSurfaces(surfaces, nil)
+    }
+
+    /// Dispatches an event to fetch propositions for the provided surfaces from remote.
+    /// If provided, `closure` will be called once the Messaging extension has fully processed the network response from Konductor.
+    /// - Parameters:
+    ///   - surfaces: An array of `Surface` objects.
+    ///   - closure: An optional completion handler to be called once the proposition response has been processed by the Messaging extension
+    @objc(updatePropositionsForSurfaces:closure:)
+    static func updatePropositionsForSurfaces(_ surfaces: [Surface], _ closure: ((Bool) -> Void)? = nil) {
         let validSurfaces = surfaces
             .filter { $0.isValid }
 
         guard !validSurfaces.isEmpty else {
             Log.warning(label: MessagingConstants.LOG_TAG,
                         "Cannot update propositions as the provided surfaces array has no valid items.")
-            completion?(false)
+            closure?(false)
             return
         }
 
@@ -127,10 +135,10 @@ import UserNotifications
                           data: eventData)
 
         // create a CompletionHandler if a callback was provided
-        if let completion = completion {
+        if let completion = closure {
             completionHandlers.append(CompletionHandler(originatingEvent: event, handler: completion))
         }
-        
+
         MobileCore.dispatch(event: event)
     }
 

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -16,14 +16,13 @@ import Foundation
 
 @objc(AEPMobileMessaging)
 public class Messaging: NSObject, Extension {
-    
     private static let handlerLock = NSLock()
     private static var _completionHandlers: [CompletionHandler] = []
     static var completionHandlers: [CompletionHandler] {
         get { handlerLock.withLock { _completionHandlers } }
         set { handlerLock.withLock { _completionHandlers = newValue } }
     }
-    
+
     // MARK: - Class members
 
     public static var extensionVersion: String = MessagingConstants.EXTENSION_VERSION
@@ -407,8 +406,6 @@ public class Messaging: NSObject, Extension {
             }
         }
     }
-    
-    
 
     /// Generates and dispatches an event prompting the Edge extension to fetch propositions (in-app, content cards, or code-based experiences).
     ///
@@ -419,10 +416,9 @@ public class Messaging: NSObject, Extension {
     ///   - event - parent event requesting that the messages be fetched. Used for event chaining to help with debugging.
     ///   - surfaces: an array of surface path strings for fetching propositions, if available.
     private func fetchPropositions(_ event: Event, for surfaces: [Surface]? = nil) {
-        
         // check for completion handler for requesting event
         let handler = completionHandlerFor(originatingEventId: event.id)
-        
+
         var requestedSurfaces: [Surface] = []
 
         // if surfaces are provided, use them - otherwise assume the request is for base surface (mobileapp://{bundle identifier})
@@ -481,7 +477,7 @@ public class Messaging: NSObject, Extension {
 
         // create entries in our local containers for managing streamed responses from edge
         beginRequestFor(newEvent, with: requestedSurfaces)
-        
+
         if var handler = handler {
             handler.edgeRequestEventId = newEvent.id
             Messaging.completionHandlers.append(handler)
@@ -604,7 +600,7 @@ public class Messaging: NSObject, Extension {
 
         // clear pending propositions
         inProgressPropositions.removeAll()
-        
+
         // call the handler if we have one
         if let handler = completionHandlerFor(edgeRequestEventId: UUID(uuidString: eventId)) {
             handler.handle?(true)
@@ -795,27 +791,27 @@ public class Messaging: NSObject, Extension {
     func propositionInfoFor(messageId: String) -> PropositionInfo? {
         propositionInfo[messageId]
     }
-    
+
     /// Removes and returns a `CompletionHandler` for the provided originatingEventId
     private func completionHandlerFor(originatingEventId: UUID?) -> CompletionHandler? {
-        let handlerIndex = Messaging.completionHandlers.firstIndex() { $0.originatingEventId == originatingEventId }
+        let handlerIndex = Messaging.completionHandlers.firstIndex { $0.originatingEventId == originatingEventId }
         if let index = handlerIndex {
             return Messaging.completionHandlers.remove(at: index)
         }
-        
+
         return nil
     }
-    
+
     /// Removes and returns a `CompletionHandler` for the provided edgeRequestEventId
     private func completionHandlerFor(edgeRequestEventId: UUID?) -> CompletionHandler? {
-        let handlerIndex = Messaging.completionHandlers.firstIndex() { $0.edgeRequestEventId == edgeRequestEventId }
+        let handlerIndex = Messaging.completionHandlers.firstIndex { $0.edgeRequestEventId == edgeRequestEventId }
         if let index = handlerIndex {
             return Messaging.completionHandlers.remove(at: index)
         }
-        
+
         return nil
     }
-    
+
     // MARK: - debug methods below are used for testing purposes only
 
     #if DEBUG

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -816,16 +816,6 @@ public class Messaging: NSObject, Extension {
         return nil
     }
     
-    private func updateHandlerFor(originatingEventId: UUID, with edgeRequestEventId: UUID) {
-        if var handler = completionHandlerFor(originatingEventId: originatingEventId) {
-            let index = Messaging.completionHandlers.firstIndex() { $0.originatingEventId == originatingEventId }
-            if let index = index {
-                Messaging.completionHandlers.remove(at: index)
-                handler.edgeRequestEventId = edgeRequestEventId
-            }
-        }
-    }
-    
     // MARK: - debug methods below are used for testing purposes only
 
     #if DEBUG

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -209,6 +209,7 @@ enum MessagingConstants {
             static let DATA = "data"
             static let REQUEST = "request"
             static let SEND_COMPLETION = "sendCompletion"
+            static let PUSH_TO_INAPP = "adb_iamId"
         }
 
         enum Inbound {

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -210,7 +210,6 @@ enum MessagingConstants {
             static let DATA = "data"
             static let REQUEST = "request"
             static let SEND_COMPLETION = "sendCompletion"
-            static let PUSH_TO_INAPP = "adb_iamId"
         }
 
         enum Inbound {
@@ -310,6 +309,7 @@ enum MessagingConstants {
     enum PushNotification {
         enum UserInfoKey {
             static let ACTION_URL = "adb_uri"
+            static let PUSH_TO_INAPP = "adb_iamId"
         }
     }
 }

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -70,6 +70,7 @@ enum MessagingConstants {
             static let FINALIZE_PROPOSITIONS_RESPONSE = "Finalize propositions response"
             static let PUSH_TRACKING_STATUS = "Push tracking status event"
             static let EVENT_HISTORY_WRITE = "Write IAM event to history"
+            static let PUSH_TO_IN_APP = "Push to in-app"
         }
 
         enum Source {

--- a/AEPMessaging/Tests/UnitTests/CompletionHandlerTests.swift
+++ b/AEPMessaging/Tests/UnitTests/CompletionHandlerTests.swift
@@ -1,0 +1,78 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+import XCTest
+
+@testable import AEPMessaging
+import AEPServices
+
+class CompletionHandlerTests: XCTestCase {
+    func testConstructorHappy() throws {
+        // setup
+        var handlerParam: Bool = false
+        let handler: ((Bool) -> Void) = { bool in
+            handlerParam = bool
+        }
+        let event = Event(name: "name", type: "type", source: "source", data: nil)
+        
+        // test
+        let completionHandler = CompletionHandler(originatingEvent: event, handler: handler)
+        
+        // verify
+        XCTAssertNotNil(completionHandler.originatingEventId)
+        XCTAssertEqual(event.id, completionHandler.originatingEventId)
+        XCTAssertNotNil(completionHandler.handle)
+        completionHandler.handle?(true)
+        XCTAssertTrue(handlerParam)
+        XCTAssertNil(completionHandler.edgeRequestEventId)
+    }
+        
+    func testOriginalEventIdOptional() throws {
+        // setup
+        let handler: ((Bool) -> Void) = { bool in }
+        let event = Event(name: "name", type: "type", source: "source", data: nil)
+        var completionHandler = CompletionHandler(originatingEvent: event, handler: handler)
+        
+        // test
+        completionHandler.originatingEventId = nil
+        
+        // verify
+        XCTAssertNil(completionHandler.originatingEventId)
+    }
+       
+    func testEdgeRequestEventIdOptional() throws {
+        // setup
+        let handler: ((Bool) -> Void) = { bool in }
+        let event = Event(name: "name", type: "type", source: "source", data: nil)
+        var completionHandler = CompletionHandler(originatingEvent: event, handler: handler)
+        
+        // test
+        completionHandler.edgeRequestEventId = nil
+        
+        // verify
+        XCTAssertNil(completionHandler.edgeRequestEventId)
+    }
+        
+    func testHandleOptional() throws {
+        // setup
+        let handler: ((Bool) -> Void) = { bool in }
+        let event = Event(name: "name", type: "type", source: "source", data: nil)
+        var completionHandler = CompletionHandler(originatingEvent: event, handler: handler)
+        
+        // test
+        completionHandler.handle = nil
+        
+        // verify
+        XCTAssertNil(completionHandler.handle)
+    }
+}

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -34,8 +34,8 @@ class MessagingPublicApiTest: XCTestCase, AnyCodableAsserts {
     }
     
     override func tearDown() {
-        resetNotificationCategories()        
-        EventHub.reset()
+        resetNotificationCategories()
+        MobileCore.resetSDK()
     }
     
     private func registerMockExtension<T: Extension>(_ type: T.Type) {
@@ -287,6 +287,28 @@ class MessagingPublicApiTest: XCTestCase, AnyCodableAsserts {
         
         // verify expectation
         wait(for: [eventExpectation], timeout: ASYNC_TIMEOUT)
+    }
+    
+    func testHandleNotificationResponse_when_userInfoHasPushToInapp_then_updatePropositionsCalled() throws {
+        // setup
+        let iamId = "mockIamId"
+        var trackingData = MessagingPublicApiTest.MOCK_TRACKING_DETAILS
+        trackingData["adb_iamId"] = iamId
+        let notificationResponse = createNotificationResponse(trackingData: trackingData)
+                
+        // register listener for update propositions call
+        let updatePropositionsExpectation = XCTestExpectation(description: "UpdatePropositions should be called")
+        MobileCore.registerEventListener(type: EventType.messaging, source: EventSource.requestContent) { event in
+            if event.name == "Update propositions" {
+                updatePropositionsExpectation.fulfill()
+            }
+        }
+        
+        // test
+        Messaging.handleNotificationResponse(notificationResponse)
+        
+        // verify
+        wait(for: [updatePropositionsExpectation], timeout: ASYNC_TIMEOUT)
     }
     
     

--- a/TestApps/MessagingDemoAppObjC/ViewController.m
+++ b/TestApps/MessagingDemoAppObjC/ViewController.m
@@ -73,8 +73,7 @@
 }
 
 - (void) urlLoaded:(NSURL *)url byMessage:(id<AEPShowable>)message {
-    NSLog(@"message loaded url: %@", url);
-    [AEPMobileMessaging updatePropositionsForSurfaces:@[]];
+    NSLog(@"message loaded url: %@", url);    
 }
 
 @end

--- a/TestApps/MessagingDemoAppObjC/ViewController.m
+++ b/TestApps/MessagingDemoAppObjC/ViewController.m
@@ -74,6 +74,7 @@
 
 - (void) urlLoaded:(NSURL *)url byMessage:(id<AEPShowable>)message {
     NSLog(@"message loaded url: %@", url);
+    [AEPMobileMessaging updatePropositionsForSurfaces:@[]];
 }
 
 @end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a new API that allows for notification once updated propositions have been processed.  Using this new API when handling push click throughs to detect if a push-to-in-app workflow was provided in the push notification's payload, and executes it.

MOB-22210
MOB-22212

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
