### PR TITLE
Content Card Cache Cleanup

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 		9285941C2522899700B2BE47 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 925DF44A2522785700A5DE31 /* Main.storyboard */; };
 		9285941E25228A1500B2BE47 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 925DF44E2522785700A5DE31 /* ADBMobileConfig.json */; };
 		4308341D232D468386DFE797 /* InboxFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B5D6873D544C4787ED0B54 /* InboxFunctionalTests.swift */; };
+		D4E3F2A15C6B708901234502 /* ContentCardCacheFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E3F2A15C6B708901234501 /* ContentCardCacheFunctionalTests.swift */; };
 		92863A022637706F000AFA53 /* MessagingFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92863A012637706F000AFA53 /* MessagingFunctionalTests.swift */; };
 		9296BA862537BFC0002C88F7 /* AEPMessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 925DF4A525227C4700A5DE31 /* AEPMessaging.framework */; };
 		92FC587B2636840C005BAE02 /* MessagingPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FC587A2636840C005BAE02 /* MessagingPublicAPITests.swift */; };
@@ -961,6 +962,7 @@
 		925DF4A525227C4700A5DE31 /* AEPMessaging.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPMessaging.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		928639FB263757A7000AFA53 /* Dictionary+Flatten.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Flatten.swift"; sourceTree = "<group>"; };
 		66B5D6873D544C4787ED0B54 /* InboxFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxFunctionalTests.swift; sourceTree = "<group>"; };
+		D4E3F2A15C6B708901234501 /* ContentCardCacheFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardCacheFunctionalTests.swift; sourceTree = "<group>"; };
 		92863A012637706F000AFA53 /* MessagingFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingFunctionalTests.swift; sourceTree = "<group>"; };
 		9296BA812537BFC0002C88F7 /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		92BCEC9C2538FC0E0068F8B8 /* AEPEdge.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEPEdge.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1777,6 +1779,7 @@
 				2469A6032759999E00E56457 /* FunctionalTestApp */,
 				24EE301D28FF61F0005E417C /* InAppMessagingEventTests.swift */,
 				66B5D6873D544C4787ED0B54 /* InboxFunctionalTests.swift */,
+				D4E3F2A15C6B708901234501 /* ContentCardCacheFunctionalTests.swift */,
 				92863A012637706F000AFA53 /* MessagingFunctionalTests.swift */,
 				B631AE152A61336800E8B82E /* MessagingNotificationTrackingTests.swift */,
 				92FC587A2636840C005BAE02 /* MessagingPublicAPITests.swift */,
@@ -3696,6 +3699,7 @@
 				92863A022637706F000AFA53 /* MessagingFunctionalTests.swift in Sources */,
 				B631AE162A61336800E8B82E /* MessagingNotificationTrackingTests.swift in Sources */,
 				4308341D232D468386DFE797 /* InboxFunctionalTests.swift in Sources */,
