### PR TITLE
Fix Messaging event handler logic for push-to-start tokens

### DIFF
--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -281,6 +281,8 @@ public class Messaging: NSObject, Extension {
                 let liveActivityToken = LiveActivity.Token(tokenFirstIssued: event.timestamp, token: token)
                 stateManager.updateTokenStore.set(liveActivityToken, attribute: attributeTypeName, id: liveActivityID)
                 runtime.createSharedState(data: stateManager.buildMessagingSharedState(), event: event)
+            } else {
+                Log.warning(label: MessagingConstants.LOG_TAG, "Unable to create a shared state for Live Activity update event (\(event.id.uuidString)) because a valid Live Activity attribute type could not be found in the event.")
             }
 
             sendLiveActivityUpdateToken(liveActivityID: liveActivityID, token: token, event: event)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a bug with Messaging's handler for push-to-start tokens never being reached (identified by @PravinPK) because it shares the same event signature as the general tracking handler `isMessagingRequestContentEvent` and was being swallowed by it.

The fix is to reorder the handlers so that push to start token which is more specific is evaluated first
* Also moved ECID check to after shared state is published for the push-to-start token, so that ECID does not block shared state publishing (similar to regular push token logic)

Also added warning log for update token being unable to dispatch a shared state for the token due to a missing attribute type in the event for traceability 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
