### PR TITLE
-[PLATIR-54374] default-content-item schema types are no longer loaded into the in-app rules engine

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		24CA4BDD2B61972500D16369 /* PropositionItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDC2B61972500D16369 /* PropositionItemTests.swift */; };
 		24CA4BDF2B61974300D16369 /* PropositionInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BDE2B61974300D16369 /* PropositionInteractionTests.swift */; };
 		24CA4BE12B61977800D16369 /* SurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CA4BE02B61977800D16369 /* SurfaceTests.swift */; };
+		24DE13ED2E9074F300D916DC /* ruleWithDefaultContentConsequence.json in Resources */ = {isa = PBXBuildFile; fileRef = 24DE13EC2E9074E700D916DC /* ruleWithDefaultContentConsequence.json */; };
 		24FD5F752CEEA50F00AE4567 /* CompletionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FD5F742CEEA50400AE4567 /* CompletionHandler.swift */; };
 		2B2B7A6E0F7CD6312D28421A /* Pods_FunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD29CE4BC879CE75AFEFF0D5 /* Pods_FunctionalTests.framework */; };
 		44DFBD558578CFDCD4A9A476 /* Pods_E2EFunctionalTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A44BD44CB3A7DA5EBB972652 /* Pods_E2EFunctionalTestApp.framework */; };
@@ -671,6 +672,7 @@
 		24CA4BDC2B61972500D16369 /* PropositionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropositionItemTests.swift; sourceTree = "<group>"; };
 		24CA4BDE2B61974300D16369 /* PropositionInteractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropositionInteractionTests.swift; sourceTree = "<group>"; };
 		24CA4BE02B61977800D16369 /* SurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTests.swift; sourceTree = "<group>"; };
+		24DE13EC2E9074E700D916DC /* ruleWithDefaultContentConsequence.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ruleWithDefaultContentConsequence.json; sourceTree = "<group>"; };
 		24EE301D28FF61F0005E417C /* InAppMessagingEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessagingEventTests.swift; sourceTree = "<group>"; };
 		24FD5F742CEEA50400AE4567 /* CompletionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionHandler.swift; sourceTree = "<group>"; };
 		28E46BC7A8F3939CF2DDDC8F /* Pods_MessagingDemoAppObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MessagingDemoAppObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1043,6 +1045,7 @@
 				243EC1EC2CD0387100BD546E /* inAppMessagePriority20.json */,
 				243EC1ED2CD0387100BD546E /* inAppMessagePriority60.json */,
 				243EC1EA2CD036A200BD546E /* inAppMessagePriority100.json */,
+				24DE13EC2E9074E700D916DC /* ruleWithDefaultContentConsequence.json */,
 				4CB003F62E30BEEA002152B0 /* ruleWithInvalidConsequenceDetail.json */,
 				242920D32ABCA559000DB2CD /* ruleWithNoConsequence.json */,
 				242920D52ABCD8A6000DB2CD /* ruleWithUnknownConsequenceSchema.json */,
