### PR TITLE
Added  rule re-evaluation support in Messaging extension

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		01B9DD6617C6AD6E99EE8472 /* Pods_E2EFunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB180620A608D2821FE98F37 /* Pods_E2EFunctionalTests.framework */; };
+		04432BEC0CB7D32AE8D7791B /* MessagingRuleEngineInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8F4262E345FBBC814E3294 /* MessagingRuleEngineInterceptor.swift */; };
 		090290C329D4EA9F00388226 /* MockCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2469A5E8274C107100E56457 /* MockCache.swift */; };
 		090290C529DCED0B00388226 /* ContentCardRulesEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090290C429DCED0B00388226 /* ContentCardRulesEngine.swift */; };
 		090290C929DD11EA00388226 /* RuleConsequence+Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090290C829DD11EA00388226 /* RuleConsequence+Messaging.swift */; };
@@ -351,6 +352,8 @@
 		D66DF10E2DD533320021AC51 /* MockNamedKeyValueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66DF10D2DD5332A0021AC51 /* MockNamedKeyValueService.swift */; };
 		D66DF10F2DD533320021AC51 /* MockNamedKeyValueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66DF10D2DD5332A0021AC51 /* MockNamedKeyValueService.swift */; };
 		D6C020412DC2B4880094C9CD /* MessagingProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C020402DC2B4800094C9CD /* MessagingProperties.swift */; };
+		D8F12C4D9192ED50E10E7DC8 /* MessagingRuleEngineInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E8C1E12F01D07AFBDF4F39 /* MessagingRuleEngineInterceptorTests.swift */; };
+		F03DEEFA3F66D2D96736F90A /* ReevaluationFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2A8A4FA7DBAD4D894D4E42 /* ReevaluationFunctionalTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -513,6 +516,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		04E8C1E12F01D07AFBDF4F39 /* MessagingRuleEngineInterceptorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagingRuleEngineInterceptorTests.swift; sourceTree = "<group>"; };
 		090290C429DCED0B00388226 /* ContentCardRulesEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardRulesEngine.swift; sourceTree = "<group>"; };
 		090290C829DD11EA00388226 /* RuleConsequence+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RuleConsequence+Messaging.swift"; sourceTree = "<group>"; };
 		090290CA29DE3F8200388226 /* MockContentCardRulesEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockContentCardRulesEngine.swift; path = AEPMessaging/Tests/TestHelpers/MockContentCardRulesEngine.swift; sourceTree = SOURCE_ROOT; };
@@ -755,6 +759,7 @@
 		92FC587C2636840C005BAE02 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		92FC594426372E34005BAE02 /* MockNotificationResponseCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationResponseCoder.swift; sourceTree = "<group>"; };
 		96B1543895E5AB667A105654 /* Pods-AEPMessaging.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPMessaging.release.xcconfig"; path = "Target Support Files/Pods-AEPMessaging/Pods-AEPMessaging.release.xcconfig"; sourceTree = "<group>"; };
+		9C2A8A4FA7DBAD4D894D4E42 /* ReevaluationFunctionalTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReevaluationFunctionalTests.swift; sourceTree = "<group>"; };
 		9C3C5F65B5C739964FD7D12D /* Pods-FunctionalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunctionalTestApp.release.xcconfig"; path = "Target Support Files/Pods-FunctionalTestApp/Pods-FunctionalTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		A44BD44CB3A7DA5EBB972652 /* Pods_E2EFunctionalTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_E2EFunctionalTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9ADDB0B1BD3178D864C6041 /* Pods-MessagingDemoAppObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MessagingDemoAppObjC.debug.xcconfig"; path = "Target Support Files/Pods-MessagingDemoAppObjC/Pods-MessagingDemoAppObjC.debug.xcconfig"; sourceTree = "<group>"; };
@@ -859,6 +864,7 @@
 		DB9F1A791A757B3C68D23B9D /* Pods_FunctionalTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD29CE4BC879CE75AFEFF0D5 /* Pods_FunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD674659DEB5142D8580C271 /* Pods-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
+		DE8F4262E345FBBC814E3294 /* MessagingRuleEngineInterceptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagingRuleEngineInterceptor.swift; sourceTree = "<group>"; };
 		E9B29BC8FDB1668EB2D55D15 /* Pods_AEPMessaging.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPMessaging.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE70278DC8550367F00F9609 /* Pods-FunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		FB180620A608D2821FE98F37 /* Pods_E2EFunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_E2EFunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1223,6 +1229,7 @@
 				243B1AFB28AD7FCE0074327E /* PropositionPayload.swift */,
 				09B071E52A64D3D900F259C1 /* Surface.swift */,
 				92315438261E3B36004AE7D3 /* Info.plist */,
+				DE8F4262E345FBBC814E3294 /* MessagingRuleEngineInterceptor.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1284,6 +1291,7 @@
 				24CA4BE02B61977800D16369 /* SurfaceTests.swift */,
 				241B2DD52821C99500E4FF67 /* URL+QueryParamsTests.swift */,
 				245059612673DBFD00CC7CA0 /* Info.plist */,
+				04E8C1E12F01D07AFBDF4F39 /* MessagingRuleEngineInterceptorTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1381,6 +1389,7 @@
 				B631AE152A61336800E8B82E /* MessagingNotificationTrackingTests.swift */,
 				92FC587A2636840C005BAE02 /* MessagingPublicAPITests.swift */,
 				92FC587C2636840C005BAE02 /* Info.plist */,
+				9C2A8A4FA7DBAD4D894D4E42 /* ReevaluationFunctionalTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -2713,6 +2722,7 @@
 				B69573C82CD4447F0027E376 /* AEPBundleImageView.swift in Sources */,
 				B6389A492A9B32D400B72FB4 /* PushTrackingStatus.swift in Sources */,
 				09F5D9402B5CF35F00117437 /* PropositionInteraction.swift in Sources */,
+				04432BEC0CB7D32AE8D7791B /* MessagingRuleEngineInterceptor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2801,6 +2811,7 @@
 				240FC4302AAFB08E00AFEEEB /* ParsedPropositionsTests.swift in Sources */,
 				243EA6DC2739D48900195945 /* MockMessage.swift in Sources */,
 				24CA4BD92B6196DF00D16369 /* MessagingMigratorTests.swift in Sources */,
