### PR TITLE
Handle reset identities event by clearing the push token from messaging shared state and persistence

### DIFF
--- a/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
@@ -207,12 +207,6 @@ extension Event {
         data?[MessagingConstants.Event.Data.Key.PUSH_IDENTIFIER] as? String
     }
 
-    // MARK: - resetIdentities Event
-
-    var isGenericIdentityResetIdentitiesEvent: Bool {
-        type == EventType.genericIdentity && source == EventSource.requestReset
-    }
-
     // MARK: - Push tracking
 
     var pushTrackingStatus: PushTrackingStatus? {

--- a/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
@@ -207,6 +207,12 @@ extension Event {
         data?[MessagingConstants.Event.Data.Key.PUSH_IDENTIFIER] as? String
     }
 
+    // MARK: - resetIdentities Event
+
+    var isGenericIdentityResetIdentitiesEvent: Bool {
+        type == EventType.genericIdentity && source == EventSource.requestReset
+    }
+
     // MARK: - Push tracking
 
     var pushTrackingStatus: PushTrackingStatus? {

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -141,6 +141,11 @@ public class Messaging: NSObject, Extension {
                          source: EventSource.requestContent,
                          listener: handleProcessEvent)
 
+        // register listener for reset identities event
+        registerListener(type: EventType.genericIdentity,
+                         source: EventSource.requestReset,
+                         listener: handleResetIdentitiesEvent)
+
         // register listener for Messaging request content event
         registerListener(type: EventType.messaging,
                          source: EventSource.requestContent,
@@ -285,7 +290,7 @@ public class Messaging: NSObject, Extension {
             }
 
             // If the push token is valid update the shared state.
-            runtime.createSharedState(data: [MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER: token], event: event)
+            createMessagingSharedState(token: token, event: event)
 
             // get identityMap from the edge identity xdm shared state
             guard let identityMap = edgeIdentitySharedState[MessagingConstants.SharedState.EdgeIdentity.IDENTITY_MAP] as? [AnyHashable: Any] else {
@@ -317,6 +322,28 @@ public class Messaging: NSObject, Extension {
             handleTrackingInfo(event: event)
             return
         }
+    }
+
+    /// Creates a shared state for the messaging extension with the provided push token.
+    /// - Parameters:
+    ///   - token: the push identifier to be set in the shared state
+    ///   - event: the `Event` that triggered the creation of the shared state
+    private func createMessagingSharedState(token: String?, event: Event) {
+        let state: [String: Any] = token?.isEmpty == false ?
+            [MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER: token!] :
+            [:]
+
+        runtime.createSharedState(data: state, event: event)
+    }
+
+    /// Handles the reset identities event by clearing the push identifier from persistence and shared state.
+    /// - Parameter event: the `Event` that triggered the reset identities event
+    private func handleResetIdentitiesEvent(_ event: Event) {
+        Log.debug(label: MessagingConstants.LOG_TAG, "Processing reset identities event.")
+        // remove the push token from the shared state
+        createMessagingSharedState(token: nil, event: event)
+        // clear the push identifier from persistence
+        messagingProperties.pushIdentifier = nil
     }
 
     /// Checks if the push identifier can be synced

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -75,9 +75,9 @@ class MessagingTests: XCTestCase {
         XCTAssertNoThrow(MobileCore.registerExtensions([Messaging.self]))
     }
     
-    /// validate that 8 listeners are registered onRegister
-    func testOnRegistered_eightListenersAreRegistered() {
-        XCTAssertEqual(mockRuntime.listeners.count, 8)
+    /// validate that 9 listeners are registered onRegister
+    func testOnRegistered_nineListenersAreRegistered() {
+        XCTAssertEqual(mockRuntime.listeners.count, 9)
     }
     
     func testOnUnregisteredCallable() throws {
@@ -1361,5 +1361,29 @@ class MessagingTests: XCTestCase {
         let pushTokenEventData = event?.data?[MessagingConstants.Event.Data.Key.DATA] as? [String: Any]
         let pushNotificationDetails = pushTokenEventData?[MessagingConstants.XDM.Push.PUSH_NOTIFICATION_DETAILS] as? [[String: Any]]
         return pushNotificationDetails?.first?[MessagingConstants.XDM.Push.TOKEN] as? String
+    }
+
+    // MARK: - Reset Identities Event Tests
+    
+    func testHandleResetIdentitiesEvent_clearsPushToken() {
+        // setup
+        let messagingState = [MessagingConstants.Event.Data.Key.PUSH_IDENTIFIER: MOCK_PUSH_TOKEN] as [String : Any]
+        mockRuntime.simulateSharedState(for: MessagingConstants.EXTENSION_NAME, data: (value: messagingState, status: SharedStateStatus.set))
+        messagingProperties.pushIdentifier = MOCK_PUSH_TOKEN
+
+        let event = Event(name: "Reset Identities",
+                         type: EventType.genericIdentity,
+                         source: EventSource.requestReset,
+                         data: nil)
+        
+        // test
+        mockRuntime.simulateComingEvents(event)
+        
+        // verify
+        XCTAssertNil(messagingProperties.pushIdentifier)
+        XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
+        let sharedState = mockRuntime.createdSharedStates.last
+        XCTAssertNotNil(sharedState as Any?)
+        XCTAssertEqual(nil, mockRuntime.firstSharedState![MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER] as? String)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A new ECID is generated when the resetIdentities API is called. The Messaging extension should clear the existing push token from Messaging shared state and persistence when a resetIdentities event is received. The app developer will then be responsible for syncing the push token with the newly generated ECID.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
