### PR TITLE
Content state events in DEBUG mode

### DIFF
--- a/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
@@ -311,19 +311,19 @@ extension Event {
     }
 
     private var liveActivityUpdateTokenFlag: Bool {
-        data?[MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_UPDATE_TOKEN] as? Bool ?? false
+        data?[MessagingConstants.Event.Data.Key.LiveActivity.UPDATE_TOKEN] as? Bool ?? false
     }
 
     private var liveActivityPushToStartTokenFlag: Bool {
-        data?[MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_PUSH_TO_START_TOKEN] as? Bool ?? false
+        data?[MessagingConstants.Event.Data.Key.LiveActivity.PUSH_TO_START_TOKEN] as? Bool ?? false
     }
 
     private var liveActivityTrackStartFlag: Bool {
-        data?[MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_START] as? Bool ?? false
+        data?[MessagingConstants.Event.Data.Key.LiveActivity.TRACK_START] as? Bool ?? false
     }
 
     private var liveActivityTrackStateFlag: Bool {
-        data?[MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_STATE] as? Bool ?? false
+        data?[MessagingConstants.Event.Data.Key.LiveActivity.TRACK_STATE] as? Bool ?? false
     }
 
     var liveActivityPushToStartToken: String? {
@@ -335,7 +335,7 @@ extension Event {
     }
 
     var liveActivityAttributeType: String? {
-        data?[MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE] as? String
+        data?[MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE] as? String
     }
 
     var liveActivityID: String? {
@@ -351,6 +351,6 @@ extension Event {
     }
 
     var liveActivityState: String? {
-        data?[MessagingConstants.Event.Data.Key.STATE] as? String
+        data?[MessagingConstants.Event.Data.Key.LiveActivity.STATE] as? String
     }
 }

--- a/AEPMessaging/Sources/LiveActivity/Persistence/ChannelActivityStore.swift
+++ b/AEPMessaging/Sources/LiveActivity/Persistence/ChannelActivityStore.swift
@@ -15,7 +15,7 @@ import Foundation
 final class ChannelActivityStore: PersistenceStoreBase<LiveActivity.ChannelMap> {
     convenience init() {
         self.init(
-            storeKey: MessagingConstants.NamedCollectionKeys.LIVE_ACTIVITY_CHANNEL_DETAILS,
+            storeKey: MessagingConstants.NamedCollectionKeys.LiveActivity.CHANNEL_DETAILS,
             ttl: MessagingConstants.LiveActivity.CHANNEL_ACTIVITY_MAX_TTL
             // No custom equivalence logic; any non-expired `ChannelActivity` replaces the old one
         )

--- a/AEPMessaging/Sources/LiveActivity/Persistence/PushToStartTokenStore.swift
+++ b/AEPMessaging/Sources/LiveActivity/Persistence/PushToStartTokenStore.swift
@@ -15,7 +15,7 @@ import AEPServices
 final class PushToStartTokenStore: PersistenceStoreBase<LiveActivity.PushToStartTokenMap> {
     convenience init() {
         self.init(
-            storeKey: MessagingConstants.NamedCollectionKeys.LIVE_ACTIVITY_PUSH_TO_START_TOKENS,
+            storeKey: MessagingConstants.NamedCollectionKeys.LiveActivity.PUSH_TO_START_TOKENS,
             customEquivalence: { old, new in
                 // Equals for push to start tokens ignores the timestamp.
                 old.token == new.token

--- a/AEPMessaging/Sources/LiveActivity/Persistence/UpdateTokenStore.swift
+++ b/AEPMessaging/Sources/LiveActivity/Persistence/UpdateTokenStore.swift
@@ -15,7 +15,7 @@ import AEPServices
 final class UpdateTokenStore: PersistenceStoreBase<LiveActivity.UpdateTokenMap> {
     convenience init() {
         self.init(
-            storeKey: MessagingConstants.NamedCollectionKeys.LIVE_ACTIVITY_UPDATE_TOKENS,
+            storeKey: MessagingConstants.NamedCollectionKeys.LiveActivity.UPDATE_TOKENS,
             ttl: MessagingConstants.LiveActivity.UPDATE_TOKEN_MAX_TTL,
             customEquivalence: { old, new in
                 // Equals for update tokens ignores the timestamp.

--- a/AEPMessaging/Sources/Messaging+EdgeEvents.swift
+++ b/AEPMessaging/Sources/Messaging+EdgeEvents.swift
@@ -181,7 +181,7 @@ extension Messaging {
         ]
 
         let pushTokenEdgeEvent = event.createChainedEvent(
-            name: MessagingConstants.Event.Name.LIVE_ACTIVITY_PUSH_TO_START_EDGE,
+            name: MessagingConstants.Event.Name.LiveActivity.PUSH_TO_START_EDGE,
             type: EventType.edge,
             source: EventSource.requestContent,
             data: eventData
@@ -210,7 +210,7 @@ extension Messaging {
         ]
 
         let updateTokenEdgeEvent = event.createChainedEvent(
-            name: MessagingConstants.Event.Name.LIVE_ACTIVITY_UPDATE_TOKEN_EDGE,
+            name: MessagingConstants.Event.Name.LiveActivity.UPDATE_TOKEN_EDGE,
             type: EventType.edge,
             source: EventSource.requestContent,
             data: xdmEventData
@@ -255,7 +255,7 @@ extension Messaging {
         ]
 
         let liveActivityStartEdgeEvent = event.createChainedEvent(
-            name: MessagingConstants.Event.Name.LIVE_ACTIVITY_START,
+            name: MessagingConstants.Event.Name.LiveActivity.START,
             type: EventType.edge,
             source: EventSource.requestContent,
             data: xdmEventData

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -72,12 +72,16 @@ enum MessagingConstants {
             static let PUSH_TRACKING_STATUS = "Push tracking status event"
             static let EVENT_HISTORY_WRITE = "Write IAM event to history"
             static let PUSH_TO_IN_APP = "Push to in-app"
-            static let LIVE_ACTIVITY_PUSH_TO_START = "Live Activity push-to-start token event"
-            static let LIVE_ACTIVITY_UPDATE_TOKEN = "Live Activity update token event"
-            static let LIVE_ACTIVITY_START = "Live Activity start event"
-            static let LIVE_ACTIVITY_STATE = "Live Activity state event"
-            static let LIVE_ACTIVITY_PUSH_TO_START_EDGE = "Live Activity push-to-start token Edge event"
-            static let LIVE_ACTIVITY_UPDATE_TOKEN_EDGE = "Live Activity update token Edge event"
+
+            enum LiveActivity {
+                static let CONTENT_STATE = "Live Activity content state"
+                static let PUSH_TO_START = "Live Activity push-to-start token event"
+                static let PUSH_TO_START_EDGE = "Live Activity push-to-start token Edge event"
+                static let START = "Live Activity start event"
+                static let STATE = "Live Activity state event"
+                static let UPDATE_TOKEN = "Live Activity update token event"
+                static let UPDATE_TOKEN_EDGE = "Live Activity update token Edge event"
+            }
         }
 
         enum Source {
@@ -125,14 +129,17 @@ enum MessagingConstants {
 
                 // MARK: Live Activity event keys
 
-                static let LIVE_ACTIVITY_UPDATE_TOKEN = "isLiveActivityUpdateTokenEvent"
-                static let LIVE_ACTIVITY_PUSH_TO_START_TOKEN = "isLiveActivityPushToStartTokenEvent"
-                static let LIVE_ACTIVITY_TRACK_START = "isLiveActivityTrackStartEvent"
-                static let LIVE_ACTIVITY_TRACK_STATE = "isLiveActivityTrackStateEvent"
-                static let APPLE_LIVE_ACTIVITY_ID = "appleLiveActivityId"
-                /// The key for Live Activity Attribute type name. For example, "FoodDeliveryLiveActivityAttributes"
-                static let ATTRIBUTE_TYPE = "attributeType"
-                static let STATE = "state"
+                enum LiveActivity {
+                    static let APPLE_ID = "appleLiveActivityId"
+                    /// The key for Live Activity Attribute type name. For example, "FoodDeliveryLiveActivityAttributes"
+                    static let ATTRIBUTE_TYPE = "attributeType"
+                    static let CONTENT_STATE = "contentState"
+                    static let PUSH_TO_START_TOKEN = "isLiveActivityPushToStartTokenEvent"
+                    static let STATE = "state"
+                    static let TRACK_START = "isLiveActivityTrackStartEvent"
+                    static let TRACK_STATE = "isLiveActivityTrackStateEvent"
+                    static let UPDATE_TOKEN = "isLiveActivityUpdateTokenEvent"
+                }
 
                 enum Feed {
                     static let SURFACE = "surface"
@@ -306,8 +313,8 @@ enum MessagingConstants {
         }
 
         enum LiveActivity {
-            static let CHANNEL_ID = "channelID"
             static let ATTRIBUTE_TYPE = "liveActivityAttributeType"
+            static let CHANNEL_ID = "channelID"
             static let ID = "liveActivityID"
             /// Represents whether the Live Activity was started remotely or locally.
             static let ORIGIN = "origin"
@@ -315,8 +322,8 @@ enum MessagingConstants {
 
             enum EventType {
                 static let PUSH_TO_START = "liveActivity.pushToStart"
-                static let UPDATE_TOKEN = "liveActivity.updateToken"
                 static let START = "liveActivity.start"
+                static let UPDATE_TOKEN = "liveActivity.updateToken"
             }
         }
     }
@@ -327,9 +334,9 @@ enum MessagingConstants {
             static let LIVE_ACTIVITY = "liveActivity"
 
             enum LiveActivity {
+                static let CHANNEL_ACTIVITIES = "channelActivities"
                 static let PUSH_TO_START_TOKENS = "pushToStartTokens"
                 static let UPDATE_TOKENS = "updateTokens"
-                static let CHANNEL_ACTIVITIES = "channelActivities"
             }
         }
 
@@ -359,9 +366,11 @@ enum MessagingConstants {
     }
 
     enum NamedCollectionKeys {
-        static let LIVE_ACTIVITY_PUSH_TO_START_TOKENS = "liveActivity.pushToStartTokens"
-        static let LIVE_ACTIVITY_UPDATE_TOKENS = "liveActivity.updateTokens"
-        static let LIVE_ACTIVITY_CHANNEL_DETAILS = "liveActivity.channelDetails"
+        enum LiveActivity {
+            static let PUSH_TO_START_TOKENS = "liveActivity.pushToStartTokens"
+            static let UPDATE_TOKENS = "liveActivity.updateTokens"
+            static let CHANNEL_DETAILS = "liveActivity.channelDetails"
+        }
     }
 
     enum LiveActivity {

--- a/AEPMessaging/Tests/FunctionalTests/LiveActivityTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/LiveActivityTests.swift
@@ -170,10 +170,10 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
     func test_LiveActivity_PushToStart_MissingAttributeType() {
         // create event without attribute type
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_PUSH_TO_START_TOKEN: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.PUSH_TO_START_TOKEN: true,
             MessagingConstants.XDM.Push.TOKEN: PUSH_TO_START_TOKEN
         ]
-        let event = Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_PUSH_TO_START,
+        let event = Event(name: MessagingConstants.Event.Name.LiveActivity.PUSH_TO_START,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
                           data: eventData)
@@ -190,11 +190,11 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
     func test_LiveActivity_PushToStart_InvalidTokenFormat() {
         // create event with invalid token format (non-string)
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_PUSH_TO_START_TOKEN: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.PUSH_TO_START_TOKEN: true,
             MessagingConstants.XDM.Push.TOKEN: 123, // Invalid token format
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE
         ]
-        let event = Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_PUSH_TO_START,
+        let event = Event(name: MessagingConstants.Event.Name.LiveActivity.PUSH_TO_START,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
                           data: eventData)
@@ -250,11 +250,11 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
     func test_LiveActivity_UpdateToken_MissingLiveActivityID() {
         // create event without Live Activity ID
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_UPDATE_TOKEN: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.UPDATE_TOKEN: true,
             MessagingConstants.XDM.Push.TOKEN: PUSH_TO_START_TOKEN,
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE
         ]
-        let event = Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_UPDATE_TOKEN,
+        let event = Event(name: MessagingConstants.Event.Name.LiveActivity.UPDATE_TOKEN,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
                           data: eventData)
@@ -270,11 +270,11 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
 
     func test_UpdateToken_MissingAttributeType() {
         let event = Event(
-            name: MessagingConstants.Event.Name.LIVE_ACTIVITY_UPDATE_TOKEN,
+            name: MessagingConstants.Event.Name.LiveActivity.UPDATE_TOKEN,
             type: EventType.messaging,
             source: EventSource.requestContent,
             data: [
-                MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_UPDATE_TOKEN: true,
+                MessagingConstants.Event.Data.Key.LiveActivity.UPDATE_TOKEN: true,
                 MessagingConstants.XDM.Push.TOKEN: PUSH_TO_START_TOKEN,
                 // Attribute type intentionally omitted
                 MessagingConstants.XDM.LiveActivity.ID: "LID"
@@ -290,12 +290,12 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
     func test_LiveActivity_UpdateToken_InvalidTokenFormat() {
         // create event with invalid token format (non-string)
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_UPDATE_TOKEN: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.UPDATE_TOKEN: true,
             MessagingConstants.XDM.Push.TOKEN: 123, // Invalid token format
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
             MessagingConstants.XDM.LiveActivity.ID: LIVE_ACTIVITY_ID
         ]
-        let event = Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_UPDATE_TOKEN,
+        let event = Event(name: MessagingConstants.Event.Name.LiveActivity.UPDATE_TOKEN,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
                           data: eventData)
@@ -347,12 +347,12 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
     func test_LiveActivity_Start_MissingOrigin() {
         // create event without origin
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_START: true,
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
-            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: "testAppleActivityID",
+            MessagingConstants.Event.Data.Key.LiveActivity.TRACK_START: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
+            MessagingConstants.Event.Data.Key.LiveActivity.APPLE_ID: "testAppleActivityID",
             MessagingConstants.XDM.LiveActivity.ID: LIVE_ACTIVITY_ID
         ]
-        let event = Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_START,
+        let event = Event(name: MessagingConstants.Event.Name.LiveActivity.START,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
                           data: eventData)
@@ -407,12 +407,12 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
 
         // Create event without state
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_STATE: true,
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
-            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: "testAppleActivityID",
+            MessagingConstants.Event.Data.Key.LiveActivity.TRACK_STATE: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
+            MessagingConstants.Event.Data.Key.LiveActivity.APPLE_ID: "testAppleActivityID",
             MessagingConstants.XDM.LiveActivity.ID: LIVE_ACTIVITY_ID
         ]
-        let event = Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_STATE,
+        let event = Event(name: MessagingConstants.Event.Name.LiveActivity.STATE,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
                           data: eventData)
@@ -432,12 +432,12 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
 
         // Create event without attribute type
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_STATE: true,
-            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: "testAppleActivityID",
+            MessagingConstants.Event.Data.Key.LiveActivity.TRACK_STATE: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.APPLE_ID: "testAppleActivityID",
             MessagingConstants.XDM.LiveActivity.ID: LIVE_ACTIVITY_ID,
-            MessagingConstants.Event.Data.Key.STATE: MessagingConstants.LiveActivity.States.DISMISSED
+            MessagingConstants.Event.Data.Key.LiveActivity.STATE: MessagingConstants.LiveActivity.States.DISMISSED
         ]
-        let event = Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_STATE,
+        let event = Event(name: MessagingConstants.Event.Name.LiveActivity.STATE,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
                           data: eventData)
@@ -457,12 +457,12 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
 
         // Create event without live activity ID
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_STATE: true,
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
-            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: "testAppleActivityID",
-            MessagingConstants.Event.Data.Key.STATE: MessagingConstants.LiveActivity.States.DISMISSED
+            MessagingConstants.Event.Data.Key.LiveActivity.TRACK_STATE: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
+            MessagingConstants.Event.Data.Key.LiveActivity.APPLE_ID: "testAppleActivityID",
+            MessagingConstants.Event.Data.Key.LiveActivity.STATE: MessagingConstants.LiveActivity.States.DISMISSED
         ]
-        let event = Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_STATE,
+        let event = Event(name: MessagingConstants.Event.Name.LiveActivity.STATE,
                           type: EventType.messaging,
                           source: EventSource.requestContent,
                           data: eventData)
@@ -559,11 +559,11 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
 
     private func createPushToStartEvent(token: String, attributeType: String) -> Event {
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_PUSH_TO_START_TOKEN: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.PUSH_TO_START_TOKEN: true,
             MessagingConstants.XDM.Push.TOKEN: token,
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: attributeType
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: attributeType
         ]
-        return Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_PUSH_TO_START,
+        return Event(name: MessagingConstants.Event.Name.LiveActivity.PUSH_TO_START,
                      type: EventType.messaging,
                      source: EventSource.requestContent,
                      data: eventData)
@@ -571,12 +571,12 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
 
     private func createUpdateTokenEvent(token: String, attributeType: String, liveActivityID: String) -> Event {
         let eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_UPDATE_TOKEN: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.UPDATE_TOKEN: true,
             MessagingConstants.XDM.Push.TOKEN: token,
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: attributeType,
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: attributeType,
             MessagingConstants.XDM.LiveActivity.ID: liveActivityID
         ]
-        return Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_UPDATE_TOKEN,
+        return Event(name: MessagingConstants.Event.Name.LiveActivity.UPDATE_TOKEN,
                      type: EventType.messaging,
                      source: EventSource.requestContent,
                      data: eventData)
@@ -584,9 +584,9 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
 
     private func createStartEvent(liveActivityID: String?, channelID: String?, origin: String) -> Event {
         var eventData: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_START: true,
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
-            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: "testAppleActivityID",
+            MessagingConstants.Event.Data.Key.LiveActivity.TRACK_START: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
+            MessagingConstants.Event.Data.Key.LiveActivity.APPLE_ID: "testAppleActivityID",
             MessagingConstants.XDM.LiveActivity.ORIGIN: origin
         ]
 
@@ -598,7 +598,7 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
             eventData[MessagingConstants.XDM.LiveActivity.CHANNEL_ID] = channelID
         }
 
-        return Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_START,
+        return Event(name: MessagingConstants.Event.Name.LiveActivity.START,
                      type: EventType.messaging,
                      source: EventSource.requestContent,
                      data: eventData)
@@ -739,10 +739,10 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
                                   liveActivityID: String?,
                                   channelID: String?) -> Event {
         var data: [String: Any] = [
-            MessagingConstants.Event.Data.Key.LIVE_ACTIVITY_TRACK_STATE: true,
-            MessagingConstants.Event.Data.Key.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
-            MessagingConstants.Event.Data.Key.APPLE_LIVE_ACTIVITY_ID: "testAppleActivityID",
-            MessagingConstants.Event.Data.Key.STATE: state
+            MessagingConstants.Event.Data.Key.LiveActivity.TRACK_STATE: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: ATTRIBUTE_TYPE,
+            MessagingConstants.Event.Data.Key.LiveActivity.APPLE_ID: "testAppleActivityID",
+            MessagingConstants.Event.Data.Key.LiveActivity.STATE: state
         ]
         if let liveActivityID = liveActivityID {
             data[MessagingConstants.XDM.LiveActivity.ID] = liveActivityID
@@ -750,7 +750,7 @@ class LiveActivityTests: XCTestCase, AnyCodableAsserts {
         if let channelID = channelID {
             data[MessagingConstants.XDM.LiveActivity.CHANNEL_ID] = channelID
         }
-        return Event(name: MessagingConstants.Event.Name.LIVE_ACTIVITY_STATE,
+        return Event(name: MessagingConstants.Event.Name.LiveActivity.STATE,
                      type: EventType.messaging,
                      source: EventSource.requestContent,
                      data: data)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements tracking content state by dispatching debug events when in DEBUG mode. Didn't create tests for this since the main business logic is: 
1. Receiving a content state (from Apple API), 
2. encoding that `ContentState` (must be Codable by definition) into a dictionary via `AEPServices` `Encodable`'s `asDictionary` and 
3. dispatching an event

It also refactors the Live Activity related constants to use a path prefix instead of the constant itself using the `LIVE_ACTIVITY` prefix

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
