### PR TITLE
[MOB-22381] - Support Custom Interaction tracking for Content Cards  

### DIFF
--- a/AEPMessaging/Sources/UI/ContentCards/ContentCardUI.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/ContentCardUI.swift
@@ -42,6 +42,11 @@ public class ContentCardUI: Identifiable {
     public var meta: [String: Any]? {
         proposition.items.first?.contentCardSchemaData?.meta
     }
+    
+    /// Method to track custom interaction on the content card
+    public func trackInteraction(_ interaction: String) {
+        proposition.items.first?.contentCardSchemaData?.track(interaction, withEdgeEventType: .interact)
+    }
 
     /// Factory method to create a `ContentCardUI` instance based on the provided schema data.
     /// - Parameters:

--- a/AEPMessaging/Sources/UI/ContentCards/ContentCardUI.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/ContentCardUI.swift
@@ -42,7 +42,7 @@ public class ContentCardUI: Identifiable {
     public var meta: [String: Any]? {
         proposition.items.first?.contentCardSchemaData?.meta
     }
-    
+
     /// Method to track custom interaction on the content card
     public func trackInteraction(_ interaction: String) {
         proposition.items.first?.contentCardSchemaData?.track(interaction, withEdgeEventType: .interact)

--- a/AEPMessaging/Tests/UnitTests/UITests/ContentCardUITests.swift
+++ b/AEPMessaging/Tests/UnitTests/UITests/ContentCardUITests.swift
@@ -22,6 +22,7 @@ class ContentCardUITests : XCTestCase, ContentCardUIEventListening {
     var displayExpectation: XCTestExpectation?
     var dismissExpectation: XCTestExpectation?
     var interactExpectation: XCTestExpectation?
+    var capturedInteractionID: String?
             
     func test_contentCardUI_createInstance_happy() throws {
         // setup
@@ -83,6 +84,7 @@ class ContentCardUITests : XCTestCase, ContentCardUIEventListening {
     
     func onInteract(_ card: ContentCardUI, _ interactionId: String, actionURL: URL?) -> Bool {
         interactExpectation?.fulfill()
+        capturedInteractionID = interactionId
         return false
     }
     
@@ -108,6 +110,26 @@ class ContentCardUITests : XCTestCase, ContentCardUIEventListening {
         }
         
         XCTAssertNotNil(templateHandler)
+    }
+    
+    func test_contentCardUI_customTracking() throws {
+        // setup
+        let proposition =  ContentCardTestUtil.createProposition(fromFile: "SmallImageTemplate")
+        interactExpectation = expectation(description: "onInteract method called")
+        
+        // test
+        let contentCardUI = ContentCardUI.createInstance(with: proposition, customizer: nil , listener: self)
+        contentCardUI?.onInteract(interactionId: "DoubleTapped", actionURL: nil)
+        
+        // verify
+        XCTAssertNotNil(contentCardUI)
+        waitForExpectations(timeout: 2.0) { error in
+            if let error = error {
+                XCTFail("Expectations were not fulfilled: \(error)")
+            }
+        }
+        XCTAssertEqual("DoubleTapped", capturedInteractionID)
+        
     }
 }
 

--- a/TestApps/MessagingDemoAppSwiftUI/AppDelegate.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppDelegate.swift
@@ -29,6 +29,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
             Lifecycle.self,
             Signal.self,
             Edge.self,
+            Consent.self,
             Messaging.self,
             Assurance.self
         ]


### PR DESCRIPTION
Exposes a new public function trackInteraction on ContentCardUI class. Which will allow customers to feed in custom interaction tracking data.