### PR TITLE
Unread Icon default size + Modifier for base template

### DIFF
--- a/AEPMessaging/Sources/UI/ContentCards/Template/BaseTemplate.swift
+++ b/AEPMessaging/Sources/UI/ContentCards/Template/BaseTemplate.swift
@@ -31,6 +31,11 @@ public class BaseTemplate: ObservableObject {
     /// Use this property to set the background color for the content card.
     @Published public var backgroundColor: Color?
 
+    /// Custom view modifier applied to the entire card, including its background.
+    /// Use this to control card-level presentation: corner radius, shadow, border, etc.
+    /// This is applied after the background color, so clipShape here will correctly round both content and background.
+    @Published public var modifier: AEPViewModifier?
+
     /// the dismiss button model
     @Published public var dismissButton: AEPDismissButton?
 
@@ -118,5 +123,7 @@ private struct TemplateWrapperView<Content: View>: View {
                             .padding(UIConstants.CardTemplate.DefaultStyle.PADDING)
                     }
                 })
+            // Card-level modifier: applied last so it wraps content + background + overlays
+            .applyModifier(template.modifier)
     }
 }

--- a/AEPMessaging/Sources/UI/UIConstants.swift
+++ b/AEPMessaging/Sources/UI/UIConstants.swift
@@ -137,6 +137,11 @@ enum UIConstants {
                 static let MESSAGE = "Loading..."
                 static let MESSAGE_COLOR = Color.secondary
             }
+
+            enum UnreadIcon {
+                static let SIZE: CGFloat = 24
+                static let PADDING: CGFloat = 6
+            }
         }
     }
 }

--- a/AEPMessaging/Sources/UI/UIElements/AEPUnreadIcon/AEPUnreadIcon.swift
+++ b/AEPMessaging/Sources/UI/UIElements/AEPUnreadIcon/AEPUnreadIcon.swift
@@ -37,6 +37,21 @@ public class AEPUnreadIcon: ObservableObject, AEPViewModel {
     init(settings: UnreadIndicatorSettings.UnreadIconSettings) {
         self.image = settings.image
         self.alignment = settings.placement.alignment
+        // Apply a sensible default size so the icon doesn't bloat the card.
+        // Customers can override this by setting image.modifier in their ContentCardCustomizing implementation.
+        self.image.modifier = AEPViewModifier(UnreadIconDefaultModifier())
+    }
+}
+
+/// Default size constraint applied to the unread icon image.
+/// Keeps the icon at a fixed size with padding so it sits neatly as a card overlay.
+@available(iOS 15.0, *)
+private struct UnreadIconDefaultModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .frame(width: UIConstants.Inbox.DefaultStyle.UnreadIcon.SIZE,
+                   height: UIConstants.Inbox.DefaultStyle.UnreadIcon.SIZE)
+            .padding(UIConstants.Inbox.DefaultStyle.UnreadIcon.PADDING)
     }
 }
 

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/InboxView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/InboxView.swift
@@ -244,7 +244,7 @@ class InboxCustomizer: ContentCardCustomizing {
         template.textVStack.spacing = 4
         template.textVStack.modifier = AEPViewModifier(InboxTextAreaModifier())
         template.buttonHStack.modifier = AEPViewModifier(InboxLargeButtonHStackModifier())
-        template.rootVStack.modifier = AEPViewModifier(InboxCardContainerModifier())
+        template.modifier = AEPViewModifier(InboxCardContainerModifier())
 
         template.dismissButton?.image.iconColor = .white
         template.dismissButton?.image.iconFont = .system(size: 12, weight: .semibold)
@@ -267,7 +267,7 @@ class InboxCustomizer: ContentCardCustomizing {
         template.textVStack.spacing = 4
         template.textVStack.modifier = AEPViewModifier(InboxTextAreaModifier())
         template.buttonHStack.modifier = AEPViewModifier(InboxSmallButtonHStackModifier())
-        template.rootHStack.modifier = AEPViewModifier(InboxCardContainerModifier())
+        template.modifier = AEPViewModifier(InboxCardContainerModifier())
 
         template.dismissButton?.image.iconColor = .primary
         template.dismissButton?.image.iconFont = .system(size: 10, weight: .semibold)
@@ -319,7 +319,6 @@ struct InboxCardContainerModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .frame(maxWidth: .infinity)
-            .background(Color(.systemBackground))
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .shadow(color: .black.opacity(0.08), radius: 8, x: 0, y: 4)
     }


### PR DESCRIPTION
**BaseTemplate — Card-level modifier property**

  Added modifier: AEPViewModifier? to BaseTemplate. It is applied in TemplateWrapperView after the background color and overlays, so it wraps the entire card as a single unit.

Significance:
   Previously, customers used rootHStack.modifier / rootVStack.modifier to apply card-level styling (corner radius, shadow, border). But template.backgroundColor is applied outside those stacks, so commond modifiers like clipShape in the root stack only clipped the content — not the background — producing a layering mismatch. With template.modifier, a clipShape correctly rounds both content and background together.
   
   
   + Applying default size and padding for Unread Icon
   