### PR TITLE
MOB-23338: push token sync improvements

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		B6F7CCC52CCA1D7100C35C64 /* small image no image.json in Resources */ = {isa = PBXBuildFile; fileRef = B6F7CC132CC2EFE400C35C64 /* small image no image.json */; };
 		B6F7CCC62CCA1D7C00C35C64 /* NoCard.json in Resources */ = {isa = PBXBuildFile; fileRef = B6F7CC182CC2EFE400C35C64 /* NoCard.json */; };
 		B6F7CCC72CCA1D7C00C35C64 /* MultipleCards.json in Resources */ = {isa = PBXBuildFile; fileRef = B6F7CC172CC2EFE400C35C64 /* MultipleCards.json */; };
+		D6C020412DC2B4880094C9CD /* MessagingProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C020402DC2B4800094C9CD /* MessagingProperties.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -761,6 +762,7 @@
 		CFBC956862FD1C6747587F09 /* Pods-E2EFunctionalTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.debug.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		CFC660CD22A375E0F809B475 /* Pods-E2EFunctionalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.release.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		D685E0AE5C614B4788DE869A /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6C020402DC2B4800094C9CD /* MessagingProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingProperties.swift; sourceTree = "<group>"; };
 		DB9F1A791A757B3C68D23B9D /* Pods_FunctionalTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD29CE4BC879CE75AFEFF0D5 /* Pods_FunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD674659DEB5142D8580C271 /* Pods-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1079,6 +1081,7 @@
 				244C2BDD26B36A4B008F086A /* Message+FullscreenMessageDelegate.swift */,
 				92315436261E3B36004AE7D3 /* Messaging.swift */,
 				244E954A267BAEBE001DC957 /* Messaging+EdgeEvents.swift */,
+				D6C020402DC2B4800094C9CD /* MessagingProperties.swift */,
 				92315434261E3B36004AE7D3 /* Messaging+PublicAPI.swift */,
 				0969D6372A79BB3C00A00BF7 /* Messaging+State.swift */,
 				92315437261E3B36004AE7D3 /* MessagingConstants.swift */,
@@ -2446,6 +2449,7 @@
 				240FC42E2AA920D400AFEEEB /* ParsedPropositions.swift in Sources */,
 				246EF0602BFFC6B5002A9B22 /* PropositionHistory.swift in Sources */,
 				245059982673F94D00CC7CA0 /* MessagingConstants.swift in Sources */,
+				D6C020412DC2B4880094C9CD /* MessagingProperties.swift in Sources */,
 				09B071EE2A651CB200F259C1 /* PropositionItem.swift in Sources */,
 				246FD07226B9F86F00FD130B /* FullscreenMessage+Message.swift in Sources */,
 				242920ED2ACF7760000DB2CD /* SchemaType.swift in Sources */,

--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -303,6 +303,9 @@
 		B6F7CCC52CCA1D7100C35C64 /* small image no image.json in Resources */ = {isa = PBXBuildFile; fileRef = B6F7CC132CC2EFE400C35C64 /* small image no image.json */; };
 		B6F7CCC62CCA1D7C00C35C64 /* NoCard.json in Resources */ = {isa = PBXBuildFile; fileRef = B6F7CC182CC2EFE400C35C64 /* NoCard.json */; };
 		B6F7CCC72CCA1D7C00C35C64 /* MultipleCards.json in Resources */ = {isa = PBXBuildFile; fileRef = B6F7CC172CC2EFE400C35C64 /* MultipleCards.json */; };
+		D66DF10C2DD5327E0021AC51 /* MessagingPropertiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66DF10B2DD5327E0021AC51 /* MessagingPropertiesTests.swift */; };
+		D66DF10E2DD533320021AC51 /* MockNamedKeyValueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66DF10D2DD5332A0021AC51 /* MockNamedKeyValueService.swift */; };
+		D66DF10F2DD533320021AC51 /* MockNamedKeyValueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66DF10D2DD5332A0021AC51 /* MockNamedKeyValueService.swift */; };
 		D6C020412DC2B4880094C9CD /* MessagingProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C020402DC2B4800094C9CD /* MessagingProperties.swift */; };
 /* End PBXBuildFile section */
 
@@ -761,6 +764,8 @@
 		CA09063EA0248339C5B2C535 /* Pods_IntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CFBC956862FD1C6747587F09 /* Pods-E2EFunctionalTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.debug.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		CFC660CD22A375E0F809B475 /* Pods-E2EFunctionalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.release.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		D66DF10B2DD5327E0021AC51 /* MessagingPropertiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingPropertiesTests.swift; sourceTree = "<group>"; };
+		D66DF10D2DD5332A0021AC51 /* MockNamedKeyValueService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNamedKeyValueService.swift; sourceTree = "<group>"; };
 		D685E0AE5C614B4788DE869A /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6C020402DC2B4800094C9CD /* MessagingProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingProperties.swift; sourceTree = "<group>"; };
 		DB9F1A791A757B3C68D23B9D /* Pods_FunctionalTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1133,6 +1138,7 @@
 				243EA6CC273325B700195945 /* MessageTests.swift */,
 				243EA6CE273325CC00195945 /* Message+FullscreenMessageDelegateTests.swift */,
 				245059642673DBFD00CC7CA0 /* MessagingTests.swift */,
+				D66DF10B2DD5327E0021AC51 /* MessagingPropertiesTests.swift */,
 				243EA6D12733260000195945 /* Messaging+EdgeEventsTests.swift */,
 				245059632673DBFD00CC7CA0 /* Messaging+PublicApiTest.swift */,
 				242920E82AC4EE2D000DB2CD /* Messaging+StateTests.swift */,
@@ -1171,6 +1177,7 @@
 				243EA6DB2739D48900195945 /* MockMessage.swift */,
 				243EA6D92739D47400195945 /* MockMessaging.swift */,
 				243EA6E1273B436400195945 /* MockMessagingRulesEngine.swift */,
+				D66DF10D2DD5332A0021AC51 /* MockNamedKeyValueService.swift */,
 				92FC594426372E34005BAE02 /* MockNotificationResponseCoder.swift */,
 				240436CD2C76685C008CCD6D /* MockProposition.swift */,
 				240436CB2C765C41008CCD6D /* MockPropositionItem.swift */,