+				D8F12C4D9192ED50E10E7DC8 /* MessagingRuleEngineInterceptorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2814,6 +2825,7 @@
 				2469A5FB2759401900E56457 /* ConfigurationLoader.swift in Sources */,
 				92863A022637706F000AFA53 /* MessagingFunctionalTests.swift in Sources */,
 				B631AE162A61336800E8B82E /* MessagingNotificationTrackingTests.swift in Sources */,
+				F03DEEFA3F66D2D96736F90A /* ReevaluationFunctionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		01B9DD6617C6AD6E99EE8472 /* Pods_E2EFunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB180620A608D2821FE98F37 /* Pods_E2EFunctionalTests.framework */; };
 		04432BEC0CB7D32AE8D7791B /* MessagingRuleEngineInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8F4262E345FBBC814E3294 /* MessagingRuleEngineInterceptor.swift */; };
+		04432BEC0CB7D32AE8D7792C /* RefreshInAppHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8F4262E345FBBC814E3295 /* RefreshInAppHandler.swift */; };
 		090290C329D4EA9F00388226 /* MockCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2469A5E8274C107100E56457 /* MockCache.swift */; };
 		090290C529DCED0B00388226 /* ContentCardRulesEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090290C429DCED0B00388226 /* ContentCardRulesEngine.swift */; };
 		090290C929DD11EA00388226 /* RuleConsequence+Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090290C829DD11EA00388226 /* RuleConsequence+Messaging.swift */; };
@@ -353,6 +354,7 @@
 		D66DF10F2DD533320021AC51 /* MockNamedKeyValueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66DF10D2DD5332A0021AC51 /* MockNamedKeyValueService.swift */; };
 		D6C020412DC2B4880094C9CD /* MessagingProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C020402DC2B4800094C9CD /* MessagingProperties.swift */; };
 		D8F12C4D9192ED50E10E7DC8 /* MessagingRuleEngineInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E8C1E12F01D07AFBDF4F39 /* MessagingRuleEngineInterceptorTests.swift */; };
+		D8F12C4D9192ED50E10E7DC9 /* RefreshInAppHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E8C1E12F01D07AFBDF4F3A /* RefreshInAppHandlerTests.swift */; };
 		F03DEEFA3F66D2D96736F90A /* ReevaluationFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2A8A4FA7DBAD4D894D4E42 /* ReevaluationFunctionalTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -517,6 +519,7 @@
 
 /* Begin PBXFileReference section */
 		04E8C1E12F01D07AFBDF4F39 /* MessagingRuleEngineInterceptorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagingRuleEngineInterceptorTests.swift; sourceTree = "<group>"; };
+		04E8C1E12F01D07AFBDF4F3A /* RefreshInAppHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RefreshInAppHandlerTests.swift; sourceTree = "<group>"; };
 		090290C429DCED0B00388226 /* ContentCardRulesEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardRulesEngine.swift; sourceTree = "<group>"; };
 		090290C829DD11EA00388226 /* RuleConsequence+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RuleConsequence+Messaging.swift"; sourceTree = "<group>"; };
 		090290CA29DE3F8200388226 /* MockContentCardRulesEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockContentCardRulesEngine.swift; path = AEPMessaging/Tests/TestHelpers/MockContentCardRulesEngine.swift; sourceTree = SOURCE_ROOT; };
@@ -865,6 +868,7 @@
 		DD29CE4BC879CE75AFEFF0D5 /* Pods_FunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD674659DEB5142D8580C271 /* Pods-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		DE8F4262E345FBBC814E3294 /* MessagingRuleEngineInterceptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagingRuleEngineInterceptor.swift; sourceTree = "<group>"; };
+		DE8F4262E345FBBC814E3295 /* RefreshInAppHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RefreshInAppHandler.swift; sourceTree = "<group>"; };
 		E9B29BC8FDB1668EB2D55D15 /* Pods_AEPMessaging.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPMessaging.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE70278DC8550367F00F9609 /* Pods-FunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		FB180620A608D2821FE98F37 /* Pods_E2EFunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_E2EFunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1230,6 +1234,7 @@
 				09B071E52A64D3D900F259C1 /* Surface.swift */,
 				92315438261E3B36004AE7D3 /* Info.plist */,
 				DE8F4262E345FBBC814E3294 /* MessagingRuleEngineInterceptor.swift */,
+				DE8F4262E345FBBC814E3295 /* RefreshInAppHandler.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1292,6 +1297,7 @@
 				241B2DD52821C99500E4FF67 /* URL+QueryParamsTests.swift */,
 				245059612673DBFD00CC7CA0 /* Info.plist */,
 				04E8C1E12F01D07AFBDF4F39 /* MessagingRuleEngineInterceptorTests.swift */,
+				04E8C1E12F01D07AFBDF4F3A /* RefreshInAppHandlerTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -2723,6 +2729,7 @@
 				B6389A492A9B32D400B72FB4 /* PushTrackingStatus.swift in Sources */,
 				09F5D9402B5CF35F00117437 /* PropositionInteraction.swift in Sources */,
 				04432BEC0CB7D32AE8D7791B /* MessagingRuleEngineInterceptor.swift in Sources */,
+				04432BEC0CB7D32AE8D7792C /* RefreshInAppHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2812,6 +2819,7 @@
 				243EA6DC2739D48900195945 /* MockMessage.swift in Sources */,
 				24CA4BD92B6196DF00D16369 /* MessagingMigratorTests.swift in Sources */,
 				D8F12C4D9192ED50E10E7DC8 /* MessagingRuleEngineInterceptorTests.swift in Sources */,
