### PR TITLE
added push notification tracking exdm events along with test cases

### DIFF
--- a/AEPMessaging/Sources/Messaging+EdgeEvents.swift
+++ b/AEPMessaging/Sources/Messaging+EdgeEvents.swift
@@ -168,6 +168,14 @@ extension Messaging {
             
             // Add propositionEventType to decisioning section for push notifications
             if var decisioningDict = experienceDict[MessagingConstants.XDM.Inbound.Key.DECISIONING] as? [String: Any] {
+                // Check if experienceDecisioningRequestId exists to validate this is a decisioning notification
+                if let exdRequestId = decisioningDict[MessagingConstants.XDM.Inbound.Key.EXPERIENCE_DECISIONING_REQUEST_ID] as? String, !exdRequestId.isEmpty {
+                    // Valid decisioning notification, proceed with propositionEventType
+                } else {
+                    // Skip adding propositionEventType if no experienceDecisioningRequestId
+                    return xdmDictResult
+                }
+                
                 // Determine the proposition event type based on push notification action
                 let propositionEventType: [String: Int]
                 

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -264,6 +264,7 @@ enum MessagingConstants {
                 static let ITEMS = "items"
                 static let CHARACTERISTICS = "characteristics"
                 static let TOKENS = "tokens"
+                static let EXPERIENCE_DECISIONING_REQUEST_ID = "exdRequestID"
             }
 
             enum Value {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added propositionEventType to push notification tracking XDM data when exdRequestID is present in the decisioning data. This enhances push tracking events with proposition event type information for Experience Decisioning (EXD) workflows.
The propositionEventType is added to _experience.decisioning with the following values based on user interaction:
{"interact": 1} - when the user opens the notification
{"interact": 1} - when the user clicks an action button on the notification
{"dismiss": 1} - when the user dismisses/swipes away the notification

Related Issue
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/MOB-24406
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
When push notifications are delivered through Experience Decisioning (EXD), the tracking events need to include propositionEventType in the XDM payload to properly attribute user interactions. This aligns the push tracking schema with in-app messaging tracking and enables accurate reporting for EXD-delivered push notifications.


<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Verified that propositionEventType is only added when exdRequestID exists in the decisioning data
Tested all three interaction scenarios:
Notification open → {"interact": 1}
Button click → {"interact": 1}
Notification dismiss → {"dismiss": 1}
Verified that existing push tracking without EXD data is unaffected


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