+				D4E3F2A15C6B708901234502 /* ContentCardCacheFunctionalTests.swift in Sources */,
 				F03DEEFA3F66D2D96736F90A /* ReevaluationFunctionalTests.swift in Sources */,
 				B6F795E22DD30238004478B4 /* LiveActivityTests.swift in Sources */,
 			);

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -681,7 +681,7 @@ public class Messaging: NSObject, Extension {
     ///   - qualifiedContentCards: The propositions keyed by surface, as returned by the content card rules engine.
     ///   - requestedSurfaces: The surfaces that were included in the originating personalization request;
     ///     used to identify surfaces that should be cleared if absent from the response.
-    func removeOrReplaceContentCards(_ qualifiedContentCards: [Surface: [Proposition]], requestedSurfaces: [Surface]) {
+    private func removeOrReplaceContentCards(_ qualifiedContentCards: [Surface: [Proposition]], requestedSurfaces: [Surface]) {
         // Evict requested surfaces that returned no qualified propositions
         for surface in requestedSurfaces {
             if qualifiedContentCards[surface] == nil {
@@ -973,32 +973,30 @@ public class Messaging: NSObject, Extension {
         processRulesForSchemaType(.contentCard, surfaceRulesBySchemaType: surfaceRulesBySchemaType, requestedSurfaces: requestedSurfaces, rulesBySurface: &contentCardRulesBySurface)
         processRulesForSchemaType(.eventHistoryOperation, surfaceRulesBySchemaType: surfaceRulesBySchemaType, requestedSurfaces: requestedSurfaces, rulesBySurface: &eventHistoryRulesBySurface)
 
-        // Content card rules engine
-        if surfaceRulesBySchemaType[.contentCard] != nil {
-            let collectedContentCardRules = collectRules(from: contentCardRulesBySurface)
-            contentCardRulesEngine.launchRulesEngine.replaceRules(with: collectedContentCardRules)
+        // Content card rules engine: always sync from `contentCardRulesBySurface` and refresh the qualified cache.
+        // `processRulesForSchemaType` clears rules for requested surfaces when `.contentCard` is absent from the
+        // response (e.g. campaign removed server-side); we must still replace rules and call `removeOrReplaceContentCards`
+        // in that case — not only when the key is present with an empty map.
+        let collectedContentCardRules = collectRules(from: contentCardRulesBySurface)
+        contentCardRulesEngine.launchRulesEngine.replaceRules(with: collectedContentCardRules)
 
-            // Seed content cards qualification using the authoritative path
-            let seedEvent = Event(name: "Seed content cards", type: EventType.messaging, source: EventSource.requestContent, data: nil)
-            let qualified = getPropositionsFromContentCardRulesEngine(seedEvent)
-            removeOrReplaceContentCards(qualified, requestedSurfaces: requestedSurfaces)
+        let seedEvent = Event(name: "Seed content cards", type: EventType.messaging, source: EventSource.requestContent, data: nil)
+        let qualified = getPropositionsFromContentCardRulesEngine(seedEvent)
+        removeOrReplaceContentCards(qualified, requestedSurfaces: requestedSurfaces)
+
+        // Always sync the in-app + event history rules engine, for the same reason as content
+        // cards above: processRulesForSchemaType already cleared stale entries from
+        // inAppRulesBySurface / eventHistoryRulesBySurface, and the engine must reflect that.
+        let collectedInAppRules = collectRules(from: inAppRulesBySurface)
+
+        // Prefetch assets only when the response actually contained new in-app rules
+        if surfaceRulesBySchemaType[.inapp] != nil {
+            rulesEngine.cacheRemoteAssetsFor(collectedInAppRules)
         }
 
-        // In-app + event history rules engine
-        if surfaceRulesBySchemaType[.inapp] != nil || surfaceRulesBySchemaType[.eventHistoryOperation] != nil {
-            let collectedInAppRules = collectRules(from: inAppRulesBySurface)
-
-            // Prefetch assets only if we actually received in-app rules this time
-            if surfaceRulesBySchemaType[.inapp] != nil {
-                rulesEngine.cacheRemoteAssetsFor(collectedInAppRules)
-            }
-
-            // Combine in-app + event history rules
-            var combined = collectedInAppRules
-            combined.append(contentsOf: collectRules(from: eventHistoryRulesBySurface))
-
-            rulesEngine.launchRulesEngine.replaceRules(with: combined)
-        }
+        var combined = collectedInAppRules
+        combined.append(contentsOf: collectRules(from: eventHistoryRulesBySurface))
+        rulesEngine.launchRulesEngine.replaceRules(with: combined)
     }
 
     private func processRulesForSchemaType(
@@ -1195,6 +1193,10 @@ public class Messaging: NSObject, Extension {
 
         func callUpdateRulesEngines(with rules: [SchemaType: [Surface: [LaunchRule]]], requestedSurfaces: [Surface]) {
             updateRulesEngines(with: rules, requestedSurfaces: requestedSurfaces)
+        }
+
+        func callRemoveOrReplaceContentCards(_ qualifiedContentCards: [Surface: [Proposition]], requestedSurfaces: [Surface]) {
+            removeOrReplaceContentCards(qualifiedContentCards, requestedSurfaces: requestedSurfaces)
         }
     #endif
 }

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -668,6 +668,59 @@ public class Messaging: NSObject, Extension {
         }
     }
 
+    /// Authoritatively refreshes the content card cache using the response from a personalization network request.
+    ///
+    /// Called after a personalization response stream completes. Treats the response as the source of truth
+    /// for the requested surfaces:
+    /// - Any requested surface that returned no qualified propositions is removed from cache, preventing stale
+    ///   cards from persisting after a server-side change.
+    /// - For surfaces that did return propositions, the cached list is fully replaced (not merged) with the new results.
+    /// - Propositions that are new (not previously in the cache) generate a `trigger` event sent to Edge Network.
+    ///
+    /// - Parameters:
+    ///   - qualifiedContentCards: The propositions keyed by surface, as returned by the content card rules engine.
+    ///   - requestedSurfaces: The surfaces that were included in the originating personalization request;
+    ///     used to identify surfaces that should be cleared if absent from the response.
+    func removeOrReplaceContentCards(_ qualifiedContentCards: [Surface: [Proposition]], requestedSurfaces: [Surface]) {
+        // Evict requested surfaces that returned no qualified propositions
+        for surface in requestedSurfaces {
+            if qualifiedContentCards[surface] == nil {
+                qualifiedContentCardsBySurface.removeValue(forKey: surface)
+            }
+        }
+
+        // Fully replace cached propositions for surfaces that have qualified content cards
+        for (surface, propositions) in qualifiedContentCards {
+            let existingPropositions = qualifiedContentCardsBySurface[surface] ?? []
+            let startingCount = existingPropositions.count
+
+            var newPropositionsToTrack: [PropositionItem] = []
+            for proposition in propositions {
+                if !existingPropositions.contains(proposition) {
+                    if let item = proposition.items.first {
+                        newPropositionsToTrack.append(item)
+                    }
+                }
+            }
+
+            // Replace the cached list entirely with the fresh response data
+            qualifiedContentCardsBySurface[surface] = propositions
+
+            if !newPropositionsToTrack.isEmpty {
+                newPropositionsToTrack.track(withEdgeEventType: .trigger)
+            }
+
+            let newCount = propositions.count
+            if startingCount != newCount {
+                if newCount > 0 {
+                    Log.trace(label: MessagingConstants.LOG_TAG, "User has qualified for \(newCount) content card(s) for surface \(surface.uri).")
+                } else {
+                    Log.trace(label: MessagingConstants.LOG_TAG, "User has not qualified for any content cards for surface \(surface.uri).")
+                }
+            }
+        }
+    }
+
     /// Removes the `Proposition` from `qualifiedContentCardsBySurface` based on provided `activityId`.
     ///
     /// - Parameter activityId: the activityId of the `Proposition` to be removed from cache.
@@ -925,12 +978,10 @@ public class Messaging: NSObject, Extension {
             let collectedContentCardRules = collectRules(from: contentCardRulesBySurface)
             contentCardRulesEngine.launchRulesEngine.replaceRules(with: collectedContentCardRules)
 
-            // Seed content cards qualification
+            // Seed content cards qualification using the authoritative path
             let seedEvent = Event(name: "Seed content cards", type: EventType.messaging, source: EventSource.requestContent, data: nil)
             let qualified = getPropositionsFromContentCardRulesEngine(seedEvent)
-            for (surface, propositions) in qualified {
-                addOrReplaceContentCards(propositions, forSurface: surface)
-            }
+            removeOrReplaceContentCards(qualified, requestedSurfaces: requestedSurfaces)
         }
 
         // In-app + event history rules engine

--- a/AEPMessaging/Tests/FunctionalTests/ContentCardCacheFunctionalTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/ContentCardCacheFunctionalTests.swift
@@ -1,0 +1,108 @@
+/*
+ Copyright 2025 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import XCTest
+import AEPRulesEngine
+import AEPTestUtils
+@testable import AEPCore
+@testable import AEPMessaging
+
+/// Integration-style tests for the content card cache path that runs after a personalization
+/// response completes (`updateRulesEngines` → `removeOrReplaceContentCards`).
+///
+/// Android parity: `MessagingPublicAPITests` content-card cases that drive Edge + rules;
+/// here we simulate the **authoritative refresh** slice using the DEBUG-only
+/// `callUpdateRulesEngines(with:requestedSurfaces:)` hook (same code path as
+/// `applyPropositionChangeFor` when the parsed response has no content-card rules for
+/// requested surfaces). Unit-level behavior of `removeOrReplaceContentCards` itself
+/// remains in `MessagingTests.swift`.
+#if DEBUG
+final class ContentCardCacheFunctionalTests: XCTestCase {
+    var messaging: Messaging!
+    var mockRuntime: TestableExtensionRuntime!
+
+    private let surfaceA = Surface(uri: "mobileapp://com.adobe.messaging.functionaltests/feed/a")
+    private let surfaceB = Surface(uri: "mobileapp://com.adobe.messaging.functionaltests/feed/b")
+    private let surfaceC = Surface(uri: "mobileapp://com.adobe.messaging.functionaltests/feed/c")
+
+    override func setUp() {
+        super.setUp()
+        mockRuntime = TestableExtensionRuntime()
+        messaging = Messaging(runtime: mockRuntime)
+        messaging.onRegistered()
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+    }
+
+    override func tearDown() {
+        messaging = nil
+        mockRuntime = nil
+        super.tearDown()
+    }
+
+    // MARK: - Authoritative refresh (empty content-card rules for request)
+
+    func testQualifiedContentCardsEvictedForBothRequestedSurfaces_whenNoContentCardRulesReturned() {
+        let propA = makeContentCardProposition(surface: surfaceA, uniqueId: "cardA")
+        let propB = makeContentCardProposition(surface: surfaceB, uniqueId: "cardB")
+        messaging.qualifiedContentCardsBySurface = [surfaceA: [propA], surfaceB: [propB]]
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let emptyContentCardRules: [SchemaType: [Surface: [LaunchRule]]] = [.contentCard: [:]]
+        messaging.callUpdateRulesEngines(with: emptyContentCardRules, requestedSurfaces: [surfaceA, surfaceB])
+        Thread.sleep(forTimeInterval: 0.15)
+
+        XCTAssertTrue(messaging.qualifiedContentCardsBySurface.isEmpty,
+                      "Both requested surfaces should be evicted when the authoritative refresh qualifies no cards")
+    }
+
+    func testQualifiedContentCardsPreservedForUnrequestedSurface_whenOtherRequestedSurfacesCleared() {
+        let propA = makeContentCardProposition(surface: surfaceA, uniqueId: "cardA")
+        let propB = makeContentCardProposition(surface: surfaceB, uniqueId: "cardB")
+        let propC = makeContentCardProposition(surface: surfaceC, uniqueId: "cardC")
+        messaging.qualifiedContentCardsBySurface = [surfaceA: [propA], surfaceB: [propB], surfaceC: [propC]]
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let emptyContentCardRules: [SchemaType: [Surface: [LaunchRule]]] = [.contentCard: [:]]
+        messaging.callUpdateRulesEngines(with: emptyContentCardRules, requestedSurfaces: [surfaceA, surfaceB])
+        Thread.sleep(forTimeInterval: 0.15)
+
+        XCTAssertEqual(1, messaging.qualifiedContentCardsBySurface.count)
+        XCTAssertNil(messaging.qualifiedContentCardsBySurface[surfaceA])
+        XCTAssertNil(messaging.qualifiedContentCardsBySurface[surfaceB])
+        XCTAssertNotNil(messaging.qualifiedContentCardsBySurface[surfaceC])
+        XCTAssertEqual("cardC", messaging.qualifiedContentCardsBySurface[surfaceC]?.first?.uniqueId)
+    }
+
+    func testQualifiedContentCardsUnchanged_whenRequestedSurfacesEmpty() {
+        let propA = makeContentCardProposition(surface: surfaceA, uniqueId: "cardA")
+        messaging.qualifiedContentCardsBySurface = [surfaceA: [propA]]
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let emptyContentCardRules: [SchemaType: [Surface: [LaunchRule]]] = [.contentCard: [:]]
+        messaging.callUpdateRulesEngines(with: emptyContentCardRules, requestedSurfaces: [])
+        Thread.sleep(forTimeInterval: 0.15)
+
+        XCTAssertEqual(1, messaging.qualifiedContentCardsBySurface.count)
+        XCTAssertEqual("cardA", messaging.qualifiedContentCardsBySurface[surfaceA]?.first?.uniqueId)
+    }
+
+    // MARK: - Helpers
+
+    private func makeContentCardProposition(surface: Surface, uniqueId: String) -> Proposition {
+        let item = PropositionItem(itemId: "\(uniqueId)_item", schema: .contentCard, itemData: [:])
+        return Proposition(uniqueId: uniqueId,
+                           scope: surface.uri,
+                           scopeDetails: ["decisionProvider": "AJO"],
+                           items: [item])
+    }
+}
+#endif

--- a/AEPMessaging/Tests/FunctionalTests/ContentCardCacheFunctionalTests.swift
+++ b/AEPMessaging/Tests/FunctionalTests/ContentCardCacheFunctionalTests.swift
@@ -22,9 +22,9 @@ import AEPTestUtils
 /// Android parity: `MessagingPublicAPITests` content-card cases that drive Edge + rules;
 /// here we simulate the **authoritative refresh** slice using the DEBUG-only
 /// `callUpdateRulesEngines(with:requestedSurfaces:)` hook (same code path as
-/// `applyPropositionChangeFor` when the parsed response has no content-card rules for
-/// requested surfaces). Unit-level behavior of `removeOrReplaceContentCards` itself
-/// remains in `MessagingTests.swift`.
+/// `applyPropositionChangeFor` when the parsed response omits content-card rules for
+/// requested surfaces — including when the `.contentCard` key is missing entirely.
+/// Direct unit coverage uses the DEBUG-only `callRemoveOrReplaceContentCards` hook in `MessagingTests.swift`.
 #if DEBUG
 final class ContentCardCacheFunctionalTests: XCTestCase {
     var messaging: Messaging!
@@ -93,6 +93,24 @@ final class ContentCardCacheFunctionalTests: XCTestCase {
 
         XCTAssertEqual(1, messaging.qualifiedContentCardsBySurface.count)
         XCTAssertEqual("cardA", messaging.qualifiedContentCardsBySurface[surfaceA]?.first?.uniqueId)
+    }
+
+    /// When the server omits the content-card schema entirely, `surfaceRulesBySchemaType[.contentCard]` is nil.
+    /// Rules for requested surfaces are cleared in `processRulesForSchemaType`, but the qualified cache must
+    /// still be refreshed (same outcome as an empty `.contentCard` map).
+    func testQualifiedContentCardsEvicted_whenContentCardKeyAbsentFromResponse() {
+        let propA = makeContentCardProposition(surface: surfaceA, uniqueId: "cardA")
+        let propB = makeContentCardProposition(surface: surfaceB, uniqueId: "cardB")
+        messaging.qualifiedContentCardsBySurface = [surfaceA: [propA], surfaceB: [propB]]
+        Thread.sleep(forTimeInterval: 0.1)
+
+        // No `.contentCard` entry — e.g. response only carries other schema types or an empty payload.
+        let rulesWithNoContentCardKey: [SchemaType: [Surface: [LaunchRule]]] = [:]
+        messaging.callUpdateRulesEngines(with: rulesWithNoContentCardKey, requestedSurfaces: [surfaceA, surfaceB])
+        Thread.sleep(forTimeInterval: 0.15)
+
+        XCTAssertTrue(messaging.qualifiedContentCardsBySurface.isEmpty,
+                      "Stale qualified cards must be evicted when the response has no content-card key")
     }
 
     // MARK: - Helpers

--- a/AEPMessaging/Tests/UnitTests/MessagingProcessCompletedEventTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingProcessCompletedEventTests.swift
@@ -416,8 +416,10 @@ class MessagingProcessCompletedEventTests: XCTestCase {
                                  data: [MessagingConstants.Event.Data.Key.ENDING_EVENT_ID: requestId])
         messaging.handleProcessCompletedEvent(processEvent)
 
-        XCTAssertFalse(mockLaunchRulesEngine.replaceRulesCalled, "In-app rules engine should NOT be invoked for code-based propositions")
-        XCTAssertFalse(mockContentCardLaunchRulesEngine.replaceRulesCalled, "Content-card rules engine should NOT be invoked for code-based propositions")
+        XCTAssertTrue(mockLaunchRulesEngine.replaceRulesCalled, "In-app rules engine should always be synced after a personalization response")
+        XCTAssertEqual(0, mockLaunchRulesEngine.paramReplaceRulesRules?.count ?? -1, "No in-app rules expected for code-based propositions")
+        XCTAssertTrue(mockContentCardLaunchRulesEngine.replaceRulesCalled, "Content-card rules engine should always be synced after a personalization response")
+        XCTAssertEqual(0, mockContentCardLaunchRulesEngine.paramReplaceRulesRules?.count ?? -1, "No content-card rules expected for code-based propositions")
 
         // One notification event should be dispatched containing the propositions
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
@@ -463,9 +465,11 @@ class MessagingProcessCompletedEventTests: XCTestCase {
                                  data: [MessagingConstants.Event.Data.Key.ENDING_EVENT_ID: requestId])
         messaging.handleProcessCompletedEvent(processEvent)
 
-        // Validate: no rules engines invoked, no notification dispatched
-        XCTAssertFalse(mockLaunchRulesEngine.replaceRulesCalled)
-        XCTAssertFalse(mockContentCardLaunchRulesEngine.replaceRulesCalled)
+        // Validate: rules engines synced with empty rules, no notification dispatched
+        XCTAssertTrue(mockLaunchRulesEngine.replaceRulesCalled)
+        XCTAssertEqual(0, mockLaunchRulesEngine.paramReplaceRulesRules?.count ?? -1)
+        XCTAssertTrue(mockContentCardLaunchRulesEngine.replaceRulesCalled)
+        XCTAssertEqual(0, mockContentCardLaunchRulesEngine.paramReplaceRulesRules?.count ?? -1)
         XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
     }
 
@@ -517,9 +521,11 @@ class MessagingProcessCompletedEventTests: XCTestCase {
                                  data: [MessagingConstants.Event.Data.Key.ENDING_EVENT_ID: requestId])
         messaging.handleProcessCompletedEvent(processEvent)
 
-        // Validate: rules engines not invoked, no notification dispatched
-        XCTAssertFalse(mockLaunchRulesEngine.replaceRulesCalled)
-        XCTAssertFalse(mockContentCardLaunchRulesEngine.replaceRulesCalled)
+        // Validate: rules engines synced with empty rules (invalid rules produce nothing), no notification dispatched
+        XCTAssertTrue(mockLaunchRulesEngine.replaceRulesCalled)
+        XCTAssertEqual(0, mockLaunchRulesEngine.paramReplaceRulesRules?.count ?? -1)
+        XCTAssertTrue(mockContentCardLaunchRulesEngine.replaceRulesCalled)
+        XCTAssertEqual(0, mockContentCardLaunchRulesEngine.paramReplaceRulesRules?.count ?? -1)
         XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
     }
 

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1379,6 +1379,122 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(completionResult, false, "Completion should be called with false on failure")
     }
 
+    // MARK: - removeOrReplaceContentCards tests
+
+    func testRemoveOrReplaceContentCards_evictsAllRequestedSurfaces_whenNoCardsQualify() {
+        let surfaceA = Surface(path: "feed1")
+        let surfaceB = Surface(path: "feed2")
+
+        let propA = Proposition(uniqueId: "propA", scope: surfaceA.uri,
+                                scopeDetails: ["activity": ["id": "activityA"]], items: [])
+        let propB = Proposition(uniqueId: "propB", scope: surfaceB.uri,
+                                scopeDetails: ["activity": ["id": "activityB"]], items: [])
+        messaging.qualifiedContentCardsBySurface[surfaceA] = [propA]
+        messaging.qualifiedContentCardsBySurface[surfaceB] = [propB]
+        XCTAssertEqual(2, messaging.qualifiedContentCardsBySurface.count)
+
+        // No qualified cards — empty map
+        messaging.removeOrReplaceContentCards([:], requestedSurfaces: [surfaceA, surfaceB])
+
+        XCTAssertEqual(0, messaging.qualifiedContentCardsBySurface.count)
+    }
+
+    func testRemoveOrReplaceContentCards_preservesUnrequestedSurfaces() {
+        let surfaceA = Surface(path: "feed1")
+        let surfaceB = Surface(path: "feed2")
+        let surfaceC = Surface(path: "feed3")
+
+        let propA = Proposition(uniqueId: "propA", scope: surfaceA.uri,
+                                scopeDetails: ["activity": ["id": "activityA"]], items: [])
+        let propB = Proposition(uniqueId: "propB", scope: surfaceB.uri,
+                                scopeDetails: ["activity": ["id": "activityB"]], items: [])
+        let propC = Proposition(uniqueId: "propC", scope: surfaceC.uri,
+                                scopeDetails: ["activity": ["id": "activityC"]], items: [])
+        messaging.qualifiedContentCardsBySurface[surfaceA] = [propA]
+        messaging.qualifiedContentCardsBySurface[surfaceB] = [propB]
+        messaging.qualifiedContentCardsBySurface[surfaceC] = [propC]
+        XCTAssertEqual(3, messaging.qualifiedContentCardsBySurface.count)
+
+        // Request only A and B, no qualified cards
+        messaging.removeOrReplaceContentCards([:], requestedSurfaces: [surfaceA, surfaceB])
+
+        XCTAssertEqual(1, messaging.qualifiedContentCardsBySurface.count)
+        XCTAssertNotNil(messaging.qualifiedContentCardsBySurface[surfaceC])
+        XCTAssertNil(messaging.qualifiedContentCardsBySurface[surfaceA])
+        XCTAssertNil(messaging.qualifiedContentCardsBySurface[surfaceB])
+    }
+
+    func testRemoveOrReplaceContentCards_replacesQualifiedSurface_andEvictsAbsentSurface() {
+        let surfaceA = Surface(path: "feed1")
+        let surfaceB = Surface(path: "feed2")
+
+        let oldPropA = Proposition(uniqueId: "oldPropA", scope: surfaceA.uri,
+                                   scopeDetails: ["activity": ["id": "oldActivityA"]], items: [])
+        let oldPropB = Proposition(uniqueId: "oldPropB", scope: surfaceB.uri,
+                                   scopeDetails: ["activity": ["id": "oldActivityB"]], items: [])
+        messaging.qualifiedContentCardsBySurface[surfaceA] = [oldPropA]
+        messaging.qualifiedContentCardsBySurface[surfaceB] = [oldPropB]
+
+        // New response returns cards only for surfaceA
+        let newPropA = Proposition(uniqueId: "newPropA", scope: surfaceA.uri,
+                                   scopeDetails: ["activity": ["id": "newActivityA"]], items: [])
+        let qualifiedCards: [Surface: [Proposition]] = [surfaceA: [newPropA]]
+
+        messaging.removeOrReplaceContentCards(qualifiedCards, requestedSurfaces: [surfaceA, surfaceB])
+
+        // surfaceA should have the new proposition (replaced, not merged)
+        let resultA = messaging.qualifiedContentCardsBySurface[surfaceA]
+        XCTAssertNotNil(resultA)
+        XCTAssertEqual(1, resultA?.count)
+        XCTAssertEqual("newActivityA", resultA?.first?.activityId)
+
+        // surfaceB should be evicted
+        XCTAssertNil(messaging.qualifiedContentCardsBySurface[surfaceB])
+    }
+
+    func testRemoveOrReplaceContentCards_noOp_whenRequestedSurfacesEmpty() {
+        let surfaceA = Surface(path: "feed1")
+        let propA = Proposition(uniqueId: "propA", scope: surfaceA.uri,
+                                scopeDetails: ["activity": ["id": "activityA"]], items: [])
+        messaging.qualifiedContentCardsBySurface[surfaceA] = [propA]
+
+        messaging.removeOrReplaceContentCards([:], requestedSurfaces: [])
+
+        XCTAssertEqual(1, messaging.qualifiedContentCardsBySurface.count)
+        XCTAssertNotNil(messaging.qualifiedContentCardsBySurface[surfaceA])
+    }
+
+    func testRemoveOrReplaceContentCards_noError_whenRequestedSurfaceNeverCached() {
+        let surfaceA = Surface(path: "feed1")
+
+        messaging.removeOrReplaceContentCards([:], requestedSurfaces: [surfaceA])
+
+        XCTAssertEqual(0, messaging.qualifiedContentCardsBySurface.count)
+    }
+
+    func testAddOrReplaceContentCards_doesNotEvictSurfaces_whenNoCardsQualify() {
+        let surfaceA = Surface(path: "feed1")
+        let surfaceB = Surface(path: "feed2")
+
+        let propA = Proposition(uniqueId: "propA", scope: surfaceA.uri,
+                                scopeDetails: ["activity": ["id": "activityA"]], items: [])
+        let propB = Proposition(uniqueId: "propB", scope: surfaceB.uri,
+                                scopeDetails: ["activity": ["id": "activityB"]], items: [])
+        messaging.qualifiedContentCardsBySurface[surfaceA] = [propA]
+        messaging.qualifiedContentCardsBySurface[surfaceB] = [propB]
+        XCTAssertEqual(2, messaging.qualifiedContentCardsBySurface.count)
+
+        // Simulate wildcard event where rules engine returns no qualified cards
+        // (default mock returns empty consequences)
+        let event = Event(name: "test", type: EventType.lifecycle, source: EventSource.responseContent, data: nil)
+        mockRuntime.simulateComingEvents(event)
+
+        // Additive path should preserve all surfaces
+        XCTAssertEqual(2, messaging.qualifiedContentCardsBySurface.count)
+        XCTAssertNotNil(messaging.qualifiedContentCardsBySurface[surfaceA])
+        XCTAssertNotNil(messaging.qualifiedContentCardsBySurface[surfaceB])
+    }
+
     // MARK: Private methods
 
     private var SampleEdgeIdentityState: [String: Any] {

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1379,8 +1379,9 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(completionResult, false, "Completion should be called with false on failure")
     }
 
-    // MARK: - removeOrReplaceContentCards tests
+    // MARK: - removeOrReplaceContentCards tests (DEBUG: uses callRemoveOrReplaceContentCards)
 
+    #if DEBUG
     func testRemoveOrReplaceContentCards_evictsAllRequestedSurfaces_whenNoCardsQualify() {
         let surfaceA = Surface(path: "feed1")
         let surfaceB = Surface(path: "feed2")
@@ -1394,7 +1395,7 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(2, messaging.qualifiedContentCardsBySurface.count)
 
         // No qualified cards — empty map
-        messaging.removeOrReplaceContentCards([:], requestedSurfaces: [surfaceA, surfaceB])
+        messaging.callRemoveOrReplaceContentCards([:], requestedSurfaces: [surfaceA, surfaceB])
 
         XCTAssertEqual(0, messaging.qualifiedContentCardsBySurface.count)
     }
@@ -1416,7 +1417,7 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(3, messaging.qualifiedContentCardsBySurface.count)
 
         // Request only A and B, no qualified cards
-        messaging.removeOrReplaceContentCards([:], requestedSurfaces: [surfaceA, surfaceB])
+        messaging.callRemoveOrReplaceContentCards([:], requestedSurfaces: [surfaceA, surfaceB])
 
         XCTAssertEqual(1, messaging.qualifiedContentCardsBySurface.count)
         XCTAssertNotNil(messaging.qualifiedContentCardsBySurface[surfaceC])
@@ -1440,7 +1441,7 @@ class MessagingTests: XCTestCase {
                                    scopeDetails: ["activity": ["id": "newActivityA"]], items: [])
         let qualifiedCards: [Surface: [Proposition]] = [surfaceA: [newPropA]]
 
-        messaging.removeOrReplaceContentCards(qualifiedCards, requestedSurfaces: [surfaceA, surfaceB])
+        messaging.callRemoveOrReplaceContentCards(qualifiedCards, requestedSurfaces: [surfaceA, surfaceB])
 
         // surfaceA should have the new proposition (replaced, not merged)
         let resultA = messaging.qualifiedContentCardsBySurface[surfaceA]
@@ -1458,7 +1459,7 @@ class MessagingTests: XCTestCase {
                                 scopeDetails: ["activity": ["id": "activityA"]], items: [])
         messaging.qualifiedContentCardsBySurface[surfaceA] = [propA]
 
-        messaging.removeOrReplaceContentCards([:], requestedSurfaces: [])
+        messaging.callRemoveOrReplaceContentCards([:], requestedSurfaces: [])
 
         XCTAssertEqual(1, messaging.qualifiedContentCardsBySurface.count)
         XCTAssertNotNil(messaging.qualifiedContentCardsBySurface[surfaceA])
@@ -1467,10 +1468,11 @@ class MessagingTests: XCTestCase {
     func testRemoveOrReplaceContentCards_noError_whenRequestedSurfaceNeverCached() {
         let surfaceA = Surface(path: "feed1")
 
-        messaging.removeOrReplaceContentCards([:], requestedSurfaces: [surfaceA])
+        messaging.callRemoveOrReplaceContentCards([:], requestedSurfaces: [surfaceA])
 
         XCTAssertEqual(0, messaging.qualifiedContentCardsBySurface.count)
     }
+    #endif
 
     func testAddOrReplaceContentCards_doesNotEvictSurfaces_whenNoCardsQualify() {
         let surfaceA = Surface(path: "feed1")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

removeOrReplaceContentCards + call from updateRulesEngines after network-driven rules refresh; unit tests in MessagingTests. Functional tests: ContentCardCacheFunctionalTests (DEBUG callUpdateRulesEngines path).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Stops stale content cards when the server returns fewer or no cards for requested surfaces. Aligns iOS with Android’s authoritative refresh behavior and adds focused tests plus minimal demo flows to reproduce refresh, qualification (trackAction), and multi-surface fetches.

## How Has This Been Tested?

Xcode FunctionalTests / UnitTests schemes; manual Cards tab with two surfaces.

Functional Tests, Unit Tests and manual testing by creating multiple campaigns and disabling them to reproduce the scenario.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