@@ -2403,6 +2410,7 @@
 			files = (
 				246EFA1A2797441600C76A6B /* Dictionary+Flatten.swift in Sources */,
 				246EFA1C2797441600C76A6B /* JSONFileLoader.swift in Sources */,
+				D66DF10E2DD533320021AC51 /* MockNamedKeyValueService.swift in Sources */,
 				246EFA1D2797441600C76A6B /* MockCache.swift in Sources */,
 				246EFA1F2797441600C76A6B /* MockFullscreenMessage.swift in Sources */,
 				246EFA202797441600C76A6B /* MockLaunchRulesEngine.swift in Sources */,
@@ -2547,6 +2555,7 @@
 				243EA6E2273B436400195945 /* MockMessagingRulesEngine.swift in Sources */,
 				245059702673DBFE00CC7CA0 /* Messaging+PublicApiTest.swift in Sources */,
 				243EA6D0273325DC00195945 /* MessageTests.swift in Sources */,
+				D66DF10F2DD533320021AC51 /* MockNamedKeyValueService.swift in Sources */,
 				244FEA4629B6A5D30058FA1C /* FeedItemTests.swift in Sources */,
 				24CA4BC12B6178EE00D16369 /* InAppSchemaDataTests.swift in Sources */,
 				24CA4BC72B617A2500D16369 /* HtmlContentSchemaDataTests.swift in Sources */,
@@ -2599,6 +2608,7 @@
 				24CA4BC32B6179F800D16369 /* ContentTypeTests.swift in Sources */,
 				243EA6CB273325A000195945 /* FullscreenMessage+MessageTests.swift in Sources */,
 				248BD9CC28BD56B300C49B94 /* PropositionPayloadTests.swift in Sources */,
+				D66DF10C2DD5327E0021AC51 /* MessagingPropertiesTests.swift in Sources */,
 				248BD9CA28BD56A200C49B94 /* PropositionInfoTests.swift in Sources */,
 				240FC4302AAFB08E00AFEEEB /* ParsedPropositionsTests.swift in Sources */,
 				243EA6DC2739D48900195945 /* MockMessage.swift in Sources */,

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -66,7 +66,6 @@ import UserNotifications
         // Get off the main thread to process notification response
         DispatchQueue.global().async {
             hasApplicationOpenedForResponse(response, completion: { isAppOpened in
-
                 let eventData: [String: Any] = [MessagingConstants.Event.Data.Key.ID: notificationRequest.identifier,
                                                 MessagingConstants.Event.Data.Key.APPLICATION_OPENED: isAppOpened,
                                                 MessagingConstants.Event.Data.Key.ADOBE_XDM: xdm]

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -100,11 +100,10 @@ public class Messaging: NSObject, Extension {
     }
 
     /// Messaging properties to hold the persisted push identifier
-    private var messagingProperties: MessagingProperties = MessagingProperties()
+    private var messagingProperties: MessagingProperties = .init()
 
     /// the timestamp of the last push token sync
     private var lastPushTokenSyncTimestamp: Date?
-
 
     /// Array containing the schema strings for the proposition items supported by the SDK, sent in the personalization query request.
     static let supportedSchemas = [
@@ -126,11 +125,12 @@ public class Messaging: NSObject, Extension {
 
     /// INTERNAL ONLY
     /// used for testing
-    init(runtime: ExtensionRuntime, rulesEngine: MessagingRulesEngine, contentCardRulesEngine: ContentCardRulesEngine, expectedSurfaceUri _: String, cache: Cache) {
+    init(runtime: ExtensionRuntime, rulesEngine: MessagingRulesEngine, contentCardRulesEngine: ContentCardRulesEngine, expectedSurfaceUri _: String, cache: Cache, messagingProperties: MessagingProperties) {
         self.runtime = runtime
         self.rulesEngine = rulesEngine
         self.contentCardRulesEngine = contentCardRulesEngine
         self.cache = cache
+        self.messagingProperties = messagingProperties
         super.init()
         loadCachedPropositions()
     }
@@ -332,15 +332,15 @@ public class Messaging: NSObject, Extension {
 
         if pushTokensMatch && !pushForceSync {
             Log.debug(label: MessagingConstants.LOG_TAG,
-                        "Existing push token matches the new push token, push token will not be synced.")
-                   return false
+                      "Existing push token matches the new push token, push token will not be synced.")
+            return false
         } else if pushTokensMatch && !isPushTokenSyncTimeoutExpired(event.timestamp) {
             Log.debug(label: MessagingConstants.LOG_TAG,
                       "Push token sync is within the previous push sync timeout window, push token will not be synced.")
             return false
         }
 
-        Log.debug(label: MessagingConstants.LOG_TAG, pushForceSync ? MessagingConstants.FORCE_SYNC_MESSAGE : MessagingConstants.NEW_PUSH_TOKEN_MESSAGE);
+        Log.debug(label: MessagingConstants.LOG_TAG, pushForceSync ? MessagingConstants.FORCE_SYNC_MESSAGE : MessagingConstants.NEW_PUSH_TOKEN_MESSAGE)
 
         // persist the push token in the messaging named collection
         messagingProperties.pushIdentifier = event.token

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -22,6 +22,10 @@ enum MessagingConstants {
     static let CONTENT_CARD_RULES_ENGINE_NAME = EXTENSION_NAME + "ContentCard" + ".rulesengine"
     static let THIRTY_DAYS_IN_SECONDS = TimeInterval(60 * 60 * 24 * 30)
     static let PATH_SEPARATOR = "/"
+    static let DATA_STORE_NAME = EXTENSION_NAME
+    static let IGNORE_PUSH_SYNC_TIMEOUT_SECONDS = TimeInterval(1) // 1 second
+    static let FORCE_SYNC_MESSAGE = "Push registration force sync is enabled. The push token will be synced."
+    static let NEW_PUSH_TOKEN_MESSAGE = "Push token is new or changed. The push token will be synced."
 
     enum ContentTypes {
         static let APPLICATION_JSON = "application/json"
@@ -298,6 +302,9 @@ enum MessagingConstants {
 
             // config for whether to useSandbox or not
             static let USE_SANDBOX = "messaging.useSandbox"
+
+            // config for whether to force the push identifier sync to be sent
+            static let PUSH_FORCE_SYNC = "messaging.pushForceSync"
         }
 
         enum EdgeIdentity {
@@ -313,5 +320,9 @@ enum MessagingConstants {
             static let ACTION_URL = "adb_uri"
             static let PUSH_TO_INAPP = "adb_iam_id"
         }
+    }
+
+    enum NamedCollectionKeys {
+        static let PUSH_IDENTIFIER = "pushidentifier"
     }
 }

--- a/AEPMessaging/Sources/MessagingProperties.swift
+++ b/AEPMessaging/Sources/MessagingProperties.swift
@@ -25,13 +25,15 @@ class MessagingProperties {
         }
 
         set {
-            if let _pushIdentifier = newValue, !_pushIdentifier.isEmpty {
-                /// Save valid values to the named key-value service
-                ServiceProvider.shared.namedKeyValueService.set(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER, value: _pushIdentifier)
-            } else {
-                /// Otherwise remove the existing push identifier value from the named key-value service
+            /// Remove the existing push identifier value from the named key-value service if the new value is nil or empty
+            guard let newValue = newValue, !newValue.isEmpty else {
+                _pushIdentifier = nil
                 ServiceProvider.shared.namedKeyValueService.remove(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+                return
             }
+            /// Otherwsie save valid values to the named key-value service
+            _pushIdentifier = newValue
+            ServiceProvider.shared.namedKeyValueService.set(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER, value: _pushIdentifier)
         }
     }
 }

--- a/AEPMessaging/Sources/MessagingProperties.swift
+++ b/AEPMessaging/Sources/MessagingProperties.swift
@@ -1,0 +1,34 @@
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import AEPServices
+
+class MessagingProperties {
+    private var _pushIdentifier: String?
+
+    public var pushIdentifier: String? {
+        get {
+            /// Check if we have a push identifier set. if not, retrieve it from the named key-value service
+            if _pushIdentifier == nil {
+                _pushIdentifier =  ServiceProvider.shared.namedKeyValueService.get(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER) as? String
+            }
+            return _pushIdentifier
+        }
+
+        set {
+            /// Set the push identifier value to the local variable
+            _pushIdentifier = newValue
+            /// Save the new value to the named key-value service
+            ServiceProvider.shared.namedKeyValueService.set(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER, value: newValue)
+        }
+    }
+}

--- a/AEPMessaging/Sources/MessagingProperties.swift
+++ b/AEPMessaging/Sources/MessagingProperties.swift
@@ -19,7 +19,7 @@ class MessagingProperties {
         get {
             /// Check if we have a push identifier set. if not, retrieve it from the named key-value service
             if _pushIdentifier == nil {
-                _pushIdentifier =  ServiceProvider.shared.namedKeyValueService.get(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER) as? String
+                _pushIdentifier = ServiceProvider.shared.namedKeyValueService.get(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER) as? String
             }
             return _pushIdentifier
         }

--- a/AEPMessaging/Sources/MessagingProperties.swift
+++ b/AEPMessaging/Sources/MessagingProperties.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2021 Adobe. All rights reserved.
+ Copyright 2025 Adobe. All rights reserved.
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/AEPMessaging/Sources/MessagingProperties.swift
+++ b/AEPMessaging/Sources/MessagingProperties.swift
@@ -25,10 +25,13 @@ class MessagingProperties {
         }
 
         set {
-            /// Set the push identifier value to the local variable
-            _pushIdentifier = newValue
-            /// Save the new value to the named key-value service
-            ServiceProvider.shared.namedKeyValueService.set(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER, value: newValue)
+            if let _pushIdentifier = newValue, !_pushIdentifier.isEmpty {
+                /// Save valid values to the named key-value service
+                ServiceProvider.shared.namedKeyValueService.set(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER, value: _pushIdentifier)
+            } else {
+                /// Otherwise remove the existing push identifier value from the named key-value service
+                ServiceProvider.shared.namedKeyValueService.remove(collectionName: MessagingConstants.DATA_STORE_NAME, key: MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+            }
         }
     }
 }

--- a/AEPMessaging/Sources/UI/Messaging+UIPublicAPI.swift
+++ b/AEPMessaging/Sources/UI/Messaging+UIPublicAPI.swift
@@ -29,7 +29,6 @@ public extension Messaging {
                                   _ completion: @escaping (Result<[ContentCardUI], Error>) -> Void) {
         // Request propositions for the specified surface from Messaging extension.
         Messaging.getPropositionsForSurfaces([surface]) { propositionDict, error in
-
             if let error = error {
                 Log.error(label: UIConstants.LOG_TAG,
                           "Error retrieving content cards UI for surface, \(surface.uri). Error \(error)")

--- a/AEPMessaging/Tests/FunctionalTests/MessagingFunctionalTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/MessagingFunctionalTests.swift
@@ -20,8 +20,12 @@ class MessagingFunctionalTests: XCTestCase, AnyCodableAsserts {
     var messaging: Messaging!
     var mockRuntime: TestableExtensionRuntime!
     var mockConfigSharedState: [String: Any] = [:]
+    var messagingProperties: MessagingProperties!
 
     override func setUp() {
+        // clear the push identifier from persistence prior to each test
+        messagingProperties = MessagingProperties()
+        messagingProperties.pushIdentifier = nil
         mockRuntime = TestableExtensionRuntime()
         mockRuntime.ignoreEvent(type: EventType.rulesEngine, source: EventSource.requestReset)
         messaging = Messaging(runtime: mockRuntime)

--- a/AEPMessaging/Tests/TestHelpers/MockNamedKeyValueService.swift
+++ b/AEPMessaging/Tests/TestHelpers/MockNamedKeyValueService.swift
@@ -1,0 +1,58 @@
+/*
+ Copyright 2025 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import AEPServices
+
+class MockNamedKeyValueService: NamedCollectionProcessing {
+    func setAppGroup(_ appGroup: String?) {
+        // no-op
+    }
+
+    func getAppGroup() -> String? {
+        // no-op
+        return nil
+    }
+
+    var getCalled = false
+    var getCollectionName: String?
+    var getKey: String?
+    var mockValue: Any?
+
+    var setCalled = false
+    var setCollectionName: String?
+    var setKey: String?
+    var setValue: Any?
+
+    var removeCalled = false
+    var removeCollectionName: String?
+    var removeKey: String?
+
+    func set(collectionName: String, key: String, value: Any?) {
+        setCalled = true
+        setCollectionName = collectionName
+        setKey = key
+        setValue = value
+    }
+
+    func get(collectionName: String, key: String) -> Any? {
+        getCalled = true
+        getCollectionName = collectionName
+        getKey = key
+        return mockValue
+    }
+
+    func remove(collectionName: String, key: String) {
+        removeCalled = true
+        removeCollectionName = collectionName
+        removeKey = key
+    }
+}

--- a/AEPMessaging/Tests/UnitTests/Messaging+EdgeEventsTests.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+EdgeEventsTests.swift
@@ -25,6 +25,7 @@ class MessagingEdgeEventsTests: XCTestCase {
     var mockFeedRulesEngine: MockContentCardRulesEngine!
     var mockLaunchRulesEngine: MockLaunchRulesEngine!
     var mockCache: MockCache!
+    var messagingProperties: MessagingProperties!
     let mockIamSurface = "mobileapp://com.apple.dt.xctest.tool"
 
     // Mock constants
@@ -40,7 +41,8 @@ class MessagingEdgeEventsTests: XCTestCase {
         mockLaunchRulesEngine = MockLaunchRulesEngine(name: "mcokLaunchRulesEngine", extensionRuntime: mockRuntime)
         mockMessagingRulesEngine = MockMessagingRulesEngine(extensionRuntime: mockRuntime, launchRulesEngine: mockLaunchRulesEngine, cache: mockCache)
         mockFeedRulesEngine = MockContentCardRulesEngine(extensionRuntime: mockRuntime, launchRulesEngine: mockLaunchRulesEngine)
-        messaging = Messaging(runtime: mockRuntime, rulesEngine: mockMessagingRulesEngine, contentCardRulesEngine: mockFeedRulesEngine, expectedSurfaceUri: mockIamSurface, cache: mockCache)
+        messagingProperties = MessagingProperties()
+        messaging = Messaging(runtime: mockRuntime, rulesEngine: mockMessagingRulesEngine, contentCardRulesEngine: mockFeedRulesEngine, expectedSurfaceUri: mockIamSurface, cache: mockCache, messagingProperties: messagingProperties)
     }
 
     // MARK: - helpers

--- a/AEPMessaging/Tests/UnitTests/Messaging+StateTests.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+StateTests.swift
@@ -28,6 +28,7 @@ class MessagingPlusStateTests: XCTestCase {
     var mockProposition: Proposition!
     var mockPropositionItem: PropositionItem!
     var mockPropositionInfo: PropositionInfo!
+    var messagingProperties: MessagingProperties!
 
     // Mock constants
     let MOCK_ECID = "mock_ecid"
@@ -43,8 +44,9 @@ class MessagingPlusStateTests: XCTestCase {
         mockMessagingRulesEngine = MockMessagingRulesEngine(extensionRuntime: mockRuntime, launchRulesEngine: mockLaunchRulesEngineForIAM, cache: mockCache)
         mockLaunchRulesEngineForFeeds = MockLaunchRulesEngine(name: "mockLaunchRulesEngineFeeds", extensionRuntime: mockRuntime)
         mockFeedRulesEngine = MockContentCardRulesEngine(extensionRuntime: mockRuntime, launchRulesEngine: mockLaunchRulesEngineForFeeds)
-        messaging = Messaging(runtime: mockRuntime, rulesEngine: mockMessagingRulesEngine, contentCardRulesEngine: mockFeedRulesEngine, expectedSurfaceUri: mockIamSurface.uri, cache: mockCache)
-        
+        messagingProperties = MessagingProperties()
+        messaging = Messaging(runtime: mockRuntime, rulesEngine: mockMessagingRulesEngine, contentCardRulesEngine: mockFeedRulesEngine, expectedSurfaceUri: mockIamSurface.uri, cache: mockCache, messagingProperties: messagingProperties)
+
         mockPropositionItem = PropositionItem(itemId: "propItemId", schema: .defaultContent, itemData: [:])
         mockProposition = Proposition(uniqueId: "propId", scope: mockIamSurface.uri, scopeDetails: [:], items: [mockPropositionItem])
         mockPropositionInfo = PropositionInfo(id: "propInfoId", scope: mockIamSurface.uri, scopeDetails: [:])

--- a/AEPMessaging/Tests/UnitTests/MessagingPropertiesTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingPropertiesTests.swift
@@ -17,14 +17,14 @@ import AEPServices
 class MessagingPropertiesTests: XCTestCase {
     var messagingProperties: MessagingProperties!
     var mockNamedKeyValueService: MockNamedKeyValueService!
-    
+
     override func setUp() {
         super.setUp()
         mockNamedKeyValueService = MockNamedKeyValueService()
         ServiceProvider.shared.namedKeyValueService = mockNamedKeyValueService
         messagingProperties = MessagingProperties()
     }
-    
+
     override func tearDown() {
         messagingProperties = nil
         mockNamedKeyValueService = nil
@@ -35,60 +35,86 @@ class MessagingPropertiesTests: XCTestCase {
     func testGetPushIdentifierWhenNotSet() {
         // Test
         let result = messagingProperties.pushIdentifier
-        
+
         // Verify
         XCTAssertNil(result)
         XCTAssertTrue(mockNamedKeyValueService.getCalled)
         XCTAssertEqual(mockNamedKeyValueService.getCollectionName, MessagingConstants.DATA_STORE_NAME)
         XCTAssertEqual(mockNamedKeyValueService.getKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
     }
-    
+
     func testGetPushIdentifierWhenSet() {
         // Setup
         let expectedIdentifier = "test-push-token"
         mockNamedKeyValueService.mockValue = expectedIdentifier
-        
+
         // Test
         let result = messagingProperties.pushIdentifier
-        
+
         // Verify
         XCTAssertEqual(result, expectedIdentifier)
         XCTAssertTrue(mockNamedKeyValueService.getCalled)
         XCTAssertEqual(mockNamedKeyValueService.getCollectionName, MessagingConstants.DATA_STORE_NAME)
         XCTAssertEqual(mockNamedKeyValueService.getKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
     }
-    
+
     func testSetValidPushIdentifier() {
         // Setup
         let testIdentifier = "test-push-token"
-        
+
         // Test
         messagingProperties.pushIdentifier = testIdentifier
-        
+
         // Verify
         XCTAssertTrue(mockNamedKeyValueService.setCalled)
         XCTAssertEqual(mockNamedKeyValueService.setCollectionName, MessagingConstants.DATA_STORE_NAME)
         XCTAssertEqual(mockNamedKeyValueService.setKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
         XCTAssertEqual(mockNamedKeyValueService.setValue as? String, testIdentifier)
     }
-    
+
     func testSetEmptyPushIdentifier() {
         // Test
         messagingProperties.pushIdentifier = ""
-        
+
         // Verify
         XCTAssertTrue(mockNamedKeyValueService.removeCalled)
         XCTAssertEqual(mockNamedKeyValueService.removeCollectionName, MessagingConstants.DATA_STORE_NAME)
         XCTAssertEqual(mockNamedKeyValueService.removeKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
     }
-    
+
     func testSetNilPushIdentifier() {
         // Test
         messagingProperties.pushIdentifier = nil
-        
+
         // Verify
         XCTAssertTrue(mockNamedKeyValueService.removeCalled)
         XCTAssertEqual(mockNamedKeyValueService.removeCollectionName, MessagingConstants.DATA_STORE_NAME)
         XCTAssertEqual(mockNamedKeyValueService.removeKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+    }
+
+    func testSetThenGetNewPushIdentifier() {
+        // Setup
+        let testIdentifier = "test-push-token"
+        let newIdentifier = "new-push-token"
+
+        // Test
+        messagingProperties.pushIdentifier = testIdentifier
+
+        // Verify
+        XCTAssertTrue(mockNamedKeyValueService.setCalled)
+        XCTAssertEqual(mockNamedKeyValueService.setCollectionName, MessagingConstants.DATA_STORE_NAME)
+        XCTAssertEqual(mockNamedKeyValueService.setKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+        XCTAssertEqual(mockNamedKeyValueService.setValue as? String, testIdentifier)
+
+        // Test with new identifier
+        messagingProperties.pushIdentifier = newIdentifier
+        let result = messagingProperties.pushIdentifier
+
+        // Verify
+        XCTAssertTrue(mockNamedKeyValueService.setCalled)
+        XCTAssertEqual(mockNamedKeyValueService.setCollectionName, MessagingConstants.DATA_STORE_NAME)
+        XCTAssertEqual(mockNamedKeyValueService.setKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+        XCTAssertEqual(mockNamedKeyValueService.setValue as? String, newIdentifier)
+        XCTAssertEqual(result, newIdentifier)
     }
 }

--- a/AEPMessaging/Tests/UnitTests/MessagingPropertiesTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingPropertiesTests.swift
@@ -1,0 +1,94 @@
+/*
+ Copyright 2025 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import XCTest
+@testable import AEPMessaging
+import AEPServices
+
+class MessagingPropertiesTests: XCTestCase {
+    var messagingProperties: MessagingProperties!
+    var mockNamedKeyValueService: MockNamedKeyValueService!
+    
+    override func setUp() {
+        super.setUp()
+        mockNamedKeyValueService = MockNamedKeyValueService()
+        ServiceProvider.shared.namedKeyValueService = mockNamedKeyValueService
+        messagingProperties = MessagingProperties()
+    }
+    
+    override func tearDown() {
+        messagingProperties = nil
+        mockNamedKeyValueService = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Push Identifier Tests
+    func testGetPushIdentifierWhenNotSet() {
+        // Test
+        let result = messagingProperties.pushIdentifier
+        
+        // Verify
+        XCTAssertNil(result)
+        XCTAssertTrue(mockNamedKeyValueService.getCalled)
+        XCTAssertEqual(mockNamedKeyValueService.getCollectionName, MessagingConstants.DATA_STORE_NAME)
+        XCTAssertEqual(mockNamedKeyValueService.getKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+    }
+    
+    func testGetPushIdentifierWhenSet() {
+        // Setup
+        let expectedIdentifier = "test-push-token"
+        mockNamedKeyValueService.mockValue = expectedIdentifier
+        
+        // Test
+        let result = messagingProperties.pushIdentifier
+        
+        // Verify
+        XCTAssertEqual(result, expectedIdentifier)
+        XCTAssertTrue(mockNamedKeyValueService.getCalled)
+        XCTAssertEqual(mockNamedKeyValueService.getCollectionName, MessagingConstants.DATA_STORE_NAME)
+        XCTAssertEqual(mockNamedKeyValueService.getKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+    }
+    
+    func testSetValidPushIdentifier() {
+        // Setup
+        let testIdentifier = "test-push-token"
+        
+        // Test
+        messagingProperties.pushIdentifier = testIdentifier
+        
+        // Verify
+        XCTAssertTrue(mockNamedKeyValueService.setCalled)
+        XCTAssertEqual(mockNamedKeyValueService.setCollectionName, MessagingConstants.DATA_STORE_NAME)
+        XCTAssertEqual(mockNamedKeyValueService.setKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+        XCTAssertEqual(mockNamedKeyValueService.setValue as? String, testIdentifier)
+    }
+    
+    func testSetEmptyPushIdentifier() {
+        // Test
+        messagingProperties.pushIdentifier = ""
+        
+        // Verify
+        XCTAssertTrue(mockNamedKeyValueService.removeCalled)
+        XCTAssertEqual(mockNamedKeyValueService.removeCollectionName, MessagingConstants.DATA_STORE_NAME)
+        XCTAssertEqual(mockNamedKeyValueService.removeKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+    }
+    
+    func testSetNilPushIdentifier() {
+        // Test
+        messagingProperties.pushIdentifier = nil
+        
+        // Verify
+        XCTAssertTrue(mockNamedKeyValueService.removeCalled)
+        XCTAssertEqual(mockNamedKeyValueService.removeCollectionName, MessagingConstants.DATA_STORE_NAME)
+        XCTAssertEqual(mockNamedKeyValueService.removeKey, MessagingConstants.NamedCollectionKeys.PUSH_IDENTIFIER)
+    }
+}

--- a/AEPMessaging/Tests/UnitTests/MessagingPropertiesTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingPropertiesTests.swift
@@ -30,7 +30,7 @@ class MessagingPropertiesTests: XCTestCase {
         mockNamedKeyValueService = nil
         super.tearDown()
     }
-    
+
     // MARK: - Push Identifier Tests
     func testGetPushIdentifierWhenNotSet() {
         // Test

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1200,13 +1200,15 @@ class MessagingTests: XCTestCase {
         let event = Event(name: "handleProcessEvent", type: EventType.genericIdentity, source: EventSource.requestContent, data: eventData)
         mockRuntime.simulateSharedState(for: MessagingConstants.SharedState.Configuration.NAME, data: (value: mockConfig, status: SharedStateStatus.set))
         mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
-        usleep(delay)
 
+        // sleep for 1.5 seconds to ensure the 2nd syncPushIdentifier event is outside the 1 second sync timeout
+        usleep(delay)
         let event2 = Event(name: "handleProcessEvent", type: EventType.genericIdentity, source: EventSource.requestContent, data: eventData)
         mockRuntime.simulateSharedState(for: MessagingConstants.SharedState.Configuration.NAME, data: (value: mockConfig, status: SharedStateStatus.set))
         mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
-        usleep(delay)
 
+        // sleep for 1.5 seconds to ensure the 3rd syncPushIdentifier event is outside the 1 second sync timeout
+        usleep(delay)
         let event3 = Event(name: "handleProcessEvent", type: EventType.genericIdentity, source: EventSource.requestContent, data: eventData)
         mockRuntime.simulateSharedState(for: MessagingConstants.SharedState.Configuration.NAME, data: (value: mockConfig, status: SharedStateStatus.set))
         mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1,14 +1,14 @@
-//
-// Copyright 2021 Adobe. All rights reserved.
-// This file is licensed to you under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License. You may obtain a copy
-// of the License at http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software distributed under
-// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-// OF ANY KIND, either express or implied. See the License for the specific language
-// governing permissions and limitations under the License.
-//
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
 
 @testable import AEPCore
 import AEPServices


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the push identifier sync network request to be sent only when the value changes. A new boolean configuration key value pair has been added `messaging.pushForceSync` which can be used to allow the push identifier sync request to be sent regardless if it has changed. As part of these improvements, there is also a 1 second timeout when sending a push identifier sync network request to prevent "spammy" behavior when the push identifier most likely hasn't changed since the last sync.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
