### PR TITLE
Post sequence batching approach

### DIFF
--- a/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
@@ -304,6 +304,10 @@ extension Event {
     var liveActivityPushToStartToken: String? {
         data?[MessagingConstants.XDM.Push.TOKEN] as? String
     }
+    
+    var liveActivityBatchedPushToStartTokens: [[String: String]]? {
+        data?[MessagingConstants.Event.Data.Key.LiveActivity.BATCHED_PUSH_TO_START_TOKENS] as? [[String: String]]
+    }
 
     var liveActivityUpdateToken: String? {
         data?[MessagingConstants.XDM.Push.TOKEN] as? String

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -366,67 +366,40 @@ public class Messaging: NSObject, Extension {
         // handle live activity push-to-start token event
         if event.isLiveActivityPushToStartTokenEvent {
             // Check if this is a batched event with multiple tokens
-            if let batchedTokens = event.data?[MessagingConstants.Event.Data.Key.LiveActivity.BATCHED_PUSH_TO_START_TOKENS] as? [[String: String]], !batchedTokens.isEmpty {
-                // Handle batched tokens
-                Log.debug(label: MessagingConstants.LOG_TAG, "Processing batched push-to-start tokens (\(batchedTokens.count) types)")
-                
-                var hasChanges = false
-                for tokenData in batchedTokens {
-                    guard let token = tokenData[MessagingConstants.XDM.Push.TOKEN], !token.isEmpty,
-                          let attributeType = tokenData[MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE], !attributeType.isEmpty else {
-                        continue
-                    }
-                    
-                    let pushToStartToken = LiveActivity.PushToStartToken(firstIssued: event.timestamp, token: token)
-                    if stateManager.pushToStartTokenStore.set(pushToStartToken, id: attributeType) {
-                        hasChanges = true
-                    }
-                }
-                
-                guard hasChanges else {
-                    Log.debug(label: MessagingConstants.LOG_TAG, "No new tokens in batch")
-                    return
-                }
-                
-                runtime.createSharedState(data: stateManager.buildMessagingSharedState(), event: event)
-                let tokenMap = stateManager.pushToStartTokenStore.all()
-                
-                guard let ecid = retrieveECID(from: edgeIdentitySharedState) else {
-                    Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process event (\(event.id.uuidString)) because the ECID is not available.")
-                    return
-                }
-                sendLiveActivityPushToStartTokens(ecid: ecid, tokenMap: tokenMap, event: event)
-                
-            } else {
-                // Handle single token event (original behavior)
-                guard let token = event.liveActivityPushToStartToken, !token.isEmpty else {
-                    Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process Live Activity push-to-start event (\(event.id.uuidString)) because a valid token could not be found in the event or token is empty.")
-                    return
-                }
-                guard let attributeType = event.liveActivityAttributeType, !attributeType.isEmpty else {
-                    Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process Live Activity push-to-start event (\(event.id.uuidString)) because a valid attribute type could not be found in the event or was empty.")
-                    return
-                }
-
-                // Update the push to start token store and update the Messaging shared state.
-                let pushToStartToken = LiveActivity.PushToStartToken(firstIssued: event.timestamp, token: token)
-                let didChange = stateManager.pushToStartTokenStore.set(pushToStartToken, id: attributeType)
-                if !didChange {
-                    Log.debug(label: MessagingConstants.LOG_TAG, "Skipping publishing push-to-start token because unchanged: \(pushToStartToken)")
-                    return
-                }
-                runtime.createSharedState(data: stateManager.buildMessagingSharedState(), event: event)
-
-                // Get all current push to start tokens to send to profile
-                let tokenMap = stateManager.pushToStartTokenStore.all()
-
-                // Don't block shared state from being published because of ECID; check after
-                guard let ecid = retrieveECID(from: edgeIdentitySharedState) else {
-                    Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process event (\(event.id.uuidString)) because the ECID is not available.")
-                    return
-                }
-                sendLiveActivityPushToStartTokens(ecid: ecid, tokenMap: tokenMap, event: event)
+            guard let batchedTokens = event.liveActivityBatchedPushToStartTokens, !batchedTokens.isEmpty else {
+                Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process Live Activity push-to-start event (\(event.id.uuidString)): no tokens found.")
+                return
             }
+
+            Log.debug(label: MessagingConstants.LOG_TAG, "Processing push-to-start tokens (\(batchedTokens.count) types)")
+
+            var hasChanges = false
+            for tokenData in batchedTokens {
+                guard let token = tokenData[MessagingConstants.XDM.Push.TOKEN], !token.isEmpty,
+                      let attributeType = tokenData[MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE], !attributeType.isEmpty
+                else {
+                    continue
+                }
+
+                let pushToStartToken = LiveActivity.PushToStartToken(firstIssued: event.timestamp, token: token)
+                if stateManager.pushToStartTokenStore.set(pushToStartToken, id: attributeType) {
+                    hasChanges = true
+                }
+            }
+
+            guard hasChanges else {
+                Log.debug(label: MessagingConstants.LOG_TAG, "No new tokens in batch")
+                return
+            }
+
+            runtime.createSharedState(data: stateManager.buildMessagingSharedState(), event: event)
+            let tokenMap = stateManager.pushToStartTokenStore.all()
+
+            guard let ecid = retrieveECID(from: edgeIdentitySharedState) else {
+                Log.warning(label: MessagingConstants.LOG_TAG, "Unable to process event (\(event.id.uuidString)) because the ECID is not available.")
+                return
+            }
+            sendLiveActivityPushToStartTokens(ecid: ecid, tokenMap: tokenMap, event: event)
         }
 
         // handle push interaction event


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Awesome to see that the `[any LiveActivityAttributes.Type]` approach preserves the underlying types! Thanks for figuring that out @ishwetansh 
* I tried testing with the batch registration and starting a local Live Activity and the tokens were associated with the correct specific types in events and shared state

Here are my thoughts on the batching approach:
1. Maybe post-async-sequence batching could be a cleaner approach than a one time batching based on the types passed to the API?
    * post-async-sequence batching gives us the ability to batch tokens regardless of _when_ they are emitted
        * Ex: on start of a local Live Activity, on app launch, on token expiration, etc.
    * It also delegates all the type registration deduplication/overlap logic to the existing infrastructure using a single logical path:
        * preventing duplicate registrations for the same type, handled by: `performRegistration` which does the `getRegistrationState` checks
        * preventing simultaneous registrations for the same type, handled by: `LiveActivityRegistrationCoordinator`'s `withExclusiveRegistration`
    * Using an actor instead of lock to make the implementation more fool proof
    * Also avoids edge case situations like if type B is already registered and a batch is submitted for [A,B,C], the registration would hang
    * Kind of unintuitive API behavior where if I submit [A,B] then [B,C] while [A,B] is still processing, my [B,C] call is rejected because it overlaps; but if I make the same calls but wait for [A,B] to finish, [B,C] will run (and hang due to the behavior from the previous point)
2. Simplification of the push-to-start token event - making the format an array by default so two paths for single token and multi-token is not required (which has a lot of shared logic)

Definitely open to ideas on these changes (and anything else!):
* the debounce duration and configurability for batching
* if we would be better served by some kind of type, rather than the `[[String: String]]` format for these values
* should we only provide the batch API instead of both single registration and batch?
    * not sure if this is exactly the same kind of case, but maybe there is some precedence in Android Core's deprecation of the singular registerExtension in favor of the array registerExtensions?

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