+				D8F12C4D9192ED50E10E7DC9 /* RefreshInAppHandlerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -600,6 +600,11 @@ public class Messaging: NSObject, Extension {
                 self.requestedSurfacesForEventId.removeValue(forKey: newEvent.id.uuidString)
                 self.eventsQueue.start()
 
+                // Call completion handler with failure so callers know the request failed
+                if let handler = self.completionHandlerFor(edgeRequestEventId: newEvent.id) {
+                    handler.handle?(false)
+                }
+
                 Log.warning(label: MessagingConstants.LOG_TAG, "Unable to run completion logic for a personalization request event - unable to obtain parent event ID")
                 return
             }

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -122,12 +122,19 @@ public class Messaging: NSObject, Extension {
 
     // MARK: - Extension protocol methods
 
+    /// Interceptor for handling rule re-evaluation when reevaluable rules are triggered
+    private let reevaluationInterceptor = MessagingRuleEngineInterceptor()
+    
     public required init?(runtime: ExtensionRuntime) {
         self.runtime = runtime
         MessagingMigrator.migrate(cache: cache)
         rulesEngine = MessagingRulesEngine(name: MessagingConstants.RULES_ENGINE_NAME, extensionRuntime: runtime, cache: cache)
         contentCardRulesEngine = ContentCardRulesEngine(name: MessagingConstants.CONTENT_CARD_RULES_ENGINE_NAME, extensionRuntime: runtime)
         super.init()
+        
+        // Register the reevaluation interceptor to handle dynamic rule updates
+        rulesEngine.launchRulesEngine.setReevaluationInterceptor(reevaluationInterceptor)
+        
         loadCachedPropositions()
     }
 
@@ -140,6 +147,10 @@ public class Messaging: NSObject, Extension {
         self.cache = cache
         self.messagingProperties = messagingProperties
         super.init()
+        
+        // Register the reevaluation interceptor to handle dynamic rule updates
+        rulesEngine.launchRulesEngine.setReevaluationInterceptor(reevaluationInterceptor)
+        
         loadCachedPropositions()
     }
 

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -122,7 +122,8 @@ public class Messaging: NSObject, Extension {
 
     // MARK: - Extension protocol methods
 
-    /// Interceptor for handling rule re-evaluation when reevaluable rules are triggered
+    /// Interceptor for handling rule re-evaluation when reevaluable rules are triggered.
+    /// Uses the shared RefreshInAppHandler for deduplication of refresh requests.
     private let reevaluationInterceptor = MessagingRuleEngineInterceptor()
     
     public required init?(runtime: ExtensionRuntime) {
@@ -282,6 +283,10 @@ public class Messaging: NSObject, Extension {
         // handle an event for refreshing in-app messages from the remote
         if event.isRefreshMessageEvent {
             Log.debug(label: MessagingConstants.LOG_TAG, "Processing manual request to refresh In-App Message definitions from the remote.")
+            // Register completion handler that notifies RefreshInAppHandler when done
+            Messaging.completionHandlers.append(CompletionHandler(originatingEvent: event) { success in
+                RefreshInAppHandler.shared.handleRefreshComplete(success: success)
+            })
             fetchPropositions(event)
             return
         }

--- a/AEPMessaging/Sources/MessagingRuleEngineInterceptor.swift
+++ b/AEPMessaging/Sources/MessagingRuleEngineInterceptor.swift
@@ -19,19 +19,48 @@ import Foundation
 /// definitions from the remote before allowing the rule consequences to be processed.
 class MessagingRuleEngineInterceptor: RuleReevaluationInterceptor {
     
+    /// Serial queue for thread-safe access to state
+    private let queue = DispatchQueue(label: "com.adobe.messaging.reevaluation.queue")
+    
+    private var isRefreshInProgress = false
+    private var pendingCompletions: [() -> Void] = []
+    
     func onReevaluationTriggered(
         event: Event,
         reevaluableRules: [LaunchRule],
         completion: @escaping () -> Void
     ) {
-        Log.trace(label: MessagingConstants.LOG_TAG,
-                  "Reevaluation triggered for event '\(event.id)' with \(reevaluableRules.count) reevaluable rule(s). Refreshing messages.")
-        
-        Messaging.updatePropositionsForSurfaces([Surface()]) { success in
-            if success {
-                completion()
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            
+            // If refresh already in progress, queue this completion for later
+            if self.isRefreshInProgress {
+                self.pendingCompletions.append(completion)
+                Log.trace(label: MessagingConstants.LOG_TAG,
+                          "Refresh already in progress, queuing completion handler.")
+                return
+            }
+            
+            // Mark refresh as in progress and add completion to queue
+            self.isRefreshInProgress = true
+            self.pendingCompletions.append(completion)
+            
+            Log.trace(label: MessagingConstants.LOG_TAG,
+                      "Reevaluation triggered for event '\(event.id)' with \(reevaluableRules.count) reevaluable rule(s). Refreshing messages.")
+            
+            Messaging.updatePropositionsForSurfaces([Surface()]) { [weak self] success in
+                self?.queue.async {
+                    guard let self = self else { return }
+                    
+                    let completionsToCall = self.pendingCompletions
+                    self.pendingCompletions = []
+                    self.isRefreshInProgress = false
+                    
+                    if success {
+                        completionsToCall.forEach { $0() }
+                    }
+                }
             }
         }
     }
 }
-

--- a/AEPMessaging/Sources/MessagingRuleEngineInterceptor.swift
+++ b/AEPMessaging/Sources/MessagingRuleEngineInterceptor.swift
@@ -1,0 +1,37 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import AEPCore
+import AEPServices
+import Foundation
+
+/// Interceptor that handles reevaluation of rules by refreshing in-app messages.
+/// When a reevaluable rule matches, this interceptor triggers a refresh of message
+/// definitions from the remote before allowing the rule consequences to be processed.
+class MessagingRuleEngineInterceptor: RuleReevaluationInterceptor {
+    
+    func onReevaluationTriggered(
+        event: Event,
+        reevaluableRules: [LaunchRule],
+        completion: @escaping () -> Void
+    ) {
+        Log.trace(label: MessagingConstants.LOG_TAG,
+                  "Reevaluation triggered for event '\(event.id)' with \(reevaluableRules.count) reevaluable rule(s). Refreshing messages.")
+        
+        Messaging.updatePropositionsForSurfaces([Surface()]) { success in
+            if success {
+                completion()
+            }
+        }
+    }
+}
+

--- a/AEPMessaging/Sources/MessagingRuleEngineInterceptor.swift
+++ b/AEPMessaging/Sources/MessagingRuleEngineInterceptor.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2024 Adobe. All rights reserved.
+ Copyright 2026 Adobe. All rights reserved.
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/AEPMessaging/Sources/MessagingRuleEngineInterceptor.swift
+++ b/AEPMessaging/Sources/MessagingRuleEngineInterceptor.swift
@@ -25,6 +25,17 @@ class MessagingRuleEngineInterceptor: RuleReevaluationInterceptor {
     private var isRefreshInProgress = false
     private var pendingCompletions: [() -> Void] = []
     
+    /// Function to refresh propositions - internal in DEBUG for testing, private otherwise
+      #if DEBUG
+        var refreshPropositions: (@escaping (Bool) -> Void) -> Void = { completion in
+          Messaging.updatePropositionsForSurfaces([Surface()], completion)
+        }
+      #else
+        private let refreshPropositions: (@escaping (Bool) -> Void) -> Void = { completion in
+          Messaging.updatePropositionsForSurfaces([Surface()], completion)
+        }
+      #endif
+    
     func onReevaluationTriggered(
         event: Event,
         reevaluableRules: [LaunchRule],

--- a/AEPMessaging/Sources/RefreshInAppHandler.swift
+++ b/AEPMessaging/Sources/RefreshInAppHandler.swift
@@ -1,0 +1,105 @@
+/*
+ Copyright 2026 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import AEPCore
+import AEPServices
+import Foundation
+
+/// Handles refresh of in-app messages with deduplication.
+/// Ensures only one refresh is in progress at a time, queuing subsequent requests.
+/// This prevents redundant network calls when multiple components request a refresh simultaneously.
+/// Dispatches the REFRESH_MESSAGES event and manages completion handlers.
+class RefreshInAppHandler {
+    
+    /// Shared instance for use by public API and internal components
+    static let shared = RefreshInAppHandler()
+    
+    /// Serial queue for thread-safe access to state
+    private let queue = DispatchQueue(label: "com.adobe.messaging.refresh.queue")
+    
+    /// Indicates whether a refresh operation is currently in progress
+    private var isRefreshInProgress = false
+    
+    /// Completion handlers waiting for the current refresh to complete
+    private var pendingCompletions: [(Bool) -> Void] = []
+    
+    /// Requests a refresh of in-app messages.
+    /// If a refresh is already in progress, the completion is queued and will be called
+    /// when the current refresh completes. All queued completions receive the same result.
+    ///
+    /// - Parameter completion: Optional callback with `true` on success, `false` on failure
+    func refresh(completion: ((Bool) -> Void)? = nil) {
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            
+            // Add completion to queue if provided
+            if let completion = completion {
+                self.pendingCompletions.append(completion)
+            }
+            
+            // If refresh already in progress, just queue the completion and return
+            if self.isRefreshInProgress {
+                Log.trace(label: MessagingConstants.LOG_TAG,
+                          "Refresh already in progress, queuing completion handler. Total pending: \(self.pendingCompletions.count)")
+                return
+            }
+            
+            // Mark refresh as in progress
+            self.isRefreshInProgress = true
+            
+            Log.trace(label: MessagingConstants.LOG_TAG, "Starting in-app message refresh.")
+            
+            // Dispatch the refresh event
+            self.dispatchRefreshEvent()
+        }
+    }
+    
+    /// Called by Messaging extension when refresh completes
+    /// - Parameter success: Whether the refresh succeeded
+    func handleRefreshComplete(success: Bool) {
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            
+            let completionsToCall = self.pendingCompletions
+            self.pendingCompletions = []
+            self.isRefreshInProgress = false
+            
+            Log.trace(label: MessagingConstants.LOG_TAG,
+                      "Refresh completed (success: \(success)), calling \(completionsToCall.count) completion handler(s).")
+            
+            // Call all queued completions with the result
+            completionsToCall.forEach { $0(success) }
+        }
+    }
+    
+    /// Dispatches the REFRESH_MESSAGES event
+    private func dispatchRefreshEvent() {
+        let eventData: [String: Any] = [MessagingConstants.Event.Data.Key.REFRESH_MESSAGES: true]
+        let event = Event(name: MessagingConstants.Event.Name.REFRESH_MESSAGES,
+                          type: EventType.messaging,
+                          source: EventSource.requestContent,
+                          data: eventData)
+        
+        MobileCore.dispatch(event: event)
+    }
+    
+    /// Resets the handler state. Used for testing.
+    #if DEBUG
+    func reset() {
+        queue.sync {
+            pendingCompletions.removeAll()
+            isRefreshInProgress = false
+        }
+    }
+    #endif
+}
+

--- a/AEPMessaging/Tests/FunctionalTests/ReevaluationFunctionalTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/ReevaluationFunctionalTests.swift
@@ -1,0 +1,109 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+@testable import AEPCore
+@testable import AEPMessaging
+@testable import AEPRulesEngine
+@testable import AEPServices
+import AEPTestUtils
+import XCTest
+
+class ReevaluationFunctionalTests: XCTestCase {
+    
+    var messaging: Messaging!
+    var mockRuntime: TestableExtensionRuntime!
+    
+    override func setUp() {
+        super.setUp()
+        mockRuntime = TestableExtensionRuntime()
+        mockRuntime.ignoreEvent(type: EventType.rulesEngine, source: EventSource.requestReset)
+        messaging = Messaging(runtime: mockRuntime)
+        messaging?.onRegistered()
+    }
+    
+    override func tearDown() {
+        messaging = nil
+        mockRuntime = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Reevaluation Interceptor Tests
+    
+    /// Verifies that MessagingRuleEngineInterceptor conforms to RuleReevaluationInterceptor protocol
+    func testMessagingRuleEngineInterceptorConformsToProtocol() {
+        // Setup
+        let interceptor = MessagingRuleEngineInterceptor()
+        
+        // Verify - interceptor should conform to the protocol
+        XCTAssertNotNil(interceptor as RuleReevaluationInterceptor,
+                        "MessagingRuleEngineInterceptor should conform to RuleReevaluationInterceptor protocol")
+    }
+    
+    /// Verifies that MessagingRuleEngineInterceptor can be instantiated
+    func testMessagingRuleEngineInterceptorInstantiation() {
+        // Setup & Test
+        let interceptor = MessagingRuleEngineInterceptor()
+        
+        // Verify
+        XCTAssertNotNil(interceptor, "MessagingRuleEngineInterceptor should be instantiable")
+    }
+    
+    /// Verifies that Messaging extension initializes successfully with runtime
+    func testMessagingInitializesSuccessfully() {
+        // Verify - messaging should be initialized in setUp
+        XCTAssertNotNil(messaging, "Messaging should initialize successfully with runtime")
+    }
+    
+    /// Verifies that onReevaluationTriggered can be called without crashing
+    func testOnReevaluationTriggeredDoesNotCrash() {
+        // Setup
+        let interceptor = MessagingRuleEngineInterceptor()
+        let event = Event(name: "Test Event", type: EventType.genericTrack, source: EventSource.requestContent, data: nil)
+        
+        // Create a rule consequence
+        let consequence = RuleConsequence(id: "testConsequence", type: "schema", details: [:])
+        
+        // Create a simple condition using ComparisonExpression from AEPRulesEngine
+        let condition = ComparisonExpression(lhs: "true", operationName: "equals", rhs: "true")
+        let rule = LaunchRule(condition: condition, consequences: [consequence])
+        
+        let expectation = XCTestExpectation(description: "Method should not crash")
+        expectation.isInverted = true // We don't expect completion without real SDK setup
+        
+        // Test - this should not crash
+        interceptor.onReevaluationTriggered(event: event, reevaluableRules: [rule]) {
+            expectation.fulfill()
+        }
+        
+        // Verify - just verify no crash, completion won't fire in test environment
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    /// Verifies that onReevaluationTriggered handles empty rules array gracefully
+    func testOnReevaluationTriggeredWithEmptyRules() {
+        // Setup
+        let interceptor = MessagingRuleEngineInterceptor()
+        let event = Event(name: "Test Event", type: EventType.genericTrack, source: EventSource.requestContent, data: nil)
+        
+        let expectation = XCTestExpectation(description: "Method should handle empty rules")
+        expectation.isInverted = true
+        
+        // Test - this should not crash even with empty rules
+        interceptor.onReevaluationTriggered(event: event, reevaluableRules: []) {
+            expectation.fulfill()
+        }
+        
+        // Verify - no crash
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+

--- a/AEPMessaging/Tests/TestHelpers/MockLaunchRulesEngine.swift
+++ b/AEPMessaging/Tests/TestHelpers/MockLaunchRulesEngine.swift
@@ -49,4 +49,11 @@ class MockLaunchRulesEngine: LaunchRulesEngine {
         addRulesCalled = true
         paramAddRulesRules = rules
     }
+    
+    var setReevaluationInterceptorCalled: Bool = false
+    var paramReevaluationInterceptor: RuleReevaluationInterceptor?
+    override func setReevaluationInterceptor(_ interceptor: RuleReevaluationInterceptor?) {
+        setReevaluationInterceptorCalled = true
+        paramReevaluationInterceptor = interceptor
+    }
 }

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -289,18 +289,19 @@ class MessagingPublicApiTest: XCTestCase, AnyCodableAsserts {
         wait(for: [eventExpectation], timeout: ASYNC_TIMEOUT)
     }
     
-    func testHandleNotificationResponse_when_userInfoHasPushToInapp_then_updatePropositionsCalled() throws {
+    func testHandleNotificationResponse_when_userInfoHasPushToInapp_then_refreshMessagesCalled() throws {
         // setup
+        RefreshInAppHandler.shared.reset()
         let iamId = "mockIamId"
         var trackingData = MessagingPublicApiTest.MOCK_TRACKING_DETAILS
         trackingData["adb_iam_id"] = iamId
         let notificationResponse = createNotificationResponse(trackingData: trackingData)
                 
-        // register listener for update propositions call
-        let updatePropositionsExpectation = XCTestExpectation(description: "UpdatePropositions should be called")
+        // register listener for refresh messages call (Push-to-InApp now uses RefreshInAppHandler)
+        let refreshMessagesExpectation = XCTestExpectation(description: "RefreshMessages should be called")
         MobileCore.registerEventListener(type: EventType.messaging, source: EventSource.requestContent) { event in
-            if event.name == "Update propositions" {
-                updatePropositionsExpectation.fulfill()
+            if event.name == MessagingConstants.Event.Name.REFRESH_MESSAGES {
+                refreshMessagesExpectation.fulfill()
             }
         }
         
@@ -308,12 +309,13 @@ class MessagingPublicApiTest: XCTestCase, AnyCodableAsserts {
         Messaging.handleNotificationResponse(notificationResponse)
         
         // verify
-        wait(for: [updatePropositionsExpectation], timeout: ASYNC_TIMEOUT)
+        wait(for: [refreshMessagesExpectation], timeout: ASYNC_TIMEOUT)
     }
     
     
     func testRefreshInAppMessages() throws {
         // setup
+        RefreshInAppHandler.shared.reset()
         let expectation = XCTestExpectation(description: "Refresh In app messages event")
         expectation.assertForOverFulfill = true
         

--- a/AEPMessaging/Tests/UnitTests/MessagingRuleEngineInterceptorTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingRuleEngineInterceptorTests.swift
@@ -30,6 +30,7 @@ class MessagingRuleEngineInterceptorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         EventHub.shared.start()
+        RefreshInAppHandler.shared.reset()
         interceptor = MessagingRuleEngineInterceptor()
         mockRuntime = TestableExtensionRuntime()
         mockCache = MockCache(name: "mockCache")
@@ -39,6 +40,7 @@ class MessagingRuleEngineInterceptorTests: XCTestCase {
     }
     
     override func tearDown() {
+        RefreshInAppHandler.shared.reset()
         interceptor = nil
         mockRuntime = nil
         mockLaunchRulesEngine = nil

--- a/AEPMessaging/Tests/UnitTests/MessagingRuleEngineInterceptorTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingRuleEngineInterceptorTests.swift
@@ -1,0 +1,96 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+@testable import AEPCore
+@testable import AEPMessaging
+import AEPServices
+import AEPTestUtils
+import XCTest
+
+class MessagingRuleEngineInterceptorTests: XCTestCase {
+    
+    var interceptor: MessagingRuleEngineInterceptor!
+    var mockRuntime: TestableExtensionRuntime!
+    var mockLaunchRulesEngine: MockLaunchRulesEngine!
+    var mockMessagingRulesEngine: MockMessagingRulesEngine!
+    var mockContentCardRulesEngine: MockContentCardRulesEngine!
+    var mockCache: MockCache!
+    var messaging: Messaging!
+    
+    override func setUp() {
+        super.setUp()
+        EventHub.shared.start()
+        interceptor = MessagingRuleEngineInterceptor()
+        mockRuntime = TestableExtensionRuntime()
+        mockCache = MockCache(name: "mockCache")
+        mockLaunchRulesEngine = MockLaunchRulesEngine(name: "mockLaunchRulesEngine", extensionRuntime: mockRuntime)
+        mockMessagingRulesEngine = MockMessagingRulesEngine(extensionRuntime: mockRuntime, launchRulesEngine: mockLaunchRulesEngine, cache: mockCache)
+        mockContentCardRulesEngine = MockContentCardRulesEngine(extensionRuntime: mockRuntime, launchRulesEngine: mockLaunchRulesEngine)
+    }
+    
+    override func tearDown() {
+        interceptor = nil
+        mockRuntime = nil
+        mockLaunchRulesEngine = nil
+        mockMessagingRulesEngine = nil
+        mockContentCardRulesEngine = nil
+        mockCache = nil
+        messaging = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Messaging Extension Interceptor Registration Tests
+    
+    func testMessagingInit_registersReevaluationInterceptor() {
+        // Setup & Test
+        let messagingProperties = MessagingProperties()
+        messaging = Messaging(runtime: mockRuntime,
+                             rulesEngine: mockMessagingRulesEngine,
+                             contentCardRulesEngine: mockContentCardRulesEngine,
+                             expectedSurfaceUri: "mobileapp://test",
+                             cache: mockCache,
+                             messagingProperties: messagingProperties)
+        
+        // Verify - the interceptor should be set on the launch rules engine
+        XCTAssertTrue(mockLaunchRulesEngine.setReevaluationInterceptorCalled,
+                      "setReevaluationInterceptor should be called during Messaging initialization")
+        XCTAssertNotNil(mockLaunchRulesEngine.paramReevaluationInterceptor,
+                        "Reevaluation interceptor should not be nil")
+    }
+    
+    func testMessagingInit_interceptorIsCorrectType() {
+        // Setup & Test
+        let messagingProperties = MessagingProperties()
+        messaging = Messaging(runtime: mockRuntime,
+                             rulesEngine: mockMessagingRulesEngine,
+                             contentCardRulesEngine: mockContentCardRulesEngine,
+                             expectedSurfaceUri: "mobileapp://test",
+                             cache: mockCache,
+                             messagingProperties: messagingProperties)
+        
+        // Verify
+        guard let interceptor = mockLaunchRulesEngine.paramReevaluationInterceptor else {
+            XCTFail("Interceptor should be set")
+            return
+        }
+        
+        XCTAssertTrue(interceptor is MessagingRuleEngineInterceptor,
+                      "Registered interceptor should be MessagingRuleEngineInterceptor")
+    }
+    
+    func testInterceptorConformsToRuleReevaluationInterceptor() {
+        // Verify the interceptor conforms to the protocol
+        XCTAssertTrue(interceptor is RuleReevaluationInterceptor,
+                      "MessagingRuleEngineInterceptor should conform to RuleReevaluationInterceptor")
+    }
+}
+

--- a/AEPMessaging/Tests/UnitTests/MessagingRuleEngineInterceptorTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingRuleEngineInterceptorTests.swift
@@ -12,6 +12,7 @@
 
 @testable import AEPCore
 @testable import AEPMessaging
+@testable import AEPRulesEngine
 import AEPServices
 import AEPTestUtils
 import XCTest
@@ -46,6 +47,18 @@ class MessagingRuleEngineInterceptorTests: XCTestCase {
         mockCache = nil
         messaging = nil
         super.tearDown()
+    }
+    
+    // MARK: - Helper Methods
+    
+    func createTestEvent(name: String = "Test Event") -> Event {
+        return Event(name: name, type: EventType.genericTrack, source: EventSource.requestContent, data: nil)
+    }
+    
+    func createTestRule() -> LaunchRule {
+        let consequence = RuleConsequence(id: "testConsequence", type: "schema", details: [:])
+        let condition = ComparisonExpression(lhs: "true", operationName: "equals", rhs: "true")
+        return LaunchRule(condition: condition, consequences: [consequence])
     }
     
     // MARK: - Messaging Extension Interceptor Registration Tests
@@ -92,5 +105,261 @@ class MessagingRuleEngineInterceptorTests: XCTestCase {
         XCTAssertTrue(interceptor is RuleReevaluationInterceptor,
                       "MessagingRuleEngineInterceptor should conform to RuleReevaluationInterceptor")
     }
+    
+    // MARK: - Single Request Tests
+    
+    func testOnReevaluationTriggered_singleRequest_completionCalledOnSuccess() {
+        // Setup
+        let completionExpectation = expectation(description: "Completion should be called")
+        var refreshCallCount = 0
+        
+        interceptor.refreshPropositions = { completion in
+            refreshCallCount += 1
+            // Simulate successful refresh
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+                completion(true)
+            }
+        }
+        
+        let event = createTestEvent()
+        let rule = createTestRule()
+        
+        // Test
+        interceptor.onReevaluationTriggered(event: event, reevaluableRules: [rule]) {
+            completionExpectation.fulfill()
+        }
+        
+        // Verify
+        wait(for: [completionExpectation], timeout: 2.0)
+        XCTAssertEqual(refreshCallCount, 1, "Refresh should be called exactly once")
+    }
+    
+    func testOnReevaluationTriggered_singleRequest_completionNotCalledOnFailure() {
+        // Setup
+        let completionExpectation = expectation(description: "Completion should not be called")
+        completionExpectation.isInverted = true
+        var refreshCallCount = 0
+        
+        interceptor.refreshPropositions = { completion in
+            refreshCallCount += 1
+            // Simulate failed refresh
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+                completion(false)
+            }
+        }
+        
+        let event = createTestEvent()
+        let rule = createTestRule()
+        
+        // Test
+        interceptor.onReevaluationTriggered(event: event, reevaluableRules: [rule]) {
+            completionExpectation.fulfill()
+        }
+        
+        // Verify
+        wait(for: [completionExpectation], timeout: 1.0)
+        XCTAssertEqual(refreshCallCount, 1, "Refresh should be called exactly once")
+    }
+    
+    // MARK: - Queueing Behavior Tests
+    
+    func testOnReevaluationTriggered_multipleRequests_queuesCompletions() {
+        // Setup
+        let completion1Expectation = expectation(description: "Completion 1 should be called")
+        let completion2Expectation = expectation(description: "Completion 2 should be called")
+        let completion3Expectation = expectation(description: "Completion 3 should be called")
+        
+        var refreshCallCount = 0
+        var storedCompletion: ((Bool) -> Void)?
+        
+        interceptor.refreshPropositions = { completion in
+            refreshCallCount += 1
+            storedCompletion = completion
+        }
+        
+        let event1 = createTestEvent(name: "Event 1")
+        let event2 = createTestEvent(name: "Event 2")
+        let event3 = createTestEvent(name: "Event 3")
+        let rule = createTestRule()
+        
+        // Test - trigger multiple requests quickly
+        interceptor.onReevaluationTriggered(event: event1, reevaluableRules: [rule]) {
+            completion1Expectation.fulfill()
+        }
+        
+        // Allow first request to start
+        Thread.sleep(forTimeInterval: 0.05)
+        
+        interceptor.onReevaluationTriggered(event: event2, reevaluableRules: [rule]) {
+            completion2Expectation.fulfill()
+        }
+        
+        interceptor.onReevaluationTriggered(event: event3, reevaluableRules: [rule]) {
+            completion3Expectation.fulfill()
+        }
+        
+        // Wait a bit for all requests to be queued
+        Thread.sleep(forTimeInterval: 0.1)
+        
+        // Complete the refresh
+        storedCompletion?(true)
+        
+        // Verify
+        wait(for: [completion1Expectation, completion2Expectation, completion3Expectation], timeout: 2.0)
+        XCTAssertEqual(refreshCallCount, 1, "Refresh should be called only once even with multiple requests")
+    }
+    
+    func testOnReevaluationTriggered_multipleRequests_noCompletionsOnFailure() {
+        // Setup
+        let completion1Expectation = expectation(description: "Completion 1 should not be called")
+        completion1Expectation.isInverted = true
+        let completion2Expectation = expectation(description: "Completion 2 should not be called")
+        completion2Expectation.isInverted = true
+        
+        var storedCompletion: ((Bool) -> Void)?
+        
+        interceptor.refreshPropositions = { completion in
+            storedCompletion = completion
+        }
+        
+        let event1 = createTestEvent(name: "Event 1")
+        let event2 = createTestEvent(name: "Event 2")
+        let rule = createTestRule()
+        
+        // Test
+        interceptor.onReevaluationTriggered(event: event1, reevaluableRules: [rule]) {
+            completion1Expectation.fulfill()
+        }
+        
+        Thread.sleep(forTimeInterval: 0.05)
+        
+        interceptor.onReevaluationTriggered(event: event2, reevaluableRules: [rule]) {
+            completion2Expectation.fulfill()
+        }
+        
+        Thread.sleep(forTimeInterval: 0.1)
+        
+        // Fail the refresh
+        storedCompletion?(false)
+        
+        // Verify - neither completion should be called
+        wait(for: [completion1Expectation, completion2Expectation], timeout: 1.0)
+    }
+    
+    // MARK: - Sequential Request Tests
+    
+    func testOnReevaluationTriggered_sequentialRequests_eachTriggersRefresh() {
+        // Setup
+        let completion1Expectation = expectation(description: "Completion 1 should be called")
+        let completion2Expectation = expectation(description: "Completion 2 should be called")
+        
+        var refreshCallCount = 0
+        
+        interceptor.refreshPropositions = { completion in
+            refreshCallCount += 1
+            // Complete immediately
+            DispatchQueue.global().async {
+                completion(true)
+            }
+        }
+        
+        let event1 = createTestEvent(name: "Event 1")
+        let event2 = createTestEvent(name: "Event 2")
+        let rule = createTestRule()
+        
+        // Test - trigger first request and wait for completion
+        interceptor.onReevaluationTriggered(event: event1, reevaluableRules: [rule]) {
+            completion1Expectation.fulfill()
+        }
+        
+        wait(for: [completion1Expectation], timeout: 2.0)
+        
+        // Trigger second request after first completes
+        interceptor.onReevaluationTriggered(event: event2, reevaluableRules: [rule]) {
+            completion2Expectation.fulfill()
+        }
+        
+        wait(for: [completion2Expectation], timeout: 2.0)
+        
+        // Verify - each sequential request should trigger its own refresh
+        XCTAssertEqual(refreshCallCount, 2, "Sequential requests should each trigger refresh")
+    }
+    
+    // MARK: - Empty Rules Tests
+    
+    func testOnReevaluationTriggered_emptyRules_stillTriggersRefresh() {
+        // Setup
+        let completionExpectation = expectation(description: "Completion should be called")
+        var refreshCallCount = 0
+        
+        interceptor.refreshPropositions = { completion in
+            refreshCallCount += 1
+            DispatchQueue.global().async {
+                completion(true)
+            }
+        }
+        
+        let event = createTestEvent()
+        
+        // Test - trigger with empty rules
+        interceptor.onReevaluationTriggered(event: event, reevaluableRules: []) {
+            completionExpectation.fulfill()
+        }
+        
+        // Verify
+        wait(for: [completionExpectation], timeout: 2.0)
+        XCTAssertEqual(refreshCallCount, 1, "Empty rules should still trigger refresh")
+    }
+    
+    // MARK: - Thread Safety Tests
+    
+    func testOnReevaluationTriggered_concurrentCalls_handledSafely() {
+        // Setup
+        let concurrentQueue = DispatchQueue(label: "test.concurrent", attributes: .concurrent)
+        let completionGroup = DispatchGroup()
+        var completionCount = 0
+        let countLock = NSLock()
+        let numberOfRequests = 10
+        
+        var storedCompletion: ((Bool) -> Void)?
+        var refreshCallCount = 0
+        let refreshLock = NSLock()
+        
+        interceptor.refreshPropositions = { completion in
+            refreshLock.lock()
+            refreshCallCount += 1
+            if storedCompletion == nil {
+                storedCompletion = completion
+            }
+            refreshLock.unlock()
+        }
+        
+        let rule = createTestRule()
+        
+        // Test - trigger many concurrent requests
+        for i in 0..<numberOfRequests {
+            completionGroup.enter()
+            concurrentQueue.async {
+                let event = self.createTestEvent(name: "Event \(i)")
+                self.interceptor.onReevaluationTriggered(event: event, reevaluableRules: [rule]) {
+                    countLock.lock()
+                    completionCount += 1
+                    countLock.unlock()
+                    completionGroup.leave()
+                }
+            }
+        }
+        
+        // Wait for all requests to be submitted
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        // Complete the refresh
+        storedCompletion?(true)
+        
+        // Verify
+        let result = completionGroup.wait(timeout: .now() + 5.0)
+        XCTAssertEqual(result, .success, "All completions should be called")
+        XCTAssertEqual(completionCount, numberOfRequests, "All \(numberOfRequests) completions should be called")
+        XCTAssertEqual(refreshCallCount, 1, "Only one refresh should be triggered for concurrent requests")
+    }
 }
-

--- a/AEPMessaging/Tests/UnitTests/RefreshInAppHandlerTests.swift
+++ b/AEPMessaging/Tests/UnitTests/RefreshInAppHandlerTests.swift
@@ -1,0 +1,233 @@
+/*
+ Copyright 2026 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+@testable import AEPMessaging
+import XCTest
+
+class RefreshInAppHandlerTests: XCTestCase {
+    
+    var handler: RefreshInAppHandler!
+    
+    override func setUp() {
+        super.setUp()
+        RefreshInAppHandler.shared.reset()
+        handler = RefreshInAppHandler.shared
+    }
+    
+    override func tearDown() {
+        RefreshInAppHandler.shared.reset()
+        handler = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Single Request Tests
+    
+    func testRefresh_singleRequest_completionCalledOnSuccess() {
+        // Setup
+        let expectation = self.expectation(description: "Completion called")
+        var receivedSuccess: Bool?
+        
+        // Test - call refresh then simulate completion from Messaging extension
+        handler.refresh { success in
+            receivedSuccess = success
+            expectation.fulfill()
+        }
+        
+        // Simulate Messaging extension completing the refresh
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+            self.handler.handleRefreshComplete(success: true)
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+        
+        // Verify
+        XCTAssertEqual(receivedSuccess, true, "Should receive success")
+    }
+    
+    func testRefresh_singleRequest_completionCalledOnFailure() {
+        // Setup
+        let expectation = self.expectation(description: "Completion called")
+        var receivedSuccess: Bool?
+        
+        // Test
+        handler.refresh { success in
+            receivedSuccess = success
+            expectation.fulfill()
+        }
+        
+        // Simulate failure
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+            self.handler.handleRefreshComplete(success: false)
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+        
+        // Verify
+        XCTAssertEqual(receivedSuccess, false, "Should receive failure")
+    }
+    
+    // MARK: - Multiple Concurrent Requests Tests
+    
+    func testRefresh_multipleConcurrentRequests_allReceiveSameResult() {
+        // Setup
+        let expectation1 = self.expectation(description: "Completion 1 called")
+        let expectation2 = self.expectation(description: "Completion 2 called")
+        let expectation3 = self.expectation(description: "Completion 3 called")
+        
+        var results: [Bool] = []
+        let resultsLock = NSLock()
+        
+        // Test - fire 3 requests in quick succession
+        handler.refresh { success in
+            resultsLock.lock()
+            results.append(success)
+            resultsLock.unlock()
+            expectation1.fulfill()
+        }
+        
+        handler.refresh { success in
+            resultsLock.lock()
+            results.append(success)
+            resultsLock.unlock()
+            expectation2.fulfill()
+        }
+        
+        handler.refresh { success in
+            resultsLock.lock()
+            results.append(success)
+            resultsLock.unlock()
+            expectation3.fulfill()
+        }
+        
+        // Simulate single completion from Messaging extension
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            self.handler.handleRefreshComplete(success: true)
+        }
+        
+        wait(for: [expectation1, expectation2, expectation3], timeout: 2.0)
+        
+        // Verify - all 3 completions should receive the same result
+        XCTAssertEqual(results.count, 3, "All 3 completions should be called")
+        XCTAssertTrue(results.allSatisfy { $0 == true }, "All completions should receive success")
+    }
+    
+    func testRefresh_multipleConcurrentRequests_allReceiveFailureOnFailure() {
+        // Setup
+        let expectation1 = self.expectation(description: "Completion 1 called")
+        let expectation2 = self.expectation(description: "Completion 2 called")
+        
+        var results: [Bool] = []
+        let resultsLock = NSLock()
+        
+        // Test
+        handler.refresh { success in
+            resultsLock.lock()
+            results.append(success)
+            resultsLock.unlock()
+            expectation1.fulfill()
+        }
+        
+        handler.refresh { success in
+            resultsLock.lock()
+            results.append(success)
+            resultsLock.unlock()
+            expectation2.fulfill()
+        }
+        
+        // Simulate failure
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            self.handler.handleRefreshComplete(success: false)
+        }
+        
+        wait(for: [expectation1, expectation2], timeout: 2.0)
+        
+        // Verify
+        XCTAssertEqual(results.count, 2, "Both completions should be called")
+        XCTAssertTrue(results.allSatisfy { $0 == false }, "All completions should receive failure")
+    }
+    
+    // MARK: - Sequential Requests Tests
+    
+    func testRefresh_sequentialRequests_eachCompletesIndependently() {
+        // Setup
+        let expectation1 = self.expectation(description: "First request completed")
+        let expectation2 = self.expectation(description: "Second request completed")
+        
+        // Test - first request
+        handler.refresh { _ in
+            expectation1.fulfill()
+        }
+        
+        // Complete first request
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+            self.handler.handleRefreshComplete(success: true)
+        }
+        
+        wait(for: [expectation1], timeout: 1.0)
+        
+        // Second request after first completes
+        handler.refresh { _ in
+            expectation2.fulfill()
+        }
+        
+        // Complete second request
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+            self.handler.handleRefreshComplete(success: true)
+        }
+        
+        wait(for: [expectation2], timeout: 1.0)
+    }
+    
+    // MARK: - Thread Safety Tests
+    
+    func testRefresh_concurrentRequestsFromMultipleThreads_noDataRace() {
+        // Setup
+        let expectations = (0..<10).map { self.expectation(description: "Completion \($0) called") }
+        
+        // Test - fire requests from multiple threads
+        for i in 0..<10 {
+            DispatchQueue.global().async {
+                self.handler.refresh { _ in
+                    expectations[i].fulfill()
+                }
+            }
+        }
+        
+        // Wait a bit for all requests to be queued, then complete
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            self.handler.handleRefreshComplete(success: true)
+        }
+        
+        wait(for: expectations, timeout: 2.0)
+        // Test passes if no crashes - validates thread safety
+    }
+    
+    // MARK: - No Completion Handler Tests
+    
+    func testRefresh_noCompletionHandler_doesNotCrash() {
+        // Test - call refresh without completion
+        handler.refresh()
+        
+        // Simulate completion
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+            self.handler.handleRefreshComplete(success: true)
+        }
+        
+        // Wait to ensure no crash
+        let expectation = self.expectation(description: "No crash")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+


### PR DESCRIPTION
- Add MessagingRuleEngineInterceptor class that implements RuleReevaluationInterceptor
- Register interceptor in Messaging init to handle reevaluable rules
- Interceptor calls updatePropositionsForSurfaces and completion on success
- Add unit tests for interceptor registration and type verification
- Add functional tests for interceptor protocol conformance
- Add logic to prevent multiple refresh call if a refresh call is already in progress. 
- Provided Completion in case of failure for refresh or update call

##To-Do
- Update version of AEP Core and AEP Messaging once Core is released. 

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
