### PR TITLE
Support IAM key value pairs by exposing public API Message.metadata

### DIFF
--- a/AEPMessaging/Sources/Message.swift
+++ b/AEPMessaging/Sources/Message.swift
@@ -196,7 +196,9 @@ extension Message {
                                                                                               isLocalImageUsed: usingLocalAssets,
                                                                                               settings: messageSettings) as? FullscreenMessage
 
-        message.metadata = iamSchemaData.meta ?? [:]
+        if let metadata = iamSchemaData.meta, !metadata.isEmpty {
+            message.metadata = metadata
+        }
 
         if usingLocalAssets {
             message.fullscreenMessage?.setAssetMap(message.assets)

--- a/AEPMessaging/Sources/Message.swift
+++ b/AEPMessaging/Sources/Message.swift
@@ -32,6 +32,9 @@ public class Message: NSObject {
         fullscreenMessage?.webView
     }
 
+    /// Custom metadata for the message, if any.
+    @objc public var metadata: [String: Any] = [:]
+
     // MARK: internal properties
 
     /// Holds a reference to the class that created this `Message`.  Used for access to tracking code owned by `Messaging`.
@@ -192,6 +195,9 @@ extension Message {
                                                                                               listener: message,
                                                                                               isLocalImageUsed: usingLocalAssets,
                                                                                               settings: messageSettings) as? FullscreenMessage
+
+        message.metadata = iamSchemaData.meta ?? [:]
+
         if usingLocalAssets {
             message.fullscreenMessage?.setAssetMap(message.assets)
         }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds support for custom key/value pairs added when authoring an IAM. Adds public API `Message.metadata` which are the contents of the `meta` property of the proposition item for the IAM.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