@@ -2075,6 +2078,7 @@
 			files = (
 				4CB003F72E30BEEA002152B0 /* ruleWithInvalidConsequenceDetail.json in Resources */,
 				B6F7CC202CC2EFE400C35C64 /* SmallImageTemplate_onlyTitle.json in Resources */,
+				24DE13ED2E9074F300D916DC /* ruleWithDefaultContentConsequence.json in Resources */,
 				754F49EB2E007FD4002601E9 /* LargeImageTemplate.json in Resources */,
 				B6F7CC252CC2EFE400C35C64 /* SmallImageTemplate_noTitle.json in Resources */,
 				B6F7CC262CC2EFE400C35C64 /* SmallImageTemplate.json in Resources */,

--- a/AEPMessaging/Sources/ParsedPropositions.swift
+++ b/AEPMessaging/Sources/ParsedPropositions.swift
@@ -15,6 +15,8 @@ import AEPServices
 import Foundation
 
 struct ParsedPropositions {
+    let LOG_TAG = "ParsedPropositions"
+    
     weak var runtime: ExtensionRuntime?
 
     // store tracking information for propositions loaded into rules engines
@@ -75,7 +77,7 @@ struct ParsedPropositions {
                         //
                         // this is important because we need a reliable key to store and retrieve `PropositionInfo` for reporting
                         switch schemaConsequence.schema {
-                        case .inapp, .defaultContent:
+                        case .inapp:
                             propositionInfoToCache[consequence.id] = PropositionInfo.fromProposition(proposition)
                             propositionsToPersist.add(proposition, forKey: surface)
                             mergeRules(parsedRule, for: surface, with: .inapp)
@@ -86,6 +88,10 @@ struct ParsedPropositions {
                             // Event history operations don't have proposition info that needs to be cached unlike the cards they are tied to
                             // The rules just need to be loaded into the processing rules engine
                             mergeRules(parsedRule, for: surface, with: .eventHistoryOperation)
+                        case .defaultContent:
+                            // in a future release, determine whether this holdout is replacing IAM or CC, handle accordingly
+                            // for now, do nothing
+                            Log.debug(label: LOG_TAG, "Ignoring holdout treatment for activity '\(proposition.activityId)'")
                         default:
                             continue
                         }

--- a/AEPMessaging/Tests/Resources/ruleWithDefaultContentConsequence.json
+++ b/AEPMessaging/Tests/Resources/ruleWithDefaultContentConsequence.json
@@ -1,0 +1,50 @@
+{
+    "version": 1,
+    "rules": [
+        {
+            "meta": {
+                "ruleType": "card"
+            },
+            "condition": {
+                "definition": {
+                    "conditions": [
+                        {
+                            "definition": {
+                                "key": "~timestampu",
+                                "matcher": "lt",
+                                "values": [2.0512476e9]
+                            },
+                            "type": "matcher"
+                        },
+                        {
+                            "definition": {
+                                "events": [
+                                    {
+                                        "iam.eventType": "disqualify",
+                                        "iam.id": "11020e96-bf51-41f6-9028-6434c74d61b0#2dbc9195-a2f4-44c7-aa38-23a1ef61172c"
+                                    }
+                                ],
+                                "matcher": "eq",
+                                "value": 0
+                            },
+                            "type": "historical"
+                        }
+                    ],
+                    "logic": "and"
+                },
+                "type": "group"
+            },
+            "consequences": [
+                {
+                    "id": "75fc40cd-3859-44d1-8f6e-a8c55d0c6b6d",
+                    "type": "schema",
+                    "detail": {
+                        "id": "30b92805-92b4-4257-8e30-2a0d640a0f68",
+                        "schema": "https://ns.adobe.com/personalization/default-content-item",
+                        "data": {}
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/AEPMessaging/Tests/UnitTests/ParsedPropositionsTests.swift
+++ b/AEPMessaging/Tests/UnitTests/ParsedPropositionsTests.swift
@@ -174,8 +174,24 @@ class ParsedPropositionTests: XCTestCase {
         XCTAssertEqual(0, result.surfaceRulesBySchemaType.count)
     }
     
-    func testInitWithDefaultContentProposition() throws {
+    func testInitWithDefaultContentConsequence() throws {
+        // setup
+        let defaultContentRule = JSONFileLoader.getRulesJsonFromFile("ruleWithDefaultContentConsequence")
+        let pi = PropositionItem(itemId: "inapp2", schema: .ruleset, itemData: defaultContentRule)
+        let prop = Proposition(uniqueId: "inapp2", scope: "inapp2", scopeDetails: ["key": "value"], items: [pi])
+        let propositions: [Surface: [Proposition]] = [
+            mockInAppSurfacev2: [prop]
+        ]
         
+        // test
+        let result = ParsedPropositions(with: propositions, requestedSurfaces: [mockInAppSurfacev2], runtime: mockRuntime)
+        
+        // verify
+        XCTAssertNotNil(result)
+        XCTAssertEqual(0, result.propositionInfoToCache.count, "default-content-item schema should be ignored")
+        XCTAssertEqual(0, result.propositionsToCache.count, "default-content-item schema should be ignored")
+        XCTAssertEqual(0, result.propositionsToPersist.count, "default-content-item schema should be ignored")
+        XCTAssertEqual(0, result.surfaceRulesBySchemaType.count, "default-content-item schema should be ignored")
     }
     
     func testInitPropositionItemEmptyContentString() throws {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
-  - AEPAssurance (5.0.1):
+  - AEPAssurance (5.0.2):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPServices (< 6.0.0, >= 5.0.0)
-  - AEPCore (5.6.0):
+  - AEPCore (5.7.0):
     - AEPRulesEngine (< 6.0.0, >= 5.0.0)
-    - AEPServices (< 6.0.0, >= 5.6.0)
+    - AEPServices (< 6.0.0, >= 5.7.0)
   - AEPEdge (5.0.3):
     - AEPCore (< 6.0.0, >= 5.3.1)
     - AEPEdgeIdentity (< 6.0.0, >= 5.0.0)
-  - AEPEdgeConsent (5.0.0):
+  - AEPEdgeConsent (5.0.1):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPEdge (< 6.0.0, >= 5.0.0)
   - AEPEdgeIdentity (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
-  - AEPLifecycle (5.6.0):
-    - AEPCore (< 6.0.0, >= 5.6.0)
+  - AEPLifecycle (5.7.0):
+    - AEPCore (< 6.0.0, >= 5.7.0)
   - AEPRulesEngine (5.0.0)
-  - AEPServices (5.6.0)
-  - AEPSignal (5.6.0):
-    - AEPCore (< 6.0.0, >= 5.6.0)
+  - AEPServices (5.7.0)
+  - AEPSignal (5.7.0):
+    - AEPCore (< 6.0.0, >= 5.7.0)
   - AEPTestUtils (5.6.0):
     - AEPCore (< 6.0.0, >= 5.6.0)
     - AEPServices (< 6.0.0, >= 5.6.0)
@@ -61,15 +61,15 @@ CHECKOUT OPTIONS:
     :tag: testutils-5.6.0
 
 SPEC CHECKSUMS:
-  AEPAssurance: df04baeace42befb0cc213fd6cdfe51651d11ba6
-  AEPCore: 404a4c600f5a885031a7e9b1e646ea9405d94b24
+  AEPAssurance: fedcd7ed72b431b5f310eb3a52921345c34c1051
+  AEPCore: d1b0905c5a9531a883d9e8c31212ff61ca900be0
   AEPEdge: 105afc7958acd7c016d57f7ac1d6f632bf05e6ee
-  AEPEdgeConsent: d7db1d19eb4c1e2146360ed3c8df315f671b26d5
+  AEPEdgeConsent: 5f28a8ed6cd86812a73b1f5a4dbde9c81e486bf1
   AEPEdgeIdentity: 3161ff33434586962946912d6b8e9e8fca1c4d23
-  AEPLifecycle: 75e6a1870259c9b50b26f1ae6f6bbe6f25fe2907
+  AEPLifecycle: da35d7393f0d635472719d292b9e4142123cb13c
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
-  AEPServices: cbdac48662ef2f1001d05d47b5930a397a8beaab
-  AEPSignal: fc0bcf6f228a35568af06a715326209d8d0857f1
+  AEPServices: e1f14e286a8680cecbe0bcdf6ea47f46573635c4
+  AEPSignal: 6e10c4d1dca8fb1ed8601cb4224ebd30fc241a59
   AEPTestUtils: 2bbed995c8974f6f6d92058db88d6cd2e4a7f869
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Addresses internal PLATIR-54374 - where content card campaigns returning a holdout treatment were causing an infinite loop in the event hub leading to OOM crashes
  - To fix the crash as a short term solution, the behavior is being changed to ignore holdout treatments on the client.  in a future release, we will add in the capability to do proper tracking for holdout display events from in-app and content card channels.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
