### PR TITLE
Live Activity handle start and update token events

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		24CA4BDF2B61974300D16369 /* PropositionInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDE2B61974300D16369 /* PropositionInteractionTests.swift */; };
 		24CA4BE12B61977800D16369 /* SurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BE02B61977800D16369 /* SurfaceTests.swift */; };
 		24FD5F752CEEA50F00AE4567 /* CompletionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FD5F742CEEA50400AE4567 /* CompletionHandler.swift */; };
+		4C0111D72DB30FD900996757 /* LiveActivityOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0111D62DB30FD900996757 /* LiveActivityOrigin.swift */; };
 		4C9BE8D42DAF59E500EF41A3 /* Data+Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9BE8D32DAF59E500EF41A3 /* Data+Messaging.swift */; };
 		4C9BE8D62DAF5A4000EF41A3 /* LiveActivityAttributes+Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9BE8D52DAF5A4000EF41A3 /* LiveActivityAttributes+Messaging.swift */; };
 		4C9BE8D82DAF5A6900EF41A3 /* ActivityTaskStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9BE8D72DAF5A6900EF41A3 /* ActivityTaskStore.swift */; };
@@ -691,6 +692,7 @@
 		36D3F6949A279969C6766FF5 /* Pods_E2EFunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_E2EFunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D55E83254139642A1CAA76E /* Pods_FunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		43204BBDCB8D5720A0D56E52 /* Pods-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
+		4C0111D62DB30FD900996757 /* LiveActivityOrigin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityOrigin.swift; sourceTree = "<group>"; };
 		4C3B9F882AE3385B00A7D395 /* AEPTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEPTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C9BE8D32DAF59E500EF41A3 /* Data+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Messaging.swift"; sourceTree = "<group>"; };
 		4C9BE8D52DAF5A4000EF41A3 /* LiveActivityAttributes+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LiveActivityAttributes+Messaging.swift"; sourceTree = "<group>"; };
@@ -1461,6 +1463,7 @@
 				B61BDAE22DA5EA43007FE12E /* Info.plist */,
 				B61BDAE32DA5EA43007FE12E /* LiveActivityAttributes.swift */,
 				B61BDAE42DA5EA43007FE12E /* LiveActivityData.swift */,
+				4C0111D62DB30FD900996757 /* LiveActivityOrigin.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -2311,9 +2314,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoApp/Pods-MessagingDemoApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoApp/Pods-MessagingDemoApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2416,9 +2423,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoAppObjC/Pods-MessagingDemoAppObjC-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoAppObjC/Pods-MessagingDemoAppObjC-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2455,9 +2466,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-E2EFunctionalTests/Pods-E2EFunctionalTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-E2EFunctionalTests/Pods-E2EFunctionalTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2538,9 +2553,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2555,9 +2574,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-UnitTests/Pods-UnitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-UnitTests/Pods-UnitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2572,9 +2595,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FunctionalTestApp/Pods-FunctionalTestApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FunctionalTestApp/Pods-FunctionalTestApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2589,9 +2616,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2628,9 +2659,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoAppSwiftUI/Pods-MessagingDemoAppSwiftUI-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoAppSwiftUI/Pods-MessagingDemoAppSwiftUI-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2645,9 +2680,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2990,6 +3029,7 @@
 			files = (
 				B61BDAE92DA5EA43007FE12E /* LiveActivityAttributes.swift in Sources */,
 				B61BDAEA2DA5EA43007FE12E /* LiveActivityData.swift in Sources */,
