### PR TITLE
[PLATIR-40656] read fitToContent from mobileParameters to support auto resizing of IAMs

### DIFF
--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -128,6 +128,7 @@ enum MessagingConstants {
                     static let HORIZONTAL_ALIGN = "horizontalAlign"
                     static let HORIZONTAL_INSET = "horizontalInset"
                     static let UI_TAKEOVER = "uiTakeover"
+                    static let FIT_TO_CONTENT = "fitToContent"
                     static let DISPLAY_ANIMATION = "displayAnimation"
                     static let DISMISS_ANIMATION = "dismissAnimation"
                     static let GESTURES = "gestures"

--- a/AEPMessaging/Sources/Schemas/InAppSchemaData.swift
+++ b/AEPMessaging/Sources/Schemas/InAppSchemaData.swift
@@ -148,6 +148,7 @@ extension InAppSchemaData {
             .setHorizontalAlign(MessageAlignment.fromString(hAlign ?? "center"))
             .setHorizontalInset(mobileParameters[MessagingConstants.Event.Data.Key.IAM.HORIZONTAL_INSET] as? Int)
             .setUiTakeover(mobileParameters[MessagingConstants.Event.Data.Key.IAM.UI_TAKEOVER] as? Bool ?? true)
+            .setFitToContent(mobileParameters[MessagingConstants.Event.Data.Key.IAM.FIT_TO_CONTENT] as? Bool ?? false)
             .setBackdropColor(mobileParameters[MessagingConstants.Event.Data.Key.IAM.BACKDROP_COLOR] as? String)
             .setBackdropOpacity(opacity)
             .setCornerRadius(cornerRadius)

--- a/AEPMessaging/Tests/UnitTests/schemas/InAppSchemaDataTests.swift
+++ b/AEPMessaging/Tests/UnitTests/schemas/InAppSchemaDataTests.swift
@@ -231,6 +231,7 @@ class InAppSchemaDataTests: XCTestCase, AnyCodableAsserts {
     ///         "horizontalAlign": "center",
     ///         "horizontalInset": 0,
     ///         "uiTakeover": true,
+    ///         "fitToContent": true,  // << added in AEPMessaging 5.6.1, compatible with AEPServices 5.4.1
     ///         "displayAnimation": "top",
     ///         "dismissAnimation": "top",
     ///         "backdropColor": "000000",    // RRGGBB
@@ -248,7 +249,7 @@ class InAppSchemaDataTests: XCTestCase, AnyCodableAsserts {
     
     func testGetMessageSettingsHappy() throws {
         // setup
-        let testMobileParameters = "{\"schemaVersion\":\"1.0\",\"width\":80,\"height\":50,\"verticalAlign\":\"center\",\"verticalInset\":0,\"horizontalAlign\":\"center\",\"horizontalInset\":0,\"uiTakeover\":true,\"displayAnimation\":\"top\",\"dismissAnimation\":\"top\",\"backdropColor\":\"000000\",\"backdropOpacity\":0.3,\"cornerRadius\":15,\"gestures\":{\"swipeUp\":\"adbinapp://dismiss?interaction=swipeUp\",\"swipeDown\":\"adbinapp://dismiss?interaction=swipeDown\",\"swipeLeft\":\"adbinapp://dismiss?interaction=swipeLeft\",\"swipeRight\":\"adbinapp://dismiss?interaction=swipeRight\",\"tapBackground\":\"adbinapp://dismiss?interaction=tapBackground\"}}"
+        let testMobileParameters = "{\"schemaVersion\":\"1.0\",\"width\":80,\"height\":50,\"verticalAlign\":\"center\",\"verticalInset\":0,\"horizontalAlign\":\"center\",\"horizontalInset\":0,\"uiTakeover\":true,\"fitToContent\":true,\"displayAnimation\":\"top\",\"dismissAnimation\":\"top\",\"backdropColor\":\"000000\",\"backdropOpacity\":0.3,\"cornerRadius\":15,\"gestures\":{\"swipeUp\":\"adbinapp://dismiss?interaction=swipeUp\",\"swipeDown\":\"adbinapp://dismiss?interaction=swipeDown\",\"swipeLeft\":\"adbinapp://dismiss?interaction=swipeLeft\",\"swipeRight\":\"adbinapp://dismiss?interaction=swipeRight\",\"tapBackground\":\"adbinapp://dismiss?interaction=tapBackground\"}}"
         
         let json = "{\"content\":\(mockContentJson),\"contentType\":\"\(ContentType.applicationJson.toString())\",\"mobileParameters\":\(testMobileParameters)}"
         guard let decodedObject = getDecodedObject(fromString: json) else {
@@ -268,6 +269,7 @@ class InAppSchemaDataTests: XCTestCase, AnyCodableAsserts {
         XCTAssertEqual(.center, result.horizontalAlign)
         XCTAssertEqual(0, result.horizontalInset)
         XCTAssertEqual(true, result.uiTakeover)
+        XCTAssertEqual(true, result.fitToContent)
         XCTAssertEqual(.top, result.displayAnimation)
         XCTAssertEqual(.top, result.dismissAnimation)
         XCTAssertEqual(UIColor(hue: 0, saturation: 0, brightness: 0, alpha: 0.3), result.getBackgroundColor()) // 000000 color and 0.3 opacity
@@ -299,6 +301,7 @@ class InAppSchemaDataTests: XCTestCase, AnyCodableAsserts {
         XCTAssertNil(result.horizontalAlign)
         XCTAssertNil(result.horizontalInset)
         XCTAssertNil(result.uiTakeover)
+        XCTAssertNil(result.fitToContent)
         XCTAssertNil(result.displayAnimation)
         XCTAssertNil(result.dismissAnimation)
         XCTAssertEqual(UIColor(red: 1, green: 1, blue: 1, alpha: 0), result.getBackgroundColor()) // default color
@@ -327,6 +330,7 @@ class InAppSchemaDataTests: XCTestCase, AnyCodableAsserts {
         XCTAssertEqual(.center, result.horizontalAlign)
         XCTAssertEqual(0, result.horizontalInset)
         XCTAssertEqual(true, result.uiTakeover)
+        XCTAssertEqual(false, result.fitToContent)
         XCTAssertEqual(MessageAnimation.none, result.displayAnimation)
         XCTAssertEqual(MessageAnimation.none, result.dismissAnimation)
         XCTAssertEqual(UIColor(hue: 0, saturation: 0, brightness: 0, alpha: 0.3), result.getBackgroundColor()) // 000000 color and 0.3 opacity

--- a/Podfile
+++ b/Podfile
@@ -15,7 +15,7 @@ project 'AEPMessaging.xcodeproj'
 pod 'SwiftLint', '0.52.0'
 
 $dev_repo = 'https://github.com/sbenedicadb/aepsdk-core-ios.git'
-$dev_branch = 'temp-utils'
+$dev_branch = 'dev-v5.4.1'
 
 # ==================
 # SHARED POD GROUPS
@@ -61,47 +61,47 @@ end
 # TARGET DEFINITIONS
 # ==================
 target 'AEPMessaging' do
-  lib_main
+  lib_dev
 end
 
 target 'MessagingDemoApp' do
-  app_main
+  app_dev
 end
 
 target 'MessagingDemoAppObjC' do
-  app_main
+  app_dev
 end
 
 target 'MessagingDemoAppSwiftUI' do
-  app_main
+  app_dev
 end
 
 target 'UnitTests' do
-  lib_main
+  lib_dev
   test_utils
 end
 
 target 'FunctionalTests' do
-  app_main
+  app_dev
   test_utils
 end
 
 target 'IntegrationTests' do
-  app_main
+  app_dev
   test_utils
 end
 
 target 'E2EFunctionalTests' do
-  app_main
+  app_dev
   test_utils
 end
 
 target 'FunctionalTestApp' do
-  app_main
+  app_dev
   test_utils
 end
 
 target 'E2EFunctionalTestApp' do
-  app_main
+  app_dev
   test_utils
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,9 +2,9 @@ PODS:
   - AEPAssurance (5.0.1):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPServices (< 6.0.0, >= 5.0.0)
-  - AEPCore (5.3.1):
+  - AEPCore (5.4.0):
     - AEPRulesEngine (< 6.0.0, >= 5.0.0)
-    - AEPServices (< 6.0.0, >= 5.3.1)
+    - AEPServices (< 6.0.0, >= 5.4.0)
   - AEPEdge (5.0.3):
     - AEPCore (< 6.0.0, >= 5.3.1)
     - AEPEdgeIdentity (< 6.0.0, >= 5.0.0)
@@ -13,66 +13,111 @@ PODS:
     - AEPEdge (< 6.0.0, >= 5.0.0)
   - AEPEdgeIdentity (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
-  - AEPLifecycle (5.3.1):
-    - AEPCore (< 6.0.0, >= 5.3.1)
+  - AEPLifecycle (5.4.0):
+    - AEPCore (< 6.0.0, >= 5.4.0)
   - AEPRulesEngine (5.0.0)
-  - AEPServices (5.3.1)
-  - AEPSignal (5.3.1):
-    - AEPCore (< 6.0.0, >= 5.3.1)
+  - AEPServices (5.4.0)
+  - AEPSignal (5.4.0):
+    - AEPCore (< 6.0.0, >= 5.4.0)
   - AEPTestUtils (5.2.0):
     - AEPCore (< 6.0.0, >= 5.2.0)
     - AEPServices (< 6.0.0, >= 5.2.0)
   - SwiftLint (0.52.0)
 
 DEPENDENCIES:
-  - AEPAssurance
-  - AEPCore
-  - AEPEdge
-  - AEPEdgeConsent
-  - AEPEdgeIdentity
-  - AEPLifecycle
-  - AEPRulesEngine
-  - AEPServices
-  - AEPSignal
+  - AEPAssurance (from `https://github.com/adobe/aepsdk-assurance-ios.git`, branch `staging`)
+  - AEPCore (from `https://github.com/sbenedicadb/aepsdk-core-ios.git`, branch `dev-v5.4.1`)
+  - AEPEdge (from `https://github.com/adobe/aepsdk-edge-ios.git`, branch `staging`)
+  - AEPEdgeConsent (from `https://github.com/adobe/aepsdk-edgeconsent-ios.git`, branch `staging`)
+  - AEPEdgeIdentity (from `https://github.com/adobe/aepsdk-edgeidentity-ios.git`, branch `staging`)
+  - AEPLifecycle (from `https://github.com/sbenedicadb/aepsdk-core-ios.git`, branch `dev-v5.4.1`)
+  - AEPRulesEngine (from `https://github.com/adobe/aepsdk-rulesengine-ios.git`, branch `staging`)
+  - AEPServices (from `https://github.com/sbenedicadb/aepsdk-core-ios.git`, branch `dev-v5.4.1`)
+  - AEPSignal (from `https://github.com/sbenedicadb/aepsdk-core-ios.git`, branch `dev-v5.4.1`)
   - AEPTestUtils (from `https://github.com/adobe/aepsdk-core-ios.git`, tag `testutils-5.2.0`)
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
   trunk:
-    - AEPAssurance
-    - AEPCore
-    - AEPEdge
-    - AEPEdgeConsent
-    - AEPEdgeIdentity
-    - AEPLifecycle
-    - AEPRulesEngine
-    - AEPServices
-    - AEPSignal
     - SwiftLint
 
 EXTERNAL SOURCES:
+  AEPAssurance:
+    :branch: staging
+    :git: https://github.com/adobe/aepsdk-assurance-ios.git
+  AEPCore:
+    :branch: dev-v5.4.1
+    :git: https://github.com/sbenedicadb/aepsdk-core-ios.git
+  AEPEdge:
+    :branch: staging
+    :git: https://github.com/adobe/aepsdk-edge-ios.git
+  AEPEdgeConsent:
+    :branch: staging
+    :git: https://github.com/adobe/aepsdk-edgeconsent-ios.git
+  AEPEdgeIdentity:
+    :branch: staging
+    :git: https://github.com/adobe/aepsdk-edgeidentity-ios.git
+  AEPLifecycle:
+    :branch: dev-v5.4.1
+    :git: https://github.com/sbenedicadb/aepsdk-core-ios.git
+  AEPRulesEngine:
+    :branch: staging
+    :git: https://github.com/adobe/aepsdk-rulesengine-ios.git
+  AEPServices:
+    :branch: dev-v5.4.1
+    :git: https://github.com/sbenedicadb/aepsdk-core-ios.git
+  AEPSignal:
+    :branch: dev-v5.4.1
+    :git: https://github.com/sbenedicadb/aepsdk-core-ios.git
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-core-ios.git
     :tag: testutils-5.2.0
 
 CHECKOUT OPTIONS:
+  AEPAssurance:
+    :commit: 686105a4d61287277418a1843225db2c819ed406
+    :git: https://github.com/adobe/aepsdk-assurance-ios.git
+  AEPCore:
+    :commit: f765960b729d4393ec3f6865db88a12ef2c5e30c
+    :git: https://github.com/sbenedicadb/aepsdk-core-ios.git
+  AEPEdge:
+    :commit: 3d76b61df8413b1ba4cdfda6861f912586d4eefe
+    :git: https://github.com/adobe/aepsdk-edge-ios.git
+  AEPEdgeConsent:
+    :commit: e867c1fa5cc8c8e183d57eda88d6f8c131dd8dd5
+    :git: https://github.com/adobe/aepsdk-edgeconsent-ios.git
+  AEPEdgeIdentity:
+    :commit: db60f99b2412c0851d9bf118179702d085c98c8e
+    :git: https://github.com/adobe/aepsdk-edgeidentity-ios.git
+  AEPLifecycle:
+    :commit: f765960b729d4393ec3f6865db88a12ef2c5e30c
+    :git: https://github.com/sbenedicadb/aepsdk-core-ios.git
+  AEPRulesEngine:
+    :commit: 814672b136b6c71ab529a3f1366f3bf16cd9a532
+    :git: https://github.com/adobe/aepsdk-rulesengine-ios.git
+  AEPServices:
+    :commit: f765960b729d4393ec3f6865db88a12ef2c5e30c
+    :git: https://github.com/sbenedicadb/aepsdk-core-ios.git
+  AEPSignal:
+    :commit: f765960b729d4393ec3f6865db88a12ef2c5e30c
+    :git: https://github.com/sbenedicadb/aepsdk-core-ios.git
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-core-ios.git
     :tag: testutils-5.2.0
 
 SPEC CHECKSUMS:
   AEPAssurance: df04baeace42befb0cc213fd6cdfe51651d11ba6
-  AEPCore: 28191f2df03225a5e88b6f8f343f7e18a604c9ef
+  AEPCore: 8cdc5390163f2b761e7f3eed1cae92b8a11c0237
   AEPEdge: 105afc7958acd7c016d57f7ac1d6f632bf05e6ee
   AEPEdgeConsent: d7db1d19eb4c1e2146360ed3c8df315f671b26d5
   AEPEdgeIdentity: 3161ff33434586962946912d6b8e9e8fca1c4d23
-  AEPLifecycle: b2c4d928a8556410b8d2ef5763432bc97ebde417
+  AEPLifecycle: 619ce7bf7b64a2caff7a172e9f12f0b6da636142
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
-  AEPServices: fcba979e90f6916b066aa66f016700d7b7534d96
-  AEPSignal: 86e4f8b7f1de33699b3d4b5832535caca0d0d60f
+  AEPServices: ce27e3f2de75a9b24b3d27c7b5f1bb519724f8cb
+  AEPSignal: 9b34890eea1b81714aa45b7d7f8deb82206b0ca2
   AEPTestUtils: 0b7e4de0203e558fc02b9f4b0f493e57039545b5
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 7c92b0f9c0760a082c9ca6ec2da5421cb3ff6b4e
+PODFILE CHECKSUM: 183b17628a80dfbfdaa48a765b84e3df43bd4339
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

in newer versions of the in-app authoring UI, the marketeer can select a `fitToContent` option. when enabled, this indicates that the SDK should automatically determine the height required to fit the content of the message, and adjust to that height.

the changes in this PR are small, as the majority of the SDK work done to support this functionality is in AEPServices - the PR with these [changes can be found here](https://github.com/adobe/aepsdk-core-ios/pull/1122).  

the messaging extension's update is dependent on the services update, which is why the pod dependencies have been updated for this PR.  

> **NOTE:** prior to release, the dependencies will need to be updated to point to the production version of services.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
