### PR TITLE
[PLATIR-60272] - Added public API to Message.swift that records a display event in the device's event history

### DIFF
--- a/AEPMessaging/Sources/Message.swift
+++ b/AEPMessaging/Sources/Message.swift
@@ -84,7 +84,14 @@ public class Message: NSObject {
 
         fullscreenMessage?.dismiss()
     }
-
+    
+    /// Records a display event in the device's event history database.
+    /// Should only be used in conjunction with a `MessagingDelegate` to enforce show frequency rules even if the `Message` was suppressed.
+    @objc
+    public func recordDisplay() {
+        recordEventHistory(eventType: .display, interaction: nil)
+    }
+    
     // MARK: - Edge Event creation
 
     /// Generates an Edge Event for the provided `interaction` and `eventType`.

--- a/Documentation/sources/inapp-messaging/advanced-guides/how-to-messaging-delegate.md
+++ b/Documentation/sources/inapp-messaging/advanced-guides/how-to-messaging-delegate.md
@@ -121,6 +121,29 @@ func shouldShowMessage(message: Showable) -> Bool {
 }
 ```
 
+## Recording a display event for suppressed messages
+
+When you suppress a message by returning `false` from `shouldShowMessage`, frequency capping rules will not count that suppression as a display. If you want frequency capping to treat the suppressed message as though it was displayed, call the `recordDisplay()` method on the `Message` object.
+
+This is useful when you want to ensure that a user doesn't qualify for the same message again, even though it was suppressed:
+
+```swift
+func shouldShowMessage(message: Showable) -> Bool {
+    let fullscreenMessage = message as? FullscreenMessage
+    let message = fullscreenMessage?.parent
+
+    if shouldSuppressMessage {
+        // Record the display event to enforce frequency capping
+        // even though the message is not shown
+        message?.recordDisplay()
+        
+        return false
+    }
+
+    return true
+}
+```
+
 ## Integrating the message into an existing UI
 
 If the developer would like to manually integrate the `View` that contains the UI for an in-app message, they can do so by accessing the `WKWebView` directly in a `MessagingDelegate` method.  

--- a/Documentation/sources/inapp-messaging/developer-documentation/message.md
+++ b/Documentation/sources/inapp-messaging/developer-documentation/message.md
@@ -71,6 +71,16 @@ public func track(_ interaction: String?, withEdgeEventType eventType: Messaging
 - _interaction_ - a custom `String` value to be recorded in the interaction
 - _eventType_ - the [`MessagingEdgeEventType`](./../../shared/enums/enum-messaging-edge-event-type.md) to be used for the ensuing Edge Event
 
+## recordDisplay
+
+Records a display event in the device's event history database.
+
+This method should be used in conjunction with a `MessagingDelegate` to enforce show frequency rules even if the `Message` was suppressed. Unlike `track(_:withEdgeEventType:)`, this method only writes to local event history and does not dispatch an Edge Event.
+
+```swift
+public func recordDisplay()
+```
+
 ## handleJavascriptMessage(_:withHandler:)
 
 Adds a handler for named Javascript messages sent from the message's `WKWebView`.


### PR DESCRIPTION
## Description

- new API, `Message.recordDisplay()`, added to record a display event in the device's event history

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