+				4C0111D72DB30FD900996757 /* LiveActivityOrigin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
@@ -334,14 +334,14 @@ extension Event {
     }
 
     var liveActivityID: String? {
-        data?[MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID] as? String
+        data?[MessagingConstants.XDM.LiveActivity.LIVE_ACTIVITY_ID] as? String
     }
 
     var liveActivityChannelID: String? {
-        data?[MessagingConstants.XDM.Push.CHANNEL_ID] as? String
+        data?[MessagingConstants.XDM.LiveActivity.CHANNEL_ID] as? String
     }
 
     var liveActivityOrigin: String? {
-        data?[MessagingConstants.XDM.Push.ORIGIN] as? String
+        data?[MessagingConstants.XDM.LiveActivity.ORIGIN] as? String
     }
 }

--- a/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
@@ -340,4 +340,8 @@ extension Event {
     var liveActivityChannelID: String? {
         data?[MessagingConstants.XDM.Push.CHANNEL_ID] as? String
     }
+
+    var liveActivityOrigin: String? {
+        data?[MessagingConstants.XDM.Push.ORIGIN] as? String
+    }
 }

--- a/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
@@ -325,7 +325,19 @@ extension Event {
         data?[MessagingConstants.XDM.Push.TOKEN] as? String
     }
 
+    var liveActivityUpdateToken: String? {
+        data?[MessagingConstants.XDM.Push.TOKEN] as? String
+    }
+
     var liveActivityAttributeType: String? {
         data?[MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE] as? String
+    }
+
+    var liveActivityID: String? {
+        data?[MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID] as? String
+    }
+
+    var liveActivityChannelID: String? {
+        data?[MessagingConstants.XDM.Push.CHANNEL_ID] as? String
     }
 }

--- a/AEPMessaging/Sources/ClassExtensions/LiveActivityAttributes+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/LiveActivityAttributes+Messaging.swift
@@ -23,7 +23,7 @@ extension LiveActivityAttributes {
         String(describing: Self.self)
     }
 
-    /// Returns a dictionary containing either the liveActivityID or the channelID, whichever is non-nil.
+    /// Returns a dictionary with the non-nil `liveActivityID` and/or `channelID`.
     /// If both are nil, returns an empty dictionary.
     var liveActivityIdentifierData: [String: String] {
         let data = [

--- a/AEPMessaging/Sources/ClassExtensions/LiveActivityAttributes+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/LiveActivityAttributes+Messaging.swift
@@ -22,4 +22,14 @@ extension LiveActivityAttributes {
     static var attributeTypeName: String {
         String(describing: Self.self)
     }
+
+    /// Returns a dictionary containing either the liveActivityID or the channelID, whichever is non-nil.
+    /// If both are nil, returns an empty dictionary.
+    var liveActivityIdentifierData: [String: String] {
+        let data = [
+            MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID: liveActivityData.liveActivityID,
+            MessagingConstants.XDM.Push.CHANNEL_ID: liveActivityData.channelID
+        ]
+        return data.compactMapValues { $0 }
+    }
 }

--- a/AEPMessaging/Sources/ClassExtensions/LiveActivityAttributes+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/LiveActivityAttributes+Messaging.swift
@@ -27,8 +27,8 @@ extension LiveActivityAttributes {
     /// If both are nil, returns an empty dictionary.
     var liveActivityIdentifierData: [String: String] {
         let data = [
-            MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID: liveActivityData.liveActivityID,
-            MessagingConstants.XDM.Push.CHANNEL_ID: liveActivityData.channelID
+            MessagingConstants.XDM.LiveActivity.LIVE_ACTIVITY_ID: liveActivityData.liveActivityID,
+            MessagingConstants.XDM.LiveActivity.CHANNEL_ID: liveActivityData.channelID
         ]
         return data.compactMapValues { $0 }
     }

--- a/AEPMessaging/Sources/LiveActivity/Messaging+LiveActivityPublicAPI.swift
+++ b/AEPMessaging/Sources/LiveActivity/Messaging+LiveActivityPublicAPI.swift
@@ -190,11 +190,10 @@ public extension Messaging {
     ///   - token: A `String` representing the update push token for the Live Activity.
     private static func dispatchUpdateTokenEvent<T: LiveActivityAttributes>(activity: Activity<T>, token: String) {
         let attributeTypeName = T.attributeTypeName
-        let liveActivityData = activity.attributes.liveActivityData
-        guard let liveActivityID = liveActivityData.liveActivityID else {
+        guard let liveActivityID = activity.attributes.liveActivityData.liveActivityID else {
             Log.error(label: MessagingConstants.LOG_TAG,
                       """
-                      Missing required '\(MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_ID)'. Update token event will not be sent.
+                      Missing required '\(MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID)'. Update token event will not be sent.
                       Type: \(attributeTypeName)
                       Apple Live Activity ID: \(activity.id)
                       """)
@@ -220,7 +219,7 @@ public extension Messaging {
                               MessagingConstants.XDM.Push.TOKEN: token,
                               MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: attributeTypeName,
                               MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id,
-                              MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_ID: liveActivityID
+                              MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID: liveActivityID
                           ])
         MobileCore.dispatch(event: event)
     }
@@ -232,26 +231,30 @@ public extension Messaging {
     /// - Parameter activity: The newly started `Activity` instance. The activity must conform to ``LiveActivityAttributes``.
     private static func dispatchStartEvent<T: LiveActivityAttributes>(activity: Activity<T>) {
         let attributeTypeName = T.attributeTypeName
-        let liveActivityID = activity.attributes.liveActivityData.liveActivityID ?? MessagingConstants.Event.Data.Value.UNAVAILABLE
+        let liveActivityIdentifierData = activity.attributes.liveActivityIdentifierData
 
         Log.debug(label: MessagingConstants.LOG_TAG,
                   """
                   Dispatching Live Activity start event.
                   Type: \(attributeTypeName)
                   Apple Live Activity ID: \(activity.id)
-                  LiveActivityID: \(liveActivityID)
+                  Identifier: \(liveActivityIdentifierData)
                   """)
+
+        var data: [String: Any] = [
+            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_START: true,
+            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: attributeTypeName,
+            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id
+        ]
+
+        // Merge in the single identifier (liveActivityID or channelID)
+        data.merge(liveActivityIdentifierData) { current, _ in current }
 
         let eventName = "\(MessagingConstants.Event.Name.LIVE_ACTIVITY_START) for type (\(attributeTypeName))"
         let event = Event(name: eventName,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
-                          data: [
-                              MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_START: true,
-                              MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: attributeTypeName,
-                              MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id,
-                              MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_ID: liveActivityID
-                          ])
+                          data: data)
         MobileCore.dispatch(event: event)
     }
 
@@ -268,26 +271,30 @@ public extension Messaging {
         state: ActivityState
     ) {
         let attributeTypeName = T.attributeTypeName
-        let liveActivityID = activity.attributes.liveActivityData.liveActivityID ?? MessagingConstants.Event.Data.Value.UNAVAILABLE
+        let liveActivityIdentifierData = activity.attributes.liveActivityIdentifierData
 
         Log.debug(label: MessagingConstants.LOG_TAG,
                   """
                   Dispatching Live Activity \(state) state update event.
                   Type: \(attributeTypeName)
                   Apple Live Activity ID: \(activity.id)
-                  LiveActivityID: \(liveActivityID)
+                  Identifier: \(liveActivityIdentifierData)
                   """)
+        
+        var data: [String: Any] = [
+            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_STATE: true,
+            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id,
+            MessagingConstants.Event.Data.Key.STATE: "\(state)"
+        ]
+
+        // Merge in the single identifier (liveActivityID or channelID)
+        data.merge(liveActivityIdentifierData) { current, _ in current }
 
         let eventName = "\(MessagingConstants.Event.Name.LIVE_ACTIVITY_STATE): \(state) for type (\(attributeTypeName))"
         let event = Event(name: eventName,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
-                          data: [
-                              MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_STATE: true,
-                              MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id,
-                              MessagingConstants.Event.Data.Key.STATE: "\(state)",
-                              MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_ID: liveActivityID
-                          ])
+                          data: data)
         MobileCore.dispatch(event: event)
     }
 }

--- a/AEPMessaging/Sources/LiveActivity/Messaging+LiveActivityPublicAPI.swift
+++ b/AEPMessaging/Sources/LiveActivity/Messaging+LiveActivityPublicAPI.swift
@@ -281,7 +281,7 @@ public extension Messaging {
                   Apple Live Activity ID: \(activity.id)
                   Identifier: \(liveActivityIdentifierData)
                   """)
-        
+
         var data: [String: Any] = [
             MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_STATE: true,
             MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id,

--- a/AEPMessaging/Sources/LiveActivity/Messaging+LiveActivityPublicAPI.swift
+++ b/AEPMessaging/Sources/LiveActivity/Messaging+LiveActivityPublicAPI.swift
@@ -193,7 +193,7 @@ public extension Messaging {
         guard let liveActivityID = activity.attributes.liveActivityData.liveActivityID else {
             Log.error(label: MessagingConstants.LOG_TAG,
                       """
-                      Missing required '\(MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID)'. Update token event will not be sent.
+                      Missing required '\(MessagingConstants.XDM.LiveActivity.LIVE_ACTIVITY_ID)'. Update token event will not be sent.
                       Type: \(attributeTypeName)
                       Apple Live Activity ID: \(activity.id)
                       """)
@@ -219,7 +219,7 @@ public extension Messaging {
                               MessagingConstants.XDM.Push.TOKEN: token,
                               MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: attributeTypeName,
                               MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id,
-                              MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID: liveActivityID
+                              MessagingConstants.XDM.LiveActivity.LIVE_ACTIVITY_ID: liveActivityID
                           ])
         MobileCore.dispatch(event: event)
     }
@@ -245,7 +245,7 @@ public extension Messaging {
             MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_START: true,
             MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: attributeTypeName,
             MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id,
-            MessagingConstants.XDM.Push.ORIGIN: activity.attributes.liveActivityData.origin
+            MessagingConstants.XDM.LiveActivity.ORIGIN: activity.attributes.liveActivityData.origin
         ]
 
         // Merge in the single identifier (liveActivityID or channelID)

--- a/AEPMessaging/Sources/LiveActivity/Messaging+LiveActivityPublicAPI.swift
+++ b/AEPMessaging/Sources/LiveActivity/Messaging+LiveActivityPublicAPI.swift
@@ -244,7 +244,8 @@ public extension Messaging {
         var data: [String: Any] = [
             MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_START: true,
             MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: attributeTypeName,
-            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id
+            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: activity.id,
+            MessagingConstants.XDM.Push.ORIGIN: activity.attributes.liveActivityData.origin
         ]
 
         // Merge in the single identifier (liveActivityID or channelID)

--- a/AEPMessaging/Sources/Messaging+EdgeEvents.swift
+++ b/AEPMessaging/Sources/Messaging+EdgeEvents.swift
@@ -190,8 +190,8 @@ extension Messaging {
     /// - Parameters:
     ///   - channelID: The unique identifier for the Live Activity broadcast channel.
     ///   - event: The original `Event` that requested tracking the start of the Live Activity.
-    func sendLiveActivityStart(channelID: String?, event: Event) {
-        sendLiveActivityStart(channelID: channelID, liveActivityID: nil, event: event)
+    func sendLiveActivityStart(channelID: String?, origin: String, event: Event) {
+        sendLiveActivityStart(channelID: channelID, liveActivityID: nil, origin: origin, event: event)
     }
 
     /// Sends an Edge request event containing a Live Activity start event using a Live Activity ID.
@@ -199,8 +199,8 @@ extension Messaging {
     /// - Parameters:
     ///   - liveActivityID: The unique identifier for the Live Activity.
     ///   - event: The original `Event` that requested tracking the start of the Live Activity.
-    func sendLiveActivityStart(liveActivityID: String?, event: Event) {
-        sendLiveActivityStart(channelID: nil, liveActivityID: liveActivityID, event: event)
+    func sendLiveActivityStart(liveActivityID: String?, origin: String, event: Event) {
+        sendLiveActivityStart(channelID: nil, liveActivityID: liveActivityID, origin: origin, event: event)
     }
 
     // MARK: - private methods
@@ -212,7 +212,7 @@ extension Messaging {
     ///   - channelID: The unique identifier for the Live Activity broadcast channel.
     ///   - liveActivityID: The unique identifier for the Live Activity.
     ///   - event: The original `Event` that requested tracking the start of the Live Activity.
-    private func sendLiveActivityStart(channelID: String?, liveActivityID: String?, event: Event) {
+    private func sendLiveActivityStart(channelID: String?, liveActivityID: String?, origin: String, event: Event) {
         guard let appId: String = Bundle.main.bundleIdentifier else {
             Log.warning(label: MessagingConstants.LOG_TAG, "Failed to track Live Activity start for event (\(event.id.uuidString)), App bundle identifier is invalid.")
             return
@@ -221,7 +221,8 @@ extension Messaging {
         let liveActivityData: [String: Any?] = [
             MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID: liveActivityID,
             MessagingConstants.XDM.Push.CHANNEL_ID: channelID,
-            MessagingConstants.XDM.Push.APP_ID: appId
+            MessagingConstants.XDM.Push.APP_ID: appId,
+            MessagingConstants.XDM.Push.ORIGIN: origin
         ]
 
         let cleanedLiveActivityData = liveActivityData.compactMapValues { $0 }

--- a/AEPMessaging/Sources/Messaging+EdgeEvents.swift
+++ b/AEPMessaging/Sources/Messaging+EdgeEvents.swift
@@ -142,7 +142,7 @@ extension Messaging {
         // Creating Edge event data with XDM and data payloads
         let eventData: [String: Any] = [
             MessagingConstants.XDM.Key.XDM: [
-                MessagingConstants.XDM.Key.EVENT_TYPE: MessagingConstants.XDM.Push.EventType.LIVE_ACTIVITY_PUSH_TO_START
+                MessagingConstants.XDM.Key.EVENT_TYPE: MessagingConstants.XDM.LiveActivity.EventType.LIVE_ACTIVITY_PUSH_TO_START
             ],
             MessagingConstants.XDM.Key.DATA: profileEventData
         ]
@@ -164,14 +164,14 @@ extension Messaging {
     ///   - event: The original `Event` that triggered the request to send the update token.
     func sendLiveActivityUpdateToken(liveActivityID: String, token: String, event: Event) {
         let liveActivityData: [String: Any?] = [
-            MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID: liveActivityID,
+            MessagingConstants.XDM.LiveActivity.LIVE_ACTIVITY_ID: liveActivityID,
             MessagingConstants.XDM.Push.TOKEN: token
         ]
 
         // Creating Edge event data with XDM and data payloads
         let xdmEventData: [String: Any] = [
             MessagingConstants.XDM.Key.XDM: [
-                MessagingConstants.XDM.Key.EVENT_TYPE: MessagingConstants.XDM.Push.EventType.LIVE_ACTIVITY_UPDATE_TOKEN
+                MessagingConstants.XDM.Key.EVENT_TYPE: MessagingConstants.XDM.LiveActivity.EventType.LIVE_ACTIVITY_UPDATE_TOKEN
             ],
             MessagingConstants.XDM.Key.DATA: liveActivityData
         ]
@@ -219,10 +219,10 @@ extension Messaging {
         }
 
         let liveActivityData: [String: Any?] = [
-            MessagingConstants.XDM.Push.LIVE_ACTIVITY_ID: liveActivityID,
-            MessagingConstants.XDM.Push.CHANNEL_ID: channelID,
+            MessagingConstants.XDM.LiveActivity.LIVE_ACTIVITY_ID: liveActivityID,
+            MessagingConstants.XDM.LiveActivity.CHANNEL_ID: channelID,
             MessagingConstants.XDM.Push.APP_ID: appId,
-            MessagingConstants.XDM.Push.ORIGIN: origin
+            MessagingConstants.XDM.LiveActivity.ORIGIN: origin
         ]
 
         let cleanedLiveActivityData = liveActivityData.compactMapValues { $0 }
@@ -230,7 +230,7 @@ extension Messaging {
         // Creating XDM Edge event data
         let xdmEventData: [String: Any] = [
             MessagingConstants.XDM.Key.XDM: [
-                MessagingConstants.XDM.Key.EVENT_TYPE: MessagingConstants.XDM.Push.EventType.LIVE_ACTIVITY_START,
+                MessagingConstants.XDM.Key.EVENT_TYPE: MessagingConstants.XDM.LiveActivity.EventType.LIVE_ACTIVITY_START,
                 MessagingConstants.XDM.Key.LIVE_ACTIVITY: cleanedLiveActivityData
             ]
         ]

--- a/AEPMessaging/Sources/Messaging+EdgeEvents.swift
+++ b/AEPMessaging/Sources/Messaging+EdgeEvents.swift
@@ -199,7 +199,7 @@ extension Messaging {
             Log.warning(label: MessagingConstants.LOG_TAG, "Failed to track Live Activity start for event (\(event.id.uuidString)), App bundle identifier is invalid.")
             return
         }
-        if channelID == nil && liveActivityID == nil {
+        if channelID == nil, liveActivityID == nil {
             Log.warning(label: MessagingConstants.LOG_TAG,
                         "Unable to process Live Activity start event (\(event.id.uuidString)) because the event must contain either a liveActivityID or a channelID.")
             return
@@ -230,6 +230,7 @@ extension Messaging {
     }
 
     // MARK: - private methods
+
     /// Adding Adobe/AJO specific data to tracking information map.
     ///
     /// - Parameters:

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -277,24 +277,12 @@ public class Messaging: NSObject, Extension {
         }
 
         if event.isLiveActivityStartEvent {
-            // Should not fail, since `origin` is a non-optional property on `LiveActivityData`
             guard let origin = event.liveActivityOrigin else {
                 Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process Live Activity start event (\(event.id.uuidString)) because a valid Live Activity 'origin' could not be found in the event.")
                 return
             }
 
-            if let liveActivityID = event.liveActivityID {
-                sendLiveActivityStart(liveActivityID: liveActivityID, origin: origin, event: event)
-                return
-            }
-
-            if let channelID = event.liveActivityChannelID {
-                sendLiveActivityStart(channelID: channelID, origin: origin, event: event)
-                return
-            }
-
-            Log.warning(label: MessagingConstants.LOG_TAG,
-                        "Unable to process Live Activity start event (\(event.id.uuidString)) because the event must contain either a liveActivityID or a channelID.")
+            sendLiveActivityStart(channelID: event.liveActivityChannelID, liveActivityID: event.liveActivityID, origin: origin, event: event)
             return
         }
 

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -261,6 +261,38 @@ public class Messaging: NSObject, Extension {
             return
         }
 
+        if event.isLiveActivityUpdateTokenEvent {
+            // Extract token and liveActivityID
+            guard let token = event.liveActivityUpdateToken else {
+                Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process Live Activity update event (\(event.id.uuidString)) because a valid token could not be found in the event.")
+                return
+            }
+
+            guard let liveActivityID = event.liveActivityID else {
+                Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process Live Activity update event (\(event.id.uuidString)) because a valid Live Activity ID could not be found in the event.")
+                return
+            }
+            sendLiveActivityUpdateToken(liveActivityID: liveActivityID, token: token, event: event)
+            return
+        }
+
+        if event.isLiveActivityStartEvent {
+            if let liveActivityID = event.liveActivityID {
+                sendLiveActivityStart(liveActivityID: liveActivityID, event: event)
+                return
+            }
+
+            if let channelID = event.liveActivityChannelID {
+                sendLiveActivityStart(channelID: channelID, event: event)
+                return
+            }
+
+            Log.warning(label: MessagingConstants.LOG_TAG,
+                "Unable to process Live Activity start event (\(event.id.uuidString)) because the event must contain either a liveActivityID or a channelID."
+            )
+            return
+        }
+
         handleEdgeIdentityDependentEvents(event)
     }
 
@@ -319,6 +351,8 @@ public class Messaging: NSObject, Extension {
             }
             sendLiveActivityPushToStartToken(ecid: ecid, attributeTypeName: attributeTypeName, token: token, event: event)
         }
+
+
     }
 
     /// Responds to event history write events.

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -294,8 +294,7 @@ public class Messaging: NSObject, Extension {
             }
 
             Log.warning(label: MessagingConstants.LOG_TAG,
-                "Unable to process Live Activity start event (\(event.id.uuidString)) because the event must contain either a liveActivityID or a channelID."
-            )
+                        "Unable to process Live Activity start event (\(event.id.uuidString)) because the event must contain either a liveActivityID or a channelID.")
             return
         }
 
@@ -357,8 +356,6 @@ public class Messaging: NSObject, Extension {
             }
             sendLiveActivityPushToStartToken(ecid: ecid, attributeTypeName: attributeTypeName, token: token, event: event)
         }
-
-
     }
 
     /// Responds to event history write events.

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -277,13 +277,19 @@ public class Messaging: NSObject, Extension {
         }
 
         if event.isLiveActivityStartEvent {
+            // Should not fail, since `origin` is a non-optional property on `LiveActivityData`
+            guard let origin = event.liveActivityOrigin else {
+                Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process Live Activity start event (\(event.id.uuidString)) because a valid Live Activity 'origin' could not be found in the event.")
+                return
+            }
+
             if let liveActivityID = event.liveActivityID {
-                sendLiveActivityStart(liveActivityID: liveActivityID, event: event)
+                sendLiveActivityStart(liveActivityID: liveActivityID, origin: origin, event: event)
                 return
             }
 
             if let channelID = event.liveActivityChannelID {
-                sendLiveActivityStart(channelID: channelID, event: event)
+                sendLiveActivityStart(channelID: channelID, origin: origin, event: event)
                 return
             }
 

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -125,8 +125,6 @@ enum MessagingConstants {
                 static let LIVE_ACTIVITY_TRACK_START = "liveActivityTrackStart"
                 static let LIVE_ACTIVITY_TRACK_STATE = "liveActivityTrackState"
                 static let APPLE_LIVE_ACTIVITY_ID = "appleLiveActivityId"
-                static let LIVE_ACTIVITY_ID = "liveActivityID"
-                static let CHANNEL_ID = "channelID"
                 /// The key for Live Activity Attribute type name. For example, "FoodDeliveryLiveActivityAttributes"
                 static let ATTRIBUTE_TYPE = "attributeType"
                 static let STATE = "state"
@@ -293,6 +291,8 @@ enum MessagingConstants {
             static let NAMESPACE = "namespace"
             static let CODE = "code"
             static let ID = "id"
+            static let LIVE_ACTIVITY_ID = "liveActivityID"
+            static let CHANNEL_ID = "channelID"
 
             enum EventType {
                 static let APPLICATION_OPENED = "pushTracking.applicationOpened"

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -119,7 +119,6 @@ enum MessagingConstants {
                 static let DATA = "data"
 
                 // MARK: Live Activity
-
                 static let LIVE_ACTIVITY_UPDATE_TOKEN = "liveActivityUpdateToken"
                 static let LIVE_ACTIVITY_PUSH_TO_START_TOKEN = "liveActivityPushToStartToken"
                 static let LIVE_ACTIVITY_TRACK_START = "liveActivityTrackStart"
@@ -291,23 +290,29 @@ enum MessagingConstants {
             static let NAMESPACE = "namespace"
             static let CODE = "code"
             static let ID = "id"
-            static let LIVE_ACTIVITY_ID = "liveActivityID"
-            static let CHANNEL_ID = "channelID"
-            /// For Live Activities, represents whether the Live Activity was started remotely or locally.
-            static let ORIGIN = "origin"
 
             enum EventType {
                 static let APPLICATION_OPENED = "pushTracking.applicationOpened"
                 static let CUSTOM_ACTION = "pushTracking.customAction"
-                static let LIVE_ACTIVITY_PUSH_TO_START = "liveActivity.pushToStart"
-                static let LIVE_ACTIVITY_UPDATE_TOKEN = "liveActivity.updateToken"
-                static let LIVE_ACTIVITY_START = "liveActivity.start"
             }
 
             enum Value {
                 static let ECID = "ECID"
                 static let APNS = "apns"
                 static let APNS_SANDBOX = "apnsSandbox"
+            }
+        }
+
+        enum LiveActivity {
+            static let CHANNEL_ID = "channelID"
+            static let LIVE_ACTIVITY_ID = "liveActivityID"
+            /// Represents whether the Live Activity was started remotely or locally.
+            static let ORIGIN = "origin"
+
+            enum EventType {
+                static let LIVE_ACTIVITY_PUSH_TO_START = "liveActivity.pushToStart"
+                static let LIVE_ACTIVITY_UPDATE_TOKEN = "liveActivity.updateToken"
+                static let LIVE_ACTIVITY_START = "liveActivity.start"
             }
         }
     }

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -293,6 +293,8 @@ enum MessagingConstants {
             static let ID = "id"
             static let LIVE_ACTIVITY_ID = "liveActivityID"
             static let CHANNEL_ID = "channelID"
+            /// For Live Activities, represents whether the Live Activity was started remotely or locally.
+            static let ORIGIN = "origin"
 
             enum EventType {
                 static let APPLICATION_OPENED = "pushTracking.applicationOpened"

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -119,6 +119,7 @@ enum MessagingConstants {
                 static let DATA = "data"
 
                 // MARK: Live Activity
+
                 static let LIVE_ACTIVITY_UPDATE_TOKEN = "liveActivityUpdateToken"
                 static let LIVE_ACTIVITY_PUSH_TO_START_TOKEN = "liveActivityPushToStartToken"
                 static let LIVE_ACTIVITY_TRACK_START = "liveActivityTrackStart"

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -161,10 +161,6 @@ enum MessagingConstants {
                     static let ID = "id"
                 }
             }
-
-            enum Value {
-                static let UNAVAILABLE = "unavailable"
-            }
         }
 
         enum History {

--- a/AEPMessagingLiveActivity/Sources/LiveActivityData.swift
+++ b/AEPMessagingLiveActivity/Sources/LiveActivityData.swift
@@ -19,17 +19,6 @@ import Foundation
 /// `LiveActivityAttributes` protocol.
 @available(iOS 16.1, *)
 public struct LiveActivityData: Codable {
-    /// Indicates the source of the Live Activity's creation.
-    ///
-    /// Use this enum to distinguish whether a Live Activity was started locally by the app
-    /// or remotely via push-to-start delivered by the server.
-    public enum Origin: String, Codable {
-        /// The Live Activity was initiated locally on the device.
-        case local
-        /// The Live Activity was initiated remotely via a push-to-start token.
-        case remote
-    }
-
     /// Unique identifier for managing and tracking a broadcast Live Activity channel in Adobe Experience Platform.
     public let channelID: String?
 
@@ -37,7 +26,7 @@ public struct LiveActivityData: Codable {
     public let liveActivityID: String?
 
     /// Defines whether the Live Activity was started locally by the app or remotely via a push-to-start notification.
-    public let origin: Origin
+    public let origin: LiveActivityOrigin
 
     /// Initializes a `LiveActivityData` instance with the specified broadcast channel ID.
     /// Use this initializer for Live Activities broadcast to subscribers of a channel.

--- a/AEPMessagingLiveActivity/Sources/LiveActivityData.swift
+++ b/AEPMessagingLiveActivity/Sources/LiveActivityData.swift
@@ -19,27 +19,27 @@ import Foundation
 /// `LiveActivityAttributes` protocol.
 @available(iOS 16.1, *)
 public struct LiveActivityData: Codable {
-    /// Unique identifier for managing and tracking an individual Live Activity in Adobe Experience Platform.
-    public var liveActivityID: String?
-
     /// Unique identifier for managing and tracking a broadcast Live Activity channel in Adobe Experience Platform.
-    public var channelID: String?
+    public let channelID: String?
 
-    /// Creates an `LiveActivityData` instance with the specified Live Activity ID.
-    /// Use this method for Live Activities for an individual person.
+    /// Unique identifier for managing and tracking an individual Live Activity in Adobe Experience Platform.
+    public let liveActivityID: String?
+
+    /// Initializes a `LiveActivityData` instance with the specified broadcast channel ID.
+    /// Use this initializer for Live Activities broadcast to subscribers of a channel.
     ///
-    /// - Parameter liveActivityID: The unique identifier for the Live Activity.
-    /// - Returns: A new `LiveActivityData` instance populated with the provided `liveActivityID`.
-    public static func create(liveActivityID: String) -> LiveActivityData {
-        LiveActivityData(liveActivityID: liveActivityID)
+    /// - Parameter channelID: The unique identifier for the Live Activity broadcast channel.
+    public init(channelID: String) {
+        self.channelID = channelID
+        self.liveActivityID = nil
     }
 
-    /// Creates an `LiveActivityData` instance with the specified Live Activity channel ID.
-    /// Use this method for Live Activities broadcast to subscribers of a channel.
+    /// Initializes a `LiveActivityData` instance with the specified Live Activity ID.
+    /// Use this initializer for Live Activities targeted at an individual user.
     ///
-    /// - Parameter channelID: The unique identifier for the Live Activity channel, used for broadcast push notifications.
-    /// - Returns: A new `LiveActivityData` instance populated with the provided `channelID`.
-    public static func create(channelID: String) -> LiveActivityData {
-        LiveActivityData(channelID: channelID)
+    /// - Parameter liveActivityID: The unique identifier for the Live Activity.
+    public init(liveActivityID: String) {
+        self.channelID = nil
+        self.liveActivityID = liveActivityID
     }
 }

--- a/AEPMessagingLiveActivity/Sources/LiveActivityData.swift
+++ b/AEPMessagingLiveActivity/Sources/LiveActivityData.swift
@@ -19,11 +19,25 @@ import Foundation
 /// `LiveActivityAttributes` protocol.
 @available(iOS 16.1, *)
 public struct LiveActivityData: Codable {
+    /// Indicates the source of the Live Activity's creation.
+    ///
+    /// Use this enum to distinguish whether a Live Activity was started locally by the app
+    /// or remotely via push-to-start delivered by the server.
+    public enum Origin: String, Codable {
+        /// The Live Activity was initiated locally on the device.
+        case local
+        /// The Live Activity was initiated remotely via a push-to-start token.
+        case remote
+    }
+
     /// Unique identifier for managing and tracking a broadcast Live Activity channel in Adobe Experience Platform.
     public let channelID: String?
 
     /// Unique identifier for managing and tracking an individual Live Activity in Adobe Experience Platform.
     public let liveActivityID: String?
+
+    /// Defines whether the Live Activity was started locally by the app or remotely via a push-to-start notification.
+    public let origin: Origin
 
     /// Initializes a `LiveActivityData` instance with the specified broadcast channel ID.
     /// Use this initializer for Live Activities broadcast to subscribers of a channel.
@@ -32,6 +46,7 @@ public struct LiveActivityData: Codable {
     public init(channelID: String) {
         self.channelID = channelID
         self.liveActivityID = nil
+        self.origin = .local
     }
 
     /// Initializes a `LiveActivityData` instance with the specified Live Activity ID.
@@ -41,5 +56,6 @@ public struct LiveActivityData: Codable {
     public init(liveActivityID: String) {
         self.channelID = nil
         self.liveActivityID = liveActivityID
+        self.origin = .local
     }
 }

--- a/AEPMessagingLiveActivity/Sources/LiveActivityOrigin.swift
+++ b/AEPMessagingLiveActivity/Sources/LiveActivityOrigin.swift
@@ -1,0 +1,24 @@
+/*
+ Copyright 2025 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+/// Indicates the source of the Live Activity's creation.
+///
+/// Use this enum to distinguish whether a Live Activity was started locally by the app
+/// or remotely via push-to-start delivered by the server.
+public enum LiveActivityOrigin: String, Codable {
+    /// The Live Activity was initiated locally on the device.
+    case local
+    /// The Live Activity was initiated remotely via a push-to-start token.
+    case remote
+}

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/LiveActivity/Pages/AirplaneTrackingLiveActivityView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/LiveActivity/Pages/AirplaneTrackingLiveActivityView.swift
@@ -307,7 +307,7 @@ private extension AirplaneTrackingLiveActivityView {
         }
         
         // Example attribute + initial content state
-        let attributes = AirplaneTrackingAttributes(liveActivityData: LiveActivityData.create(liveActivityID: "<unique_ID_for_airplane_tracking>"), arrivalAirport: "SFO", departureAirport: "MIA", arrivalTerminal: "Terminal 2")
+        let attributes = AirplaneTrackingAttributes(liveActivityData: LiveActivityData(liveActivityID: "<unique_ID_for_airplane_tracking>"), arrivalAirport: "SFO", departureAirport: "MIA", arrivalTerminal: "Terminal 2")
         let initialContentState = AirplaneTrackingAttributes.ContentState(journeyProgress: 0)
         
         do {
@@ -334,7 +334,7 @@ private extension AirplaneTrackingLiveActivityView {
          }
          
          // Example attribute + initial content state
-         let attributes = AirplaneTrackingAttributes(liveActivityData: LiveActivityData.create(channelID: "<Apple Push Channel ID>"), arrivalAirport: "SFO", departureAirport: "MIA", arrivalTerminal: "Terminal 2")
+         let attributes = AirplaneTrackingAttributes(liveActivityData: LiveActivityData(channelID: "<Apple Push Channel ID>"), arrivalAirport: "SFO", departureAirport: "MIA", arrivalTerminal: "Terminal 2")
          let initialContentState = AirplaneTrackingAttributes.ContentState(journeyProgress: 0)
          
          // The channelID is taken from the text field

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/LiveActivity/Pages/FoodDeliveryLiveActivityView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/LiveActivity/Pages/FoodDeliveryLiveActivityView.swift
@@ -276,7 +276,7 @@ private extension FoodDeliveryLiveActivityView {
         }
         
         // Create attributes using the entered restaurant name
-        let attributes = FoodDeliveryLiveActivityAttributes(liveActivityData: LiveActivityData.create(liveActivityID: "orderID_234"),
+        let attributes = FoodDeliveryLiveActivityAttributes(liveActivityData: LiveActivityData(liveActivityID: "orderID_234"),
                                                             restaurantName: restaurantName)
         let initialContentState = FoodDeliveryLiveActivityAttributes.ContentState(
             orderStatus: "Ordered"

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/LiveActivity/Pages/GameScoreLiveActivityView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/LiveActivity/Pages/GameScoreLiveActivityView.swift
@@ -278,7 +278,7 @@ private extension GameScoreLiveActivityView {
             return
         }
         
-        let attributes = GameScoreLiveActivityAttributes(liveActivityData: LiveActivityData.create(liveActivityID: "<Unique_Game_ID>"))
+        let attributes = GameScoreLiveActivityAttributes(liveActivityData: LiveActivityData(liveActivityID: "<Unique_Game_ID>"))
         let initialContentState = GameScoreLiveActivityAttributes.ContentState(
             homeTeamScore: 0,
             awayTeamScore: 0,

--- a/TestApps/WidgetMessagingDemoAppSwiftUI/LiveActivityUI/AirplaneTracker/AirplaneLiveActivity.swift
+++ b/TestApps/WidgetMessagingDemoAppSwiftUI/LiveActivityUI/AirplaneTracker/AirplaneLiveActivity.swift
@@ -271,7 +271,7 @@ extension AirplaneTrackingAttributes.ContentState {
 // MARK: - Preview
 
 #Preview("Notification", as: .content,
-         using: AirplaneTrackingAttributes(liveActivityData: LiveActivityData.create(liveActivityID: "<FLIGHT_ID>"),
+         using: AirplaneTrackingAttributes(liveActivityData: LiveActivityData(liveActivityID: "<FLIGHT_ID>"),
                                            arrivalAirport: "MIA",
                                            departureAirport: "SFO",
                                            arrivalTerminal: "Terminal C")

--- a/TestApps/WidgetMessagingDemoAppSwiftUI/LiveActivityUI/FoodDelivery/FoodDeliveryLiveActivity.swift
+++ b/TestApps/WidgetMessagingDemoAppSwiftUI/LiveActivityUI/FoodDelivery/FoodDeliveryLiveActivity.swift
@@ -174,7 +174,7 @@ extension FoodDeliveryLiveActivityAttributes.ContentState {
 
 // MARK: - Preview
 #Preview("Notification", as: .content,
-         using: FoodDeliveryLiveActivityAttributes(liveActivityData: LiveActivityData.create(liveActivityID: "<UNIQUE_ORDER_ID>"),
+         using: FoodDeliveryLiveActivityAttributes(liveActivityData: LiveActivityData(liveActivityID: "<UNIQUE_ORDER_ID>"),
             restaurantName: "Burger Boss")) {
     FoodDeliveryLiveActivity()
 } contentStates: {

--- a/TestApps/WidgetMessagingDemoAppSwiftUI/LiveActivityUI/Game/GameScoreLiveActivity.swift
+++ b/TestApps/WidgetMessagingDemoAppSwiftUI/LiveActivityUI/Game/GameScoreLiveActivity.swift
@@ -247,7 +247,7 @@ extension GameScoreLiveActivityAttributes.ContentState {
 // MARK: - Preview
 
 #Preview("Notification", as: .content,
-         using: GameScoreLiveActivityAttributes(liveActivityData: LiveActivityData.create(liveActivityID: "<UNIQUE_GAME_ID>"))
+         using: GameScoreLiveActivityAttributes(liveActivityData: LiveActivityData(liveActivityID: "<UNIQUE_GAME_ID>"))
 ) {
     GameScoreLiveActivity()
 } contentStates: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Questions for reviewers
1. Do we want to create a Messaging shared state for the Live Activity push tokens? Both push-to-start and update token, similar to the regular push token?:

https://github.com/adobe/aepsdk-messaging-ios/blob/d21ef3f65e975d91fb84df2787bd72d10a0d7bd8/AEPMessaging/Sources/Messaging.swift#L270-L277

## Description

This PR implements Messaging event handlers for Live Activity update token and start events. It also adds support for tracking the Live Activity start origin (remote vs local) in the start event. 

It mostly build on top of the implementation in:
* #358

### `LiveActivityData`
* Updated to use custom initializers instead of static `create` methods
* Added new `Origin` enum to enable tracking Live Activity local vs remote start
    * App side constructors always set origin to `.local`


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
