### PR TITLE
Consent listener for push and la tokens

### DIFF
--- a/AEPMessaging.xcodeproj/project.pbxproj
+++ b/AEPMessaging.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 /* Begin PBXBuildFile section */
 		04432BEC0CB7D32AE8D7791B /* MessagingRuleEngineInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8F4262E345FBBC814E3294 /* MessagingRuleEngineInterceptor.swift */; };
 		04432BEC0CB7D32AE8D7792C /* RefreshInAppHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8F4262E345FBBC814E3295 /* RefreshInAppHandler.swift */; };
+		0896CA676CE24E3BAC9CFC21 /* EmptyStateSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E38A50A394377B713C9E2 /* EmptyStateSettingsTests.swift */; };
 		090290C329D4EA9F00388226 /* MockCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2469A5E8274C107100E56457 /* MockCache.swift */; };
 		090290C529DCED0B00388226 /* ContentCardRulesEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090290C429DCED0B00388226 /* ContentCardRulesEngine.swift */; };
 		090290C929DD11EA00388226 /* RuleConsequence+Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090290C829DD11EA00388226 /* RuleConsequence+Messaging.swift */; };
@@ -54,10 +55,16 @@
 		09B071EE2A651CB200F259C1 /* PropositionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B071ED2A651CB200F259C1 /* PropositionItem.swift */; };
 		09B071F62A7318CB00F259C1 /* Array+Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B071F52A7318CB00F259C1 /* Array+Messaging.swift */; };
 		09F5D9402B5CF35F00117437 /* PropositionInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F5D93F2B5CF35F00117437 /* PropositionInteraction.swift */; };
+		0A9D155B84174774B6F6DD11 /* LayoutSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A301B4C9BC74A618FBA92EC /* LayoutSettingsTests.swift */; };
+		0F0F12972F910FBB00C2198C /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0F12962F910FBB00C2198C /* SettingsView.swift */; };
+		0F0F12982F910FBB00C2198C /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0F12962F910FBB00C2198C /* SettingsView.swift */; };
+		0F0F12992F910FBB00C2198C /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0F12962F910FBB00C2198C /* SettingsView.swift */; };
 		0F630F3F2F0ED2DE0080688A /* LiveActivityBatchTokenCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F630F3E2F0ED2DE0080688A /* LiveActivityBatchTokenCollector.swift */; };
 		109659B997B843E2933FFADD /* AEPMessagingNotificationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C712A4BE9744C2B77101B3 /* AEPMessagingNotificationHelperTests.swift */; };
 		1168DE412A8ADE12A1489749 /* Pods_E2EFunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36D3F6949A279969C6766FF5 /* Pods_E2EFunctionalTests.framework */; };
 		11809F1839C1AFE69C2A61CA /* Pods_MessagingDemoAppSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 233D0E8FD8252487C368E8F3 /* Pods_MessagingDemoAppSwiftUI.framework */; };
+		1949AACD944344D7BC32A19F /* InboxSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCA947D94604DCCACF943AC /* InboxSettingsTests.swift */; };
+		21E9FEC362EF41B9A7D57D3F /* InboxEventListeningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB4C861868845FFA51C3132 /* InboxEventListeningTests.swift */; };
 		221C0C046D74DE5033D7E677 /* Pods_NotificationServiceSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8FFFF03D4A43DCD4C18DF3A /* Pods_NotificationServiceSwiftUI.framework */; };
 		2313E365F83F4D96774FA00E /* Pods_MessagingDemoApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4674E5E3D4CA595638A62EB /* Pods_MessagingDemoApp.framework */; };
 		2402745C29FC424000884DFE /* TestableMessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2402745B29FC424000884DFE /* TestableMessagingDelegate.swift */; };
@@ -205,6 +212,8 @@
 		24CE4B3B43C96993215AA54C /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CD8814A5A4F7E260933A8CB /* Pods_NotificationService.framework */; };
 		24DE13ED2E9074F300D916DC /* ruleWithDefaultContentConsequence.json in Resources */ = {isa = PBXBuildFile; fileRef = 24DE13EC2E9074E700D916DC /* ruleWithDefaultContentConsequence.json */; };
 		24FD5F752CEEA50F00AE4567 /* CompletionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FD5F742CEEA50400AE4567 /* CompletionHandler.swift */; };
+		289698134F074CC2AFEB4C43 /* UnreadIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1579C648A4431298A5C9EF /* UnreadIndicatorSettingsTests.swift */; };
+		4308341D232D468386DFE797 /* InboxFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B5D6873D544C4787ED0B54 /* InboxFunctionalTests.swift */; };
 		4C0111D72DB30FD900996757 /* LiveActivityOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0111D62DB30FD900996757 /* LiveActivityOrigin.swift */; };
 		4C075D6E2DDE74D70082B66C /* ChannelActivityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C075D6D2DDE74D70082B66C /* ChannelActivityStore.swift */; };
 		4C075D722DDE83D20082B66C /* PersistenceStoreBaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C075D712DDE83D20082B66C /* PersistenceStoreBaseTests.swift */; };
@@ -236,7 +245,10 @@
 		4CC464D42E83B35D00217A78 /* TestMapBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC464CF2E83B35D00217A78 /* TestMapBase.swift */; };
 		4CC464D52E83B35D00217A78 /* TestElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC464CE2E83B35D00217A78 /* TestElement.swift */; };
 		4CC464D62E83B35D00217A78 /* CountingDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC464CD2E83B35D00217A78 /* CountingDataStore.swift */; };
+		610D7694C87747DA9FBA2602 /* InboxErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5CB0ADD5CD4B09B46D6A6D /* InboxErrorTests.swift */; };
+		66A544B390364C269E47365C /* DefaultHeadingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE401ECA108F4EF3ADB6F667 /* DefaultHeadingViewTests.swift */; };
 		6C2343E8785E6B47C8D961F7 /* Pods_FunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D55E83254139642A1CAA76E /* Pods_FunctionalTests.framework */; };
+		7454DD310E3A41F883456325 /* DefaultLoadingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3783B7834D4427ABDFAEE02 /* DefaultLoadingViewTests.swift */; };
 		754F49E92DFCA9EF002601E9 /* LargeImageTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754F49E82DFCA9EA002601E9 /* LargeImageTemplate.swift */; };
 		754F49EB2E007FD4002601E9 /* LargeImageTemplate.json in Resources */ = {isa = PBXBuildFile; fileRef = 754F49EA2E007FC1002601E9 /* LargeImageTemplate.json */; };
 		755DB8AB2E02003100F3B21B /* LargeImageCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755DB8AA2E02003100F3B21B /* LargeImageCustomizer.swift */; };
@@ -267,6 +279,7 @@
 		755DB8F22E624F1700F3B21B /* InboxEventListening.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755DB8F12E624F1700F3B21B /* InboxEventListening.swift */; };
 		755DB8F52E624F2D00F3B21B /* InboxState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755DB8F32E624F2D00F3B21B /* InboxState.swift */; };
 		755DB8F62E624F2D00F3B21B /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755DB8F42E624F2D00F3B21B /* InboxView.swift */; };
+		7FC8752D2FEC4B8490F75863 /* InboxSchemaDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ED549B7D5D4BD2B3766E46 /* InboxSchemaDataTests.swift */; };
 		8306057F6EE4683383660BD8 /* Pods_MessagingDemoAppObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BDCBFF342013F2FF0CE1472 /* Pods_MessagingDemoAppObjC.framework */; };
 		846794A21245172CEE3FF1CA /* Pods_E2EFunctionalTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B18970846882D9DC0CD1C50 /* Pods_E2EFunctionalTestApp.framework */; };
 		92315508261E444A004AE7D3 /* AEPMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = 92315435261E3B36004AE7D3 /* AEPMessaging.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -279,8 +292,6 @@
 		928594162522880900B2BE47 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 925DF4482522785700A5DE31 /* LaunchScreen.storyboard */; };
 		9285941C2522899700B2BE47 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 925DF44A2522785700A5DE31 /* Main.storyboard */; };
 		9285941E25228A1500B2BE47 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 925DF44E2522785700A5DE31 /* ADBMobileConfig.json */; };
-		4308341D232D468386DFE797 /* InboxFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B5D6873D544C4787ED0B54 /* InboxFunctionalTests.swift */; };
-		D4E3F2A15C6B708901234502 /* ContentCardCacheFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E3F2A15C6B708901234501 /* ContentCardCacheFunctionalTests.swift */; };
 		92863A022637706F000AFA53 /* MessagingFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92863A012637706F000AFA53 /* MessagingFunctionalTests.swift */; };
 		9296BA862537BFC0002C88F7 /* AEPMessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 925DF4A525227C4700A5DE31 /* AEPMessaging.framework */; };
 		92FC587B2636840C005BAE02 /* MessagingPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FC587A2636840C005BAE02 /* MessagingPublicAPITests.swift */; };
@@ -288,6 +299,11 @@
 		92FC594526372E34005BAE02 /* MockNotificationResponseCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FC594426372E34005BAE02 /* MockNotificationResponseCoder.swift */; };
 		92FC594626372E34005BAE02 /* MockNotificationResponseCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FC594426372E34005BAE02 /* MockNotificationResponseCoder.swift */; };
 		A583FC9173E905F9E5DF6D0F /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B86A865B6338E5FAFD760F08 /* Pods_UnitTests.framework */; };
+		A5B04DE7DDE3431AB773F0EB /* DefaultErrorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E308C1D0514AC89E6435D0 /* DefaultErrorViewTests.swift */; };
+		AA000006AAAA0001000AA001 /* AEPMessagingNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = AA000002AAAA0001000AA001 /* AEPMessagingNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA000007AAAA0001000AA001 /* MessagingNotificationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000003AAAA0001000AA001 /* MessagingNotificationHelper.swift */; };
+		AA000008AAAA0001000AA001 /* MessagingLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000004AAAA0001000AA001 /* MessagingLog.swift */; };
+		AB98D09FDC6D47C1B79DC26B /* InboxUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC044480E85745A0A6FE4C4F /* InboxUITests.swift */; };
 		B42C4B4F21284FB6EDC07676 /* Pods_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7872C9FF7BE2CF1D18017C01 /* Pods_IntegrationTests.framework */; };
 		B60EE0C22F0E40C30040189F /* AEPUnreadIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60EE0C12F0E40C30040189F /* AEPUnreadIcon.swift */; };
 		B6165DA629A67ADA0031B84D /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6165DA529A67ADA0031B84D /* NotificationService.swift */; };
@@ -336,20 +352,6 @@
 		B69573C82CD4447F0027E376 /* AEPBundleImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69573C72CD444790027E376 /* AEPBundleImageView.swift */; };
 		B6C752782F02692A00F76A54 /* InboxSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C752772F02692A00F76A54 /* InboxSettings.swift */; };
 		B6C7527A2F04B0CB00F76A54 /* ReadStatusManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C752792F04B0CB00F76A54 /* ReadStatusManagerTests.swift */; };
-		0A9D155B84174774B6F6DD11 /* LayoutSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A301B4C9BC74A618FBA92EC /* LayoutSettingsTests.swift */; };
-		1949AACD944344D7BC32A19F /* InboxSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCA947D94604DCCACF943AC /* InboxSettingsTests.swift */; };
-		7FC8752D2FEC4B8490F75863 /* InboxSchemaDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ED549B7D5D4BD2B3766E46 /* InboxSchemaDataTests.swift */; };
-		289698134F074CC2AFEB4C43 /* UnreadIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1579C648A4431298A5C9EF /* UnreadIndicatorSettingsTests.swift */; };
-		0896CA676CE24E3BAC9CFC21 /* EmptyStateSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E38A50A394377B713C9E2 /* EmptyStateSettingsTests.swift */; };
-		CBE050CB53BF402086329301 /* HeadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC56DFB8D444A25BC205CAD /* HeadingTests.swift */; };
-		610D7694C87747DA9FBA2602 /* InboxErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5CB0ADD5CD4B09B46D6A6D /* InboxErrorTests.swift */; };
-		E09CA04F82054CB4A8AC5D2E /* InboxStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385094F2A3B648BC820CEFA9 /* InboxStateTests.swift */; };
-		21E9FEC362EF41B9A7D57D3F /* InboxEventListeningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB4C861868845FFA51C3132 /* InboxEventListeningTests.swift */; };
-		AB98D09FDC6D47C1B79DC26B /* InboxUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC044480E85745A0A6FE4C4F /* InboxUITests.swift */; };
-		66A544B390364C269E47365C /* DefaultHeadingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE401ECA108F4EF3ADB6F667 /* DefaultHeadingViewTests.swift */; };
-		D14F4F38212749F7AAEF4EAF /* DefaultEmptyStateViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF126D339E6043AF9BA26807 /* DefaultEmptyStateViewTests.swift */; };
-		7454DD310E3A41F883456325 /* DefaultLoadingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3783B7834D4427ABDFAEE02 /* DefaultLoadingViewTests.swift */; };
-		A5B04DE7DDE3431AB773F0EB /* DefaultErrorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E308C1D0514AC89E6435D0 /* DefaultErrorViewTests.swift */; };
 		B6C7527C2F04B10100F76A54 /* ReadStatusManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C7527B2F04B10100F76A54 /* ReadStatusManager.swift */; };
 		B6D02CF92F67ECA300D65C16 /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D02CF82F67ECA300D65C16 /* InboxView.swift */; };
 		B6D035E22D2F23E900031170 /* AppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D035E12D2F23E900031170 /* AppStateManager.swift */; };
@@ -441,6 +443,9 @@
 		B6F7CCC72CCA1D7C00C35C64 /* MultipleCards.json in Resources */ = {isa = PBXBuildFile; fileRef = B6F7CC172CC2EFE400C35C64 /* MultipleCards.json */; };
 		C6B8865ECCA5AFACDB7A2794 /* NotificationServiceSwiftUI.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 245ADEB8419B6E777CF08F6D /* NotificationServiceSwiftUI.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		CB4DB3613E8FD4B78B164916 /* Pods_FunctionalTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1331B50C344AD02FE0C9E2BF /* Pods_FunctionalTestApp.framework */; };
+		CBE050CB53BF402086329301 /* HeadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC56DFB8D444A25BC205CAD /* HeadingTests.swift */; };
+		D14F4F38212749F7AAEF4EAF /* DefaultEmptyStateViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF126D339E6043AF9BA26807 /* DefaultEmptyStateViewTests.swift */; };
+		D4E3F2A15C6B708901234502 /* ContentCardCacheFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E3F2A15C6B708901234501 /* ContentCardCacheFunctionalTests.swift */; };
 		D63FC3AC2E00DACB00037B50 /* String+DataConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63FC3AB2E00DAB800037B50 /* String+DataConversion.swift */; };
 		D66DF10C2DD5327E0021AC51 /* MessagingStateManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66DF10B2DD5327E0021AC51 /* MessagingStateManagerTests.swift */; };
 		D66DF10E2DD533320021AC51 /* MockNamedKeyValueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66DF10D2DD5332A0021AC51 /* MockNamedKeyValueService.swift */; };
@@ -449,11 +454,9 @@
 		D8F12C4D9192ED50E10E7DC8 /* MessagingRuleEngineInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E8C1E12F01D07AFBDF4F39 /* MessagingRuleEngineInterceptorTests.swift */; };
 		D8F12C4D9192ED50E10E7DC9 /* RefreshInAppHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E8C1E12F01D07AFBDF4F3A /* RefreshInAppHandlerTests.swift */; };
 		DCA9F90C57FBD4B61DAEC1C7 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6165DA529A67ADA0031B84D /* NotificationService.swift */; };
+		E09CA04F82054CB4A8AC5D2E /* InboxStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385094F2A3B648BC820CEFA9 /* InboxStateTests.swift */; };
 		E1E1C4D19DDFA98963D58BB5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4E78D9F64A7EAE46F3B8CF3 /* Foundation.framework */; };
 		F03DEEFA3F66D2D96736F90A /* ReevaluationFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2A8A4FA7DBAD4D894D4E42 /* ReevaluationFunctionalTests.swift */; };
-		AA000006AAAA0001000AA001 /* AEPMessagingNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = AA000002AAAA0001000AA001 /* AEPMessagingNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA000007AAAA0001000AA001 /* MessagingNotificationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000003AAAA0001000AA001 /* MessagingNotificationHelper.swift */; };
-		AA000008AAAA0001000AA001 /* MessagingLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000004AAAA0001000AA001 /* MessagingLog.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -541,6 +544,13 @@
 			remoteGlobalIDString = C56C549C7AB2416ACBCEB0C4;
 			remoteInfo = NotificationServiceSwiftUI;
 		};
+		AA000013AAAA0001000AA001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 922FFCE7251B2BBA00BCE010 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AA00000DAAAA0001000AA001;
+			remoteInfo = AEPMessagingNotification;
+		};
 		B6165DA829A67ADA0031B84D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 922FFCE7251B2BBA00BCE010 /* Project object */;
@@ -568,13 +578,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = B61BDACD2DA5E861007FE12E;
 			remoteInfo = AEPMessagingLiveActivity;
-		};
-		AA000013AAAA0001000AA001 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 922FFCE7251B2BBA00BCE010 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = AA00000DAAAA0001000AA001;
-			remoteInfo = AEPMessagingNotification;
 		};
 		B6D6AE912BA8C48100F0E975 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -720,6 +723,8 @@
 		09B071F52A7318CB00F259C1 /* Array+Messaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Messaging.swift"; sourceTree = "<group>"; };
 		09F5D93F2B5CF35F00117437 /* PropositionInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropositionInteraction.swift; sourceTree = "<group>"; };
 		0A20A058AD70A9C7E3085CFC /* Pods-MessagingDemoApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MessagingDemoApp.release.xcconfig"; path = "Target Support Files/Pods-MessagingDemoApp/Pods-MessagingDemoApp.release.xcconfig"; sourceTree = "<group>"; };
+		0EB4C861868845FFA51C3132 /* InboxEventListeningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxEventListeningTests.swift; sourceTree = "<group>"; };
+		0F0F12962F910FBB00C2198C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		0F630F3E2F0ED2DE0080688A /* LiveActivityBatchTokenCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityBatchTokenCollector.swift; sourceTree = "<group>"; };
 		0F7A26ACD18052FCC10BA070 /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
 		1331B50C344AD02FE0C9E2BF /* Pods_FunctionalTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -864,8 +869,11 @@
 		28D6E4E97B560158744075F9 /* Pods-FunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		29328F7F748796787B53604C /* Pods-FunctionalTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunctionalTestApp.debug.xcconfig"; path = "Target Support Files/Pods-FunctionalTestApp/Pods-FunctionalTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		2B84E8FD674BD07F86C712FD /* Pods-AEPMessaging.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPMessaging.release.xcconfig"; path = "Target Support Files/Pods-AEPMessaging/Pods-AEPMessaging.release.xcconfig"; sourceTree = "<group>"; };
+		2BCA947D94604DCCACF943AC /* InboxSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxSettingsTests.swift; sourceTree = "<group>"; };
 		36D3F6949A279969C6766FF5 /* Pods_E2EFunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_E2EFunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		385094F2A3B648BC820CEFA9 /* InboxStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxStateTests.swift; sourceTree = "<group>"; };
 		3D55E83254139642A1CAA76E /* Pods_FunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F5CB0ADD5CD4B09B46D6A6D /* InboxErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxErrorTests.swift; sourceTree = "<group>"; };
 		43204BBDCB8D5720A0D56E52 /* Pods-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		4C0111D62DB30FD900996757 /* LiveActivityOrigin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityOrigin.swift; sourceTree = "<group>"; };
 		4C075D6D2DDE74D70082B66C /* ChannelActivityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelActivityStore.swift; sourceTree = "<group>"; };
@@ -896,11 +904,15 @@
 		4CC464CD2E83B35D00217A78 /* CountingDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountingDataStore.swift; sourceTree = "<group>"; };
 		4CC464CE2E83B35D00217A78 /* TestElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestElement.swift; sourceTree = "<group>"; };
 		4CC464CF2E83B35D00217A78 /* TestMapBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMapBase.swift; sourceTree = "<group>"; };
+		531E38A50A394377B713C9E2 /* EmptyStateSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateSettingsTests.swift; sourceTree = "<group>"; };
 		560D22BF9A200A023D6B2DED /* Pods-NotificationServiceSwiftUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceSwiftUI.debug.xcconfig"; path = "Target Support Files/Pods-NotificationServiceSwiftUI/Pods-NotificationServiceSwiftUI.debug.xcconfig"; sourceTree = "<group>"; };
-
 		56F59E16FF701ECF14A230E6 /* NotificationServiceInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = NotificationServiceInfo.plist; sourceTree = "<group>"; };
+		62E308C1D0514AC89E6435D0 /* DefaultErrorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultErrorViewTests.swift; sourceTree = "<group>"; };
 		6346827F4BC239DF7DDFD044 /* Pods-MessagingDemoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MessagingDemoApp.debug.xcconfig"; path = "Target Support Files/Pods-MessagingDemoApp/Pods-MessagingDemoApp.debug.xcconfig"; sourceTree = "<group>"; };
+		65ED549B7D5D4BD2B3766E46 /* InboxSchemaDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxSchemaDataTests.swift; sourceTree = "<group>"; };
+		66B5D6873D544C4787ED0B54 /* InboxFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxFunctionalTests.swift; sourceTree = "<group>"; };
 		6912F64FC8C8BFAF5ACD8EF0 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
+		6A301B4C9BC74A618FBA92EC /* LayoutSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutSettingsTests.swift; sourceTree = "<group>"; };
 		6D215989BF9365E7165510B0 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
 		71895CC75A7A5B934C60718F /* Pods-E2EFunctionalTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.debug.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		754F49E82DFCA9EA002601E9 /* LargeImageTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTemplate.swift; sourceTree = "<group>"; };
@@ -961,8 +973,6 @@
 		925DF4502522785700A5DE31 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		925DF4A525227C4700A5DE31 /* AEPMessaging.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPMessaging.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		928639FB263757A7000AFA53 /* Dictionary+Flatten.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Flatten.swift"; sourceTree = "<group>"; };
-		66B5D6873D544C4787ED0B54 /* InboxFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxFunctionalTests.swift; sourceTree = "<group>"; };
-		D4E3F2A15C6B708901234501 /* ContentCardCacheFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardCacheFunctionalTests.swift; sourceTree = "<group>"; };
 		92863A012637706F000AFA53 /* MessagingFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingFunctionalTests.swift; sourceTree = "<group>"; };
 		9296BA812537BFC0002C88F7 /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		92BCEC9C2538FC0E0068F8B8 /* AEPEdge.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEPEdge.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -976,6 +986,11 @@
 		A4674E5E3D4CA595638A62EB /* Pods_MessagingDemoApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MessagingDemoApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4E78D9F64A7EAE46F3B8CF3 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		A8FFFF03D4A43DCD4C18DF3A /* Pods_NotificationServiceSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationServiceSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA000001AAAA0001000AA001 /* AEPMessagingNotification.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPMessagingNotification.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA000002AAAA0001000AA001 /* AEPMessagingNotification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AEPMessagingNotification.h; sourceTree = "<group>"; };
+		AA000003AAAA0001000AA001 /* MessagingNotificationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagingNotificationHelper.swift; sourceTree = "<group>"; };
+		AA000004AAAA0001000AA001 /* MessagingLog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagingLog.swift; sourceTree = "<group>"; };
+		AA000005AAAA0001000AA001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B60EE0C12F0E40C30040189F /* AEPUnreadIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPUnreadIcon.swift; sourceTree = "<group>"; };
 		B6165DA329A67AD90031B84D /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6165DA529A67ADA0031B84D /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -1026,20 +1041,6 @@
 		B69573C72CD444790027E376 /* AEPBundleImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPBundleImageView.swift; sourceTree = "<group>"; };
 		B6C752772F02692A00F76A54 /* InboxSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxSettings.swift; sourceTree = "<group>"; };
 		B6C752792F04B0CB00F76A54 /* ReadStatusManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStatusManagerTests.swift; sourceTree = "<group>"; };
-		6A301B4C9BC74A618FBA92EC /* LayoutSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutSettingsTests.swift; sourceTree = "<group>"; };
-		2BCA947D94604DCCACF943AC /* InboxSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxSettingsTests.swift; sourceTree = "<group>"; };
-		65ED549B7D5D4BD2B3766E46 /* InboxSchemaDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxSchemaDataTests.swift; sourceTree = "<group>"; };
-		DB1579C648A4431298A5C9EF /* UnreadIndicatorSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadIndicatorSettingsTests.swift; sourceTree = "<group>"; };
-		531E38A50A394377B713C9E2 /* EmptyStateSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateSettingsTests.swift; sourceTree = "<group>"; };
-		DBC56DFB8D444A25BC205CAD /* HeadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingTests.swift; sourceTree = "<group>"; };
-		3F5CB0ADD5CD4B09B46D6A6D /* InboxErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxErrorTests.swift; sourceTree = "<group>"; };
-		385094F2A3B648BC820CEFA9 /* InboxStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxStateTests.swift; sourceTree = "<group>"; };
-		0EB4C861868845FFA51C3132 /* InboxEventListeningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxEventListeningTests.swift; sourceTree = "<group>"; };
-		BC044480E85745A0A6FE4C4F /* InboxUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxUITests.swift; sourceTree = "<group>"; };
-		BE401ECA108F4EF3ADB6F667 /* DefaultHeadingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHeadingViewTests.swift; sourceTree = "<group>"; };
-		BF126D339E6043AF9BA26807 /* DefaultEmptyStateViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEmptyStateViewTests.swift; sourceTree = "<group>"; };
-		F3783B7834D4427ABDFAEE02 /* DefaultLoadingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLoadingViewTests.swift; sourceTree = "<group>"; };
-		62E308C1D0514AC89E6435D0 /* DefaultErrorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultErrorViewTests.swift; sourceTree = "<group>"; };
 		B6C7527B2F04B10100F76A54 /* ReadStatusManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStatusManager.swift; sourceTree = "<group>"; };
 		B6D02CF82F67ECA300D65C16 /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
 		B6D035E12D2F23E900031170 /* AppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateManager.swift; sourceTree = "<group>"; };
@@ -1127,22 +1128,24 @@
 		B6F7CCC82CCAB18700C35C64 /* IntegrationTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = IntegrationTestPlan.xctestplan; sourceTree = "<group>"; };
 		B7B411B1F9538EB09000C67E /* Pods_AEPMessaging.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPMessaging.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B86A865B6338E5FAFD760F08 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BC044480E85745A0A6FE4C4F /* InboxUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxUITests.swift; sourceTree = "<group>"; };
+		BE401ECA108F4EF3ADB6F667 /* DefaultHeadingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHeadingViewTests.swift; sourceTree = "<group>"; };
+		BF126D339E6043AF9BA26807 /* DefaultEmptyStateViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEmptyStateViewTests.swift; sourceTree = "<group>"; };
 		BF90DF53585960AE051234A9 /* Pods-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C7465CB5D942426740F36F97 /* Pods-MessagingDemoAppSwiftUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MessagingDemoAppSwiftUI.debug.xcconfig"; path = "Target Support Files/Pods-MessagingDemoAppSwiftUI/Pods-MessagingDemoAppSwiftUI.debug.xcconfig"; sourceTree = "<group>"; };
+		D4E3F2A15C6B708901234501 /* ContentCardCacheFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardCacheFunctionalTests.swift; sourceTree = "<group>"; };
 		D5773DB866CADAB59B3043AE /* Pods-FunctionalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunctionalTestApp.release.xcconfig"; path = "Target Support Files/Pods-FunctionalTestApp/Pods-FunctionalTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		D63FC3AB2E00DAB800037B50 /* String+DataConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+DataConversion.swift"; sourceTree = "<group>"; };
 		D66DF10B2DD5327E0021AC51 /* MessagingStateManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingStateManagerTests.swift; sourceTree = "<group>"; };
 		D66DF10D2DD5332A0021AC51 /* MockNamedKeyValueService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNamedKeyValueService.swift; sourceTree = "<group>"; };
 		DA6922BC75669B1A110C84A1 /* Pods-AEPMessaging.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPMessaging.debug.xcconfig"; path = "Target Support Files/Pods-AEPMessaging/Pods-AEPMessaging.debug.xcconfig"; sourceTree = "<group>"; };
+		DB1579C648A4431298A5C9EF /* UnreadIndicatorSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadIndicatorSettingsTests.swift; sourceTree = "<group>"; };
+		DBC56DFB8D444A25BC205CAD /* HeadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingTests.swift; sourceTree = "<group>"; };
 		DE8F4262E345FBBC814E3294 /* MessagingRuleEngineInterceptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagingRuleEngineInterceptor.swift; sourceTree = "<group>"; };
 		DE8F4262E345FBBC814E3295 /* RefreshInAppHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RefreshInAppHandler.swift; sourceTree = "<group>"; };
 		E7A2B17D34C47FB6CA55B1E9 /* Pods-MessagingDemoAppObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MessagingDemoAppObjC.debug.xcconfig"; path = "Target Support Files/Pods-MessagingDemoAppObjC/Pods-MessagingDemoAppObjC.debug.xcconfig"; sourceTree = "<group>"; };
 		EF179C2F973B478E3EA6F0EB /* Pods-E2EFunctionalTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTestApp.release.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp.release.xcconfig"; sourceTree = "<group>"; };
-		AA000001AAAA0001000AA001 /* AEPMessagingNotification.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPMessagingNotification.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AA000002AAAA0001000AA001 /* AEPMessagingNotification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AEPMessagingNotification.h; sourceTree = "<group>"; };
-		AA000003AAAA0001000AA001 /* MessagingNotificationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagingNotificationHelper.swift; sourceTree = "<group>"; };
-		AA000004AAAA0001000AA001 /* MessagingLog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagingLog.swift; sourceTree = "<group>"; };
-		AA000005AAAA0001000AA001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F3783B7834D4427ABDFAEE02 /* DefaultLoadingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLoadingViewTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1227,6 +1230,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AA00000BAAAA0001000AA001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B6165DA029A67AD90031B84D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1253,13 +1263,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B61BDACB2DA5E861007FE12E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AA00000BAAAA0001000AA001 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1549,7 +1552,7 @@
 				922FFCF0251B2BBA00BCE010 /* Products */,
 				92BD7B0B251C0B7700C758CB /* Frameworks */,
 				2A4D31945863BC9FEBE21FE1 /* Pods */,
-				);
+			);
 			sourceTree = "<group>";
 		};
 		922FFCF0251B2BBA00BCE010 /* Products */ = {
@@ -1790,6 +1793,25 @@
 			path = FunctionalTests;
 			sourceTree = "<group>";
 		};
+		AA000011AAAA0001000AA001 /* AEPMessagingNotification */ = {
+			isa = PBXGroup;
+			children = (
+				AA000012AAAA0001000AA001 /* Sources */,
+			);
+			path = AEPMessagingNotification;
+			sourceTree = "<group>";
+		};
+		AA000012AAAA0001000AA001 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				AA000002AAAA0001000AA001 /* AEPMessagingNotification.h */,
+				AA000003AAAA0001000AA001 /* MessagingNotificationHelper.swift */,
+				AA000004AAAA0001000AA001 /* MessagingLog.swift */,
+				AA000005AAAA0001000AA001 /* Info.plist */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		B60EE0C02F0E409A0040189F /* AEPUnreadIcon */ = {
 			isa = PBXGroup;
 			children = (
@@ -1905,25 +1927,6 @@
 				B61BDAE52DA5EA43007FE12E /* Sources */,
 			);
 			path = AEPMessagingLiveActivity;
-			sourceTree = "<group>";
-		};
-		AA000011AAAA0001000AA001 /* AEPMessagingNotification */ = {
-			isa = PBXGroup;
-			children = (
-				AA000012AAAA0001000AA001 /* Sources */,
-			);
-			path = AEPMessagingNotification;
-			sourceTree = "<group>";
-		};
-		AA000012AAAA0001000AA001 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				AA000002AAAA0001000AA001 /* AEPMessagingNotification.h */,
-				AA000003AAAA0001000AA001 /* MessagingNotificationHelper.swift */,
-				AA000004AAAA0001000AA001 /* MessagingLog.swift */,
-				AA000005AAAA0001000AA001 /* Info.plist */,
-			);
-			path = Sources;
 			sourceTree = "<group>";
 		};
 		B64256B72D93B06F00EDCAC5 /* LiveActivity */ = {
@@ -2252,6 +2255,7 @@
 				B6F7CC922CC80DE500C35C64 /* ElementViews */,
 				091881E82A16BAE300615481 /* HomeView.swift */,
 				091881FE2A16D7A200615481 /* PushView.swift */,
+				0F0F12962F910FBB00C2198C /* SettingsView.swift */,
 				091881F22A16C2A200615481 /* InAppView.swift */,
 				B6D02CF82F67ECA300D65C16 /* InboxView.swift */,
 				091881F52A16C2D600615481 /* CardsView.swift */,
@@ -2299,19 +2303,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B61BDAC92DA5E861007FE12E /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B61BDAE72DA5EA43007FE12E /* AEPMessagingLiveActivity.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		AA000009AAAA0001000AA001 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				AA000006AAAA0001000AA001 /* AEPMessagingNotification.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B61BDAC92DA5E861007FE12E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B61BDAE72DA5EA43007FE12E /* AEPMessagingLiveActivity.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2511,6 +2515,24 @@
 			productReference = 92FC58782636840C005BAE02 /* FunctionalTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		AA00000DAAAA0001000AA001 /* AEPMessagingNotification */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AA00000EAAAA0001000AA001 /* Build configuration list for PBXNativeTarget "AEPMessagingNotification" */;
+			buildPhases = (
+				AA000009AAAA0001000AA001 /* Headers */,
+				AA00000AAAAA0001000AA001 /* Sources */,
+				AA00000BAAAA0001000AA001 /* Frameworks */,
+				AA00000CAAAA0001000AA001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AEPMessagingNotification;
+			productName = AEPMessagingNotification;
+			productReference = AA000001AAAA0001000AA001 /* AEPMessagingNotification.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		B6165DA229A67AD90031B84D /* NotificationService */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B6165DAE29A67ADA0031B84D /* Build configuration list for PBXNativeTarget "NotificationService" */;
@@ -2583,24 +2605,6 @@
 			productReference = B61BDACE2DA5E861007FE12E /* AEPMessagingLiveActivity.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		AA00000DAAAA0001000AA001 /* AEPMessagingNotification */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = AA00000EAAAA0001000AA001 /* Build configuration list for PBXNativeTarget "AEPMessagingNotification" */;
-			buildPhases = (
-				AA000009AAAA0001000AA001 /* Headers */,
-				AA00000AAAAA0001000AA001 /* Sources */,
-				AA00000BAAAA0001000AA001 /* Frameworks */,
-				AA00000CAAAA0001000AA001 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = AEPMessagingNotification;
-			productName = AEPMessagingNotification;
-			productReference = AA000001AAAA0001000AA001 /* AEPMessagingNotification.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		B6F7CCA32CCA165B00C35C64 /* IntegrationTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B6F7CCAB2CCA165B00C35C64 /* Build configuration list for PBXNativeTarget "IntegrationTests" */;
@@ -2653,6 +2657,7 @@
 					};
 					2414ED7E2899BA080036D505 = {
 						CreatedOnToolsVersion = 13.4.1;
+						LastSwiftMigration = 2640;
 					};
 					2469A6012759999E00E56457 = {
 						CreatedOnToolsVersion = 13.1;
@@ -2867,6 +2872,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AA00000CAAAA0001000AA001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B6165DA129A67AD90031B84D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2890,13 +2902,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B61BDACC2DA5E861007FE12E /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AA00000CAAAA0001000AA001 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2934,9 +2939,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoApp/Pods-MessagingDemoApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoApp/Pods-MessagingDemoApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3039,9 +3048,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoAppObjC/Pods-MessagingDemoAppObjC-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoAppObjC/Pods-MessagingDemoAppObjC-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3078,9 +3091,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-E2EFunctionalTests/Pods-E2EFunctionalTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-E2EFunctionalTests/Pods-E2EFunctionalTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3161,9 +3178,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3178,9 +3199,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-UnitTests/Pods-UnitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-UnitTests/Pods-UnitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3195,9 +3220,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FunctionalTestApp/Pods-FunctionalTestApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FunctionalTestApp/Pods-FunctionalTestApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3212,9 +3241,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-E2EFunctionalTestApp/Pods-E2EFunctionalTestApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3251,9 +3284,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoAppSwiftUI/Pods-MessagingDemoAppSwiftUI-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MessagingDemoAppSwiftUI/Pods-MessagingDemoAppSwiftUI-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3290,9 +3327,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3351,6 +3392,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				091881F72A16C2D600615481 /* CardsView.swift in Sources */,
+				0F0F12972F910FBB00C2198C /* SettingsView.swift in Sources */,
 				B6F7CC992CC874E900C35C64 /* TabHeader.swift in Sources */,
 				0969D6342A75D55E00A00BF7 /* CustomImageView.swift in Sources */,
 				091881E92A16BAE300615481 /* HomeView.swift in Sources */,
@@ -3379,6 +3421,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0F0F12982F910FBB00C2198C /* SettingsView.swift in Sources */,
 				2414ED892899BA080036D505 /* ViewController.m in Sources */,
 				2414ED832899BA080036D505 /* AppDelegate.m in Sources */,
 				2414ED942899BA0A0036D505 /* main.m in Sources */,
@@ -3443,6 +3486,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0F0F12992F910FBB00C2198C /* SettingsView.swift in Sources */,
 				D63FC3AC2E00DACB00037B50 /* String+DataConversion.swift in Sources */,
 				92859411252287C600B2BE47 /* ViewController.swift in Sources */,
 				92859412252287C600B2BE47 /* AppDelegate.swift in Sources */,
@@ -3705,6 +3749,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AA00000AAAAA0001000AA001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA000007AAAA0001000AA001 /* MessagingNotificationHelper.swift in Sources */,
+				AA000008AAAA0001000AA001 /* MessagingLog.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B6165D9F29A67AD90031B84D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3743,15 +3796,6 @@
 				B61BDAEA2DA5EA43007FE12E /* LiveActivityData.swift in Sources */,
 				B6471C7B2E00B0CB0013F127 /* LiveActivityDebuggable.swift in Sources */,
 				4C0111D72DB30FD900996757 /* LiveActivityOrigin.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AA00000AAAAA0001000AA001 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AA000007AAAA0001000AA001 /* MessagingNotificationHelper.swift in Sources */,
-				AA000008AAAA0001000AA001 /* MessagingLog.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3840,6 +3884,11 @@
 			target = 925DF4A425227C4700A5DE31 /* AEPMessaging */;
 			targetProxy = 92FC587E2636840C005BAE02 /* PBXContainerItemProxy */;
 		};
+		AA000014AAAA0001000AA001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AA00000DAAAA0001000AA001 /* AEPMessagingNotification */;
+			targetProxy = AA000013AAAA0001000AA001 /* PBXContainerItemProxy */;
+		};
 		B6165DA929A67ADA0031B84D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B6165DA229A67AD90031B84D /* NotificationService */;
@@ -3859,11 +3908,6 @@
 			isa = PBXTargetDependency;
 			target = B61BDACD2DA5E861007FE12E /* AEPMessagingLiveActivity */;
 			targetProxy = B64B9F9A2DCBB43700F77359 /* PBXContainerItemProxy */;
-		};
-		AA000014AAAA0001000AA001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = AA00000DAAAA0001000AA001 /* AEPMessagingNotification */;
-			targetProxy = AA000013AAAA0001000AA001 /* PBXContainerItemProxy */;
 		};
 		B6D6AE922BA8C48100F0E975 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4062,6 +4106,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = FKGEE875K4;
@@ -4081,6 +4126,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.Messaging.TestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -4092,6 +4139,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = FKGEE875K4;
@@ -4111,6 +4159,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.Messaging.TestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -4703,6 +4752,91 @@
 			};
 			name = Release;
 		};
+		AA00000FAAAA0001000AA001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = AEPMessagingNotification/Sources/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 5.13.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.messagingnotification;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		AA000010AAAA0001000AA001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = AEPMessagingNotification/Sources/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 5.13.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.messagingnotification;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		B6165DAC29A67ADA0031B84D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6D215989BF9365E7165510B0 /* Pods-NotificationService.debug.xcconfig */;
@@ -4963,91 +5097,6 @@
 			};
 			name = Release;
 		};
-		AA00000FAAAA0001000AA001 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = AEPMessagingNotification/Sources/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 5.13.0;
-				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.messagingnotification;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		AA000010AAAA0001000AA001 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = AEPMessagingNotification/Sources/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 5.13.0;
-				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.messagingnotification;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		B6F7CCAC2CCA165B00C35C64 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BF90DF53585960AE051234A9 /* Pods-IntegrationTests.debug.xcconfig */;
@@ -5230,6 +5279,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		AA00000EAAAA0001000AA001 /* Build configuration list for PBXNativeTarget "AEPMessagingNotification" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA00000FAAAA0001000AA001 /* Debug */,
+				AA000010AAAA0001000AA001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B6165DAE29A67ADA0031B84D /* Build configuration list for PBXNativeTarget "NotificationService" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -5271,15 +5329,6 @@
 			buildConfigurations = (
 				B6F7CCAC2CCA165B00C35C64 /* Debug */,
 				B6F7CCAD2CCA165B00C35C64 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		AA00000EAAAA0001000AA001 /* Build configuration list for PBXNativeTarget "AEPMessagingNotification" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				AA00000FAAAA0001000AA001 /* Debug */,
-				AA000010AAAA0001000AA001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -531,29 +531,69 @@ public class Messaging: NSObject, Extension {
         runtime.createSharedState(data: state, event: event)
     }
 
-    /// Handles the reset identities event by clearing the push identifier from persistence and shared state.
+    /// Handles the reset identities event by clearing the push identifier and live activity stores,
+    /// then re-dispatching the persisted push-to-start tokens so they re-flow to Edge with the new ECID.
     /// - Parameter event: the `Event` that triggered the reset identities event
     private func handleResetIdentitiesEvent(_ event: Event) {
         Log.debug(label: MessagingConstants.LOG_TAG, "Processing reset identities event, clearing push identifier and live activity tokens.")
         stateManager.pushIdentifier = nil
 
-        let currentPushToStartTokens = stateManager.pushToStartTokenStore.all()
+        // Capture push-to-start tokens before clearing the store so they can be re-dispatched.
+        let preservedPushToStartTokens = stateManager.pushToStartTokenStore.all()
         stateManager.pushToStartTokenStore.clear()
         stateManager.updateTokenStore.clear()
         stateManager.channelActivityStore.clear()
 
         runtime.createSharedState(data: stateManager.buildMessagingSharedState(), event: event)
 
-        // Re-dispatch saved push-to-start tokens so they are synced to Edge with the new ECID
-        if !currentPushToStartTokens.isEmpty {
-            let tokensArray = currentPushToStartTokens.map { attributeType, tokenData in
+        // Push token is intentionally not re-dispatched on reset (it was just cleared).
+        dispatchPersistedTokenResync(includePushToken: false,
+                                     pushToStartTokens: preservedPushToStartTokens,
+                                     event: event)
+    }
+
+    /// Listens for `edgeConsent` response events and triggers a token re-sync the first time
+    /// `consents.collect.val` transitions into `"y"`.
+    private func handleEdgeConsentResponse(_ event: Event) {
+        let collectVal = extractCollectConsent(from: event.data)
+        defer { lastObservedCollectConsent = collectVal }
+
+        guard collectVal == MessagingConstants.SharedState.Consent.YES,
+              lastObservedCollectConsent != MessagingConstants.SharedState.Consent.YES
+        else {
+            return
+        }
+
+        // Push token must be re-flowed alongside push-to-start tokens because Edge dropped
+        // any sync attempts made while collect consent was not "y".
+        dispatchPersistedTokenResync(includePushToken: true,
+                                     pushToStartTokens: stateManager.pushToStartTokenStore.all(),
+                                     event: event)
+    }
+
+    /// Re-dispatches persisted tokens as Messaging events so they re-flow through the
+    /// normal event pipeline (and on to Edge) using the current ECID.
+    ///
+    /// Used by both reset-identities and consent-granted flows to keep Edge state consistent.
+    /// - Parameters:
+    ///   - includePushToken: when `true`, the persisted push identifier is also re-dispatched.
+    ///     Reset-identities passes `false` (the push token was just cleared by design);
+    ///     consent-granted passes `true`.
+    ///   - pushToStartTokens: the push-to-start token map to re-dispatch (typically a snapshot
+    ///     of `stateManager.pushToStartTokenStore` taken before any clearing).
+    ///   - event: the triggering event, used as the parent for chaining/log correlation.
+    private func dispatchPersistedTokenResync(includePushToken: Bool,
+                                              pushToStartTokens: [LiveActivity.AttributeType: LiveActivity.PushToStartToken],
+                                              event: Event) {
+        if !pushToStartTokens.isEmpty {
+            let tokensArray = pushToStartTokens.map { attributeType, tokenData in
                 [
                     MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: attributeType,
                     MessagingConstants.XDM.Push.TOKEN: tokenData.token
                 ]
             }
             let resyncEvent = Event(
-                name: "\(MessagingConstants.Event.Name.LiveActivity.PUSH_TO_START) (Batched) After Identity Reset",
+                name: "\(MessagingConstants.Event.Name.LiveActivity.PUSH_TO_START) (Batched) Re-sync",
                 type: EventType.messaging,
                 source: EventSource.requestContent,
                 data: [
@@ -562,42 +602,18 @@ public class Messaging: NSObject, Extension {
                 ])
             dispatch(event: resyncEvent)
         }
-    }
 
-    /// Re-syncs persisted push and push-to-start tokens on a collect-consent transition into "y".
-    private func handleEdgeConsentResponse(_ event: Event) {
-        let collectVal = extractCollectConsent(from: event.data)
-        guard collectVal == MessagingConstants.SharedState.Consent.YES,
-              lastObservedCollectConsent != MessagingConstants.SharedState.Consent.YES
-        else {
-            lastObservedCollectConsent = collectVal
-            return
-        }
-        lastObservedCollectConsent = collectVal
-
-        resyncTokensOnConsentGranted(event: event)
-    }
-
-    private func resyncTokensOnConsentGranted(event: Event) {
-        guard let edgeIdentitySharedState = getXDMSharedState(extensionName: MessagingConstants.SharedState.EdgeIdentity.NAME,
-                                                              event: event)?.value,
-              let ecid = retrieveECID(from: edgeIdentitySharedState) else {
-            Log.debug(label: MessagingConstants.LOG_TAG,
-                      "Skipping token re-sync on consent grant — ECID is not available yet.")
-            return
-        }
-
-        if let token = stateManager.pushIdentifier, !token.isEmpty {
-            Log.debug(label: MessagingConstants.LOG_TAG,
-                      "Re-syncing persisted push token to Edge following consent grant.")
-            sendPushToken(ecid: ecid, token: token, event: event)
-        }
-
-        let pushToStartTokens = stateManager.pushToStartTokenStore.all()
-        if !pushToStartTokens.isEmpty {
-            Log.debug(label: MessagingConstants.LOG_TAG,
-                      "Re-syncing \(pushToStartTokens.count) persisted push-to-start token(s) to Edge following consent grant.")
-            sendLiveActivityPushToStartTokens(ecid: ecid, tokenMap: pushToStartTokens, event: event)
+        // Re-dispatch the persisted push identifier when requested. The persisted token is
+        // cleared first so `shouldSyncPushToken` does not short-circuit the re-flow on a
+        // "same token" comparison; `handleProcessEvent` will re-persist it after the sync.
+        if includePushToken, let token = stateManager.pushIdentifier, !token.isEmpty {
+            stateManager.pushIdentifier = nil
+            let pushTokenResyncEvent = Event(
+                name: "Push Identifier Re-sync",
+                type: EventType.genericIdentity,
+                source: EventSource.requestContent,
+                data: [MessagingConstants.Event.Data.Key.PUSH_IDENTIFIER: token])
+            dispatch(event: pushTokenResyncEvent)
         }
     }
 

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -573,6 +573,9 @@ public class Messaging: NSObject, Extension {
                                               pushToStartTokens: [LiveActivity.AttributeType: LiveActivity.PushToStartToken],
                                               event: Event) {
         if !pushToStartTokens.isEmpty {
+            // Cleared first so the same-token equivalence guard in `handleBatchedPushToStartTokenEvent`
+            // does not drop the re-flow. The snapshot has already been captured in `pushToStartTokens`.
+            stateManager.pushToStartTokenStore.clear()
             let tokensArray = pushToStartTokens.map { attributeType, tokenData in
                 [
                     MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: attributeType,

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -498,8 +498,7 @@ public class Messaging: NSObject, Extension {
             hasChanges = hasChanges || didChange
         }
 
-        guard hasChanges else {
-            Log.debug(label: MessagingConstants.LOG_TAG, "No new tokens in batch")
+        guard shouldSyncPushToStartTokens(event: event, hasChanges: hasChanges) else {
             return
         }
 
@@ -573,8 +572,7 @@ public class Messaging: NSObject, Extension {
                                               pushToStartTokens: [LiveActivity.AttributeType: LiveActivity.PushToStartToken],
                                               event: Event) {
         if !pushToStartTokens.isEmpty {
-            // Cleared first so the same-token equivalence guard in `handleBatchedPushToStartTokenEvent`
-            // does not drop the re-flow. The snapshot has already been captured in `pushToStartTokens`.
+            // Cleared so the same-token equivalence guard does not drop the re-flow.
             stateManager.pushToStartTokenStore.clear()
             let tokensArray = pushToStartTokens.map { attributeType, tokenData in
                 [
@@ -593,7 +591,7 @@ public class Messaging: NSObject, Extension {
             dispatch(event: resyncEvent)
         }
 
-        // Cleared first so `shouldSyncPushToken`'s same-token guard does not block the re-flow.
+        // Cleared so `shouldSyncPushToken`'s same-token guard does not block the re-flow.
         if includePushToken, let token = stateManager.pushIdentifier, !token.isEmpty {
             stateManager.pushIdentifier = nil
             let pushTokenResyncEvent = Event(
@@ -657,6 +655,26 @@ public class Messaging: NSObject, Extension {
             return true
         }
         return eventTimestamp.timeIntervalSince(lastPushTokenSyncTimestamp) > MessagingConstants.IGNORE_PUSH_SYNC_TIMEOUT_SECONDS
+    }
+
+    private func shouldSyncPushToStartTokens(event: Event, hasChanges: Bool) -> Bool {
+        if hasChanges {
+            Log.debug(label: MessagingConstants.LOG_TAG,
+                      "Push-to-start token is new or changed. The push-to-start tokens will be synced.")
+            return true
+        }
+
+        let configSharedState = getSharedState(extensionName: MessagingConstants.SharedState.Configuration.NAME, event: event)
+        let optimizePushSync = configSharedState?.value?[MessagingConstants.SharedState.Configuration.OPTIMIZE_PUSH_SYNC] as? Bool ?? true
+        if !optimizePushSync {
+            Log.debug(label: MessagingConstants.LOG_TAG,
+                      "Push-to-start sync optimization is disabled. The push-to-start tokens will be synced.")
+            return true
+        }
+
+        Log.debug(label: MessagingConstants.LOG_TAG,
+                  "Push-to-start sync optimization is enabled. The push-to-start tokens will not be synced.")
+        return false
     }
 
     // MARK: - In-app Messaging methods

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -120,6 +120,9 @@ public class Messaging: NSObject, Extension {
     /// the timestamp of the last push token sync
     private var lastPushTokenSyncTimestamp: Date?
 
+    /// Last collect-consent value observed; used to re-sync only on transition into "y".
+    private var lastObservedCollectConsent: String?
+
     /// Array containing the schema strings for the proposition items supported by the SDK, sent in the personalization query request.
     static let supportedSchemas = [
         MessagingConstants.PersonalizationSchemas.HTML_CONTENT,
@@ -202,6 +205,11 @@ public class Messaging: NSObject, Extension {
         registerListener(type: EventType.system,
                          source: EventSource.debug,
                          listener: handleDebugEvent)
+
+        // Re-sync persisted tokens when collect consent transitions to "y".
+        registerListener(type: EventType.edgeConsent,
+                         source: EventSource.responseContent,
+                         listener: handleEdgeConsentResponse)
 
         // Handler function called for each queued event. If the queued event is a get propositions event, process it
         // otherwise if it is an Edge event to update propositions, process it only if it is completed.
@@ -531,6 +539,49 @@ public class Messaging: NSObject, Extension {
         createMessagingSharedState(token: nil, event: event)
         // clear the push identifier from persistence
         stateManager.pushIdentifier = nil
+    }
+
+    /// Re-syncs persisted push and push-to-start tokens on a collect-consent transition into "y".
+    private func handleEdgeConsentResponse(_ event: Event) {
+        let collectVal = extractCollectConsent(from: event.data)
+        guard collectVal == MessagingConstants.SharedState.Consent.YES,
+              lastObservedCollectConsent != MessagingConstants.SharedState.Consent.YES
+        else {
+            lastObservedCollectConsent = collectVal
+            return
+        }
+        lastObservedCollectConsent = collectVal
+
+        resyncTokensOnConsentGranted(event: event)
+    }
+
+    private func resyncTokensOnConsentGranted(event: Event) {
+        guard let edgeIdentitySharedState = getXDMSharedState(extensionName: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                                              event: event)?.value,
+              let ecid = retrieveECID(from: edgeIdentitySharedState) else {
+            Log.debug(label: MessagingConstants.LOG_TAG,
+                      "Skipping token re-sync on consent grant — ECID is not available yet.")
+            return
+        }
+
+        if let token = stateManager.pushIdentifier, !token.isEmpty {
+            Log.debug(label: MessagingConstants.LOG_TAG,
+                      "Re-syncing persisted push token to Edge following consent grant.")
+            sendPushToken(ecid: ecid, token: token, event: event)
+        }
+
+        let pushToStartTokens = stateManager.pushToStartTokenStore.all()
+        if !pushToStartTokens.isEmpty {
+            Log.debug(label: MessagingConstants.LOG_TAG,
+                      "Re-syncing \(pushToStartTokens.count) persisted push-to-start token(s) to Edge following consent grant.")
+            sendLiveActivityPushToStartTokens(ecid: ecid, tokenMap: pushToStartTokens, event: event)
+        }
+    }
+
+    private func extractCollectConsent(from data: [String: Any]?) -> String? {
+        return (data?[MessagingConstants.SharedState.Consent.CONSENTS] as? [String: Any])
+            .flatMap { $0[MessagingConstants.SharedState.Consent.COLLECT] as? [String: Any] }
+            .flatMap { $0[MessagingConstants.SharedState.Consent.VAL] as? String }
     }
 
     /// Checks if the push identifier can be synced

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -120,7 +120,7 @@ public class Messaging: NSObject, Extension {
     /// the timestamp of the last push token sync
     private var lastPushTokenSyncTimestamp: Date?
 
-    /// Last collect-consent value observed; used to re-sync only on transition into "y".
+    /// last observed collect-consent value, used to detect transitions into "y"
     private var lastObservedCollectConsent: String?
 
     /// Array containing the schema strings for the proposition items supported by the SDK, sent in the personalization query request.
@@ -531,14 +531,12 @@ public class Messaging: NSObject, Extension {
         runtime.createSharedState(data: state, event: event)
     }
 
-    /// Handles the reset identities event by clearing the push identifier and live activity stores,
-    /// then re-dispatching the persisted push-to-start tokens so they re-flow to Edge with the new ECID.
-    /// - Parameter event: the `Event` that triggered the reset identities event
+    /// Handles the reset identities event: clears persisted state and re-dispatches push-to-start
+    /// tokens so they re-flow to Edge with the new ECID.
     private func handleResetIdentitiesEvent(_ event: Event) {
         Log.debug(label: MessagingConstants.LOG_TAG, "Processing reset identities event, clearing push identifier and live activity tokens.")
         stateManager.pushIdentifier = nil
 
-        // Capture push-to-start tokens before clearing the store so they can be re-dispatched.
         let preservedPushToStartTokens = stateManager.pushToStartTokenStore.all()
         stateManager.pushToStartTokenStore.clear()
         stateManager.updateTokenStore.clear()
@@ -546,14 +544,12 @@ public class Messaging: NSObject, Extension {
 
         runtime.createSharedState(data: stateManager.buildMessagingSharedState(), event: event)
 
-        // Push token is intentionally not re-dispatched on reset (it was just cleared).
         dispatchPersistedTokenResync(includePushToken: false,
                                      pushToStartTokens: preservedPushToStartTokens,
                                      event: event)
     }
 
-    /// Listens for `edgeConsent` response events and triggers a token re-sync the first time
-    /// `consents.collect.val` transitions into `"y"`.
+    /// Triggers a token re-sync the first time `consents.collect.val` transitions to `"y"`.
     private func handleEdgeConsentResponse(_ event: Event) {
         let collectVal = extractCollectConsent(from: event.data)
         defer { lastObservedCollectConsent = collectVal }
@@ -564,24 +560,13 @@ public class Messaging: NSObject, Extension {
             return
         }
 
-        // Push token must be re-flowed alongside push-to-start tokens because Edge dropped
-        // any sync attempts made while collect consent was not "y".
         dispatchPersistedTokenResync(includePushToken: true,
                                      pushToStartTokens: stateManager.pushToStartTokenStore.all(),
                                      event: event)
     }
 
-    /// Re-dispatches persisted tokens as Messaging events so they re-flow through the
-    /// normal event pipeline (and on to Edge) using the current ECID.
-    ///
-    /// Used by both reset-identities and consent-granted flows to keep Edge state consistent.
-    /// - Parameters:
-    ///   - includePushToken: when `true`, the persisted push identifier is also re-dispatched.
-    ///     Reset-identities passes `false` (the push token was just cleared by design);
-    ///     consent-granted passes `true`.
-    ///   - pushToStartTokens: the push-to-start token map to re-dispatch (typically a snapshot
-    ///     of `stateManager.pushToStartTokenStore` taken before any clearing).
-    ///   - event: the triggering event, used as the parent for chaining/log correlation.
+    /// Re-dispatches persisted tokens as Messaging events so they re-flow through `handleProcessEvent`
+    /// using the current ECID. Shared by reset-identities and consent-granted flows.
     private func dispatchPersistedTokenResync(includePushToken: Bool,
                                               pushToStartTokens: [LiveActivity.AttributeType: LiveActivity.PushToStartToken],
                                               event: Event) {
@@ -603,9 +588,7 @@ public class Messaging: NSObject, Extension {
             dispatch(event: resyncEvent)
         }
 
-        // Re-dispatch the persisted push identifier when requested. The persisted token is
-        // cleared first so `shouldSyncPushToken` does not short-circuit the re-flow on a
-        // "same token" comparison; `handleProcessEvent` will re-persist it after the sync.
+        // Cleared first so `shouldSyncPushToken`'s same-token guard does not block the re-flow.
         if includePushToken, let token = stateManager.pushIdentifier, !token.isEmpty {
             stateManager.pushIdentifier = nil
             let pushTokenResyncEvent = Event(

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -551,11 +551,13 @@ public class Messaging: NSObject, Extension {
 
     /// Triggers a token re-sync the first time `consents.collect.val` transitions to `"y"`.
     private func handleEdgeConsentResponse(_ event: Event) {
-        let collectVal = extractCollectConsent(from: event.data)
+        guard let collectVal = extractCollectConsent(from: event.data) else {
+            return
+        }
         defer { lastObservedCollectConsent = collectVal }
 
-        guard collectVal == MessagingConstants.SharedState.Consent.YES,
-              lastObservedCollectConsent != MessagingConstants.SharedState.Consent.YES
+        guard collectVal == MessagingConstants.Event.Data.Key.Consent.YES,
+              lastObservedCollectConsent != MessagingConstants.Event.Data.Key.Consent.YES
         else {
             return
         }
@@ -601,9 +603,9 @@ public class Messaging: NSObject, Extension {
     }
 
     private func extractCollectConsent(from data: [String: Any]?) -> String? {
-        return (data?[MessagingConstants.SharedState.Consent.CONSENTS] as? [String: Any])
-            .flatMap { $0[MessagingConstants.SharedState.Consent.COLLECT] as? [String: Any] }
-            .flatMap { $0[MessagingConstants.SharedState.Consent.VAL] as? String }
+        return (data?[MessagingConstants.Event.Data.Key.Consent.CONSENTS] as? [String: Any])
+            .flatMap { $0[MessagingConstants.Event.Data.Key.Consent.COLLECT] as? [String: Any] }
+            .flatMap { $0[MessagingConstants.Event.Data.Key.Consent.VAL] as? String }
     }
 
     /// Checks if the push identifier can be synced

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -182,6 +182,13 @@ enum MessagingConstants {
                     static let PRIORITY = "priority"
                     static let ID = "id"
                 }
+
+                enum Consent {
+                    static let CONSENTS = "consents"
+                    static let COLLECT = "collect"
+                    static let VAL = "val"
+                    static let YES = "y"
+                }
             }
         }
 
@@ -378,13 +385,6 @@ enum MessagingConstants {
             static let IDENTITY_MAP = "identityMap"
             static let ECID = "ECID"
             static let ID = "id"
-        }
-
-        enum Consent {
-            static let CONSENTS = "consents"
-            static let COLLECT = "collect"
-            static let VAL = "val"
-            static let YES = "y"
         }
     }
 

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -379,6 +379,13 @@ enum MessagingConstants {
             static let ECID = "ECID"
             static let ID = "id"
         }
+
+        enum Consent {
+            static let CONSENTS = "consents"
+            static let COLLECT = "collect"
+            static let VAL = "val"
+            static let YES = "y"
+        }
     }
 
     enum PushNotification {

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1309,8 +1309,8 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "n"))
 
-        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
-        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushTokenResyncEvents().count)
+        XCTAssertEqual(0, dispatchedPushToStartResyncEvents().count)
     }
 
     func testConsentResponse_collectPending_doesNotResync() {
@@ -1320,8 +1320,8 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "p"))
 
-        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
-        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushTokenResyncEvents().count)
+        XCTAssertEqual(0, dispatchedPushToStartResyncEvents().count)
     }
 
     func testConsentResponse_repeatedYes_onlyResyncsOnTransition() {
@@ -1330,10 +1330,12 @@ class MessagingTests: XCTestCase {
                                            data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+        // Re-set the persisted push identifier because the first re-sync clears it.
+        stateManager.pushIdentifier = MOCK_PUSH_TOKEN
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        XCTAssertEqual(1, dispatchedPushProfileEdgeEvents().count)
+        XCTAssertEqual(1, dispatchedPushTokenResyncEvents().count)
     }
 
     func testConsentResponse_resyncsAgainAfterToggle() {
@@ -1342,17 +1344,23 @@ class MessagingTests: XCTestCase {
                                            data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+        // Re-set the persisted push identifier because the first re-sync clears it.
+        stateManager.pushIdentifier = MOCK_PUSH_TOKEN
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "n"))
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        XCTAssertEqual(2, dispatchedPushProfileEdgeEvents().count)
+        XCTAssertEqual(2, dispatchedPushTokenResyncEvents().count)
     }
 
-    func testConsentResponse_collectYes_noEdgeIdentityState_doesNotResync() {
+    func testConsentResponse_collectYes_noEdgeIdentityState_dispatchesResyncForPipeline() {
+        // The consent listener no longer pre-checks Edge Identity; the dispatched re-sync events
+        // re-flow through `handleProcessEvent`, which itself defers until Edge Identity is ready.
+        // This mirrors how `handleResetIdentitiesEvent` operates and removes duplicated guards.
         stateManager.pushIdentifier = MOCK_PUSH_TOKEN
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
+        XCTAssertEqual(1, dispatchedPushTokenResyncEvents().count)
         XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
         XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
     }
@@ -1378,8 +1386,8 @@ class MessagingTests: XCTestCase {
                                                    data: data))
         }
 
-        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
-        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushTokenResyncEvents().count)
+        XCTAssertEqual(0, dispatchedPushToStartResyncEvents().count)
     }
 
     // MARK: - Edge Consent Response: Push Token Re-sync Tests
@@ -1391,11 +1399,14 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        let pushEvents = dispatchedPushProfileEdgeEvents()
-        XCTAssertEqual(1, pushEvents.count)
-        XCTAssertEqual(EventType.edge, pushEvents.first?.type)
-        XCTAssertEqual(EventSource.requestContent, pushEvents.first?.source)
-        XCTAssertEqual(MOCK_PUSH_TOKEN, getDispatchedEventPushToken(event: pushEvents.first))
+        let resyncEvents = dispatchedPushTokenResyncEvents()
+        XCTAssertEqual(1, resyncEvents.count)
+        XCTAssertEqual(EventType.genericIdentity, resyncEvents.first?.type)
+        XCTAssertEqual(EventSource.requestContent, resyncEvents.first?.source)
+        XCTAssertEqual(MOCK_PUSH_TOKEN, tokenFromResyncEvent(resyncEvents.first))
+        // Persisted token is cleared by the helper so handleProcessEvent's same-token
+        // optimization does not block the re-sync.
+        XCTAssertNil(stateManager.pushIdentifier)
     }
 
     func testConsentResponse_collectYes_noPersistedPushToken_doesNotDispatch() {
@@ -1405,7 +1416,7 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushTokenResyncEvents().count)
     }
 
     func testConsentResponse_collectYes_emptyPushIdentifier_doesNotDispatch() {
@@ -1415,7 +1426,7 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushTokenResyncEvents().count)
     }
 
     // MARK: - Edge Consent Response: End-to-End Scenario (MOB-24789)
@@ -1429,6 +1440,7 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "n"))
         XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushTokenResyncEvents().count)
 
         let setPushEvent = Event(name: "setPushIdentifier",
                                  type: EventType.genericIdentity,
@@ -1441,10 +1453,15 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        let pushEvents = dispatchedPushProfileEdgeEvents()
-        XCTAssertEqual(2, pushEvents.count)
-        XCTAssertEqual(MOCK_PUSH_TOKEN, getDispatchedEventPushToken(event: pushEvents[0]))
-        XCTAssertEqual(MOCK_PUSH_TOKEN, getDispatchedEventPushToken(event: pushEvents[1]))
+        // Outbound Edge sync from setPushIdentifier still counts as 1; the consent re-sync
+        // produces an internal genericIdentity / requestContent event that re-flows through
+        // handleProcessEvent in production.
+        XCTAssertEqual(1, dispatchedPushProfileEdgeEvents().count)
+        let resyncEvents = dispatchedPushTokenResyncEvents()
+        // Both the original setPushEvent and the consent re-sync match the resync filter shape.
+        XCTAssertTrue(resyncEvents.contains { tokenFromResyncEvent($0) == MOCK_PUSH_TOKEN })
+        // Persisted push identifier was cleared by the helper to bypass the same-token guard.
+        XCTAssertNil(stateManager.pushIdentifier)
     }
 
     func testEndToEnd_pushToStartTokenSetWhileConsentNo_thenRemoteConsentYes_resyncs() {
@@ -1455,7 +1472,7 @@ class MessagingTests: XCTestCase {
                                            data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "n"))
-        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushToStartResyncEvents().count)
 
         stateManager.pushToStartTokenStore.set(
             LiveActivity.PushToStartToken(firstIssued: Date(), token: "pts-token-1"),
@@ -1465,10 +1482,14 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        let ptsEvents = dispatchedPushToStartEdgeEvents()
+        let ptsEvents = dispatchedPushToStartResyncEvents()
         XCTAssertEqual(1, ptsEvents.count)
-        XCTAssertEqual(EventType.edge, ptsEvents.first?.type)
+        XCTAssertEqual(EventType.messaging, ptsEvents.first?.type)
         XCTAssertEqual(EventSource.requestContent, ptsEvents.first?.source)
+        let batchedTokens = ptsEvents.first?.liveActivityBatchedPushToStartTokens
+        XCTAssertEqual(1, batchedTokens?.count)
+        XCTAssertEqual("AttrTypeA", batchedTokens?.first?[MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE])
+        XCTAssertEqual("pts-token-1", batchedTokens?.first?[MessagingConstants.XDM.Push.TOKEN])
     }
 
     // MARK: - Edge Consent Response: Live Activity Push-to-Start Token Re-sync Tests
@@ -1487,10 +1508,12 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        let ptsEvents = dispatchedPushToStartEdgeEvents()
+        let ptsEvents = dispatchedPushToStartResyncEvents()
         XCTAssertEqual(1, ptsEvents.count)
-        XCTAssertEqual(EventType.edge, ptsEvents.first?.type)
+        XCTAssertEqual(EventType.messaging, ptsEvents.first?.type)
         XCTAssertEqual(EventSource.requestContent, ptsEvents.first?.source)
+        let batchedTokens = ptsEvents.first?.liveActivityBatchedPushToStartTokens
+        XCTAssertEqual(2, batchedTokens?.count)
     }
 
     func testConsentResponse_collectYes_noPersistedPushToStartTokens_doesNotDispatch() {
@@ -1499,7 +1522,7 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushToStartResyncEvents().count)
     }
 
     // MARK: - Helpers
@@ -1823,5 +1846,26 @@ class MessagingTests: XCTestCase {
         mockRuntime.dispatchedEvents.filter {
             $0.name == MessagingConstants.Event.Name.LiveActivity.PUSH_TO_START_EDGE
         }
+    }
+
+    /// Internal push-identifier re-sync events dispatched by `dispatchPersistedTokenResync`.
+    /// These are the same shape as a `setPushIdentifier` request event (genericIdentity / requestContent
+    /// with `pushidentifier` in the data) and are routed back through `handleProcessEvent`.
+    private func dispatchedPushTokenResyncEvents() -> [Event] {
+        mockRuntime.dispatchedEvents.filter {
+            $0.type == EventType.genericIdentity
+                && $0.source == EventSource.requestContent
+                && ($0.data?[MessagingConstants.Event.Data.Key.PUSH_IDENTIFIER] as? String) != nil
+        }
+    }
+
+    /// Internal push-to-start re-sync events dispatched by `dispatchPersistedTokenResync`.
+    /// These are routed back through `handleProcessEvent` → `handleBatchedPushToStartTokenEvent`.
+    private func dispatchedPushToStartResyncEvents() -> [Event] {
+        mockRuntime.dispatchedEvents.filter { $0.isLiveActivityPushToStartTokenEvent }
+    }
+
+    private func tokenFromResyncEvent(_ event: Event?) -> String? {
+        event?.data?[MessagingConstants.Event.Data.Key.PUSH_IDENTIFIER] as? String
     }
 }

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -68,6 +68,9 @@ class MessagingTests: XCTestCase {
     override func tearDown() {
         MobileCore.messagingDelegate = nil
         stateManager.pushIdentifier = nil
+        for id in stateManager.pushToStartTokenStore.all().keys {
+            stateManager.pushToStartTokenStore.remove(id: id)
+        }
     }
     
     /// validate the extension is registered without any error
@@ -75,9 +78,9 @@ class MessagingTests: XCTestCase {
         XCTAssertNoThrow(MobileCore.registerExtensions([Messaging.self]))
     }
     
-    /// validate that 8 listeners are registered onRegister
-    func testOnRegistered_eightListenersAreRegistered() {
-        XCTAssertEqual(mockRuntime.listeners.count, 8)
+    /// validate that 9 listeners are registered onRegister
+    func testOnRegistered_nineListenersAreRegistered() {
+        XCTAssertEqual(mockRuntime.listeners.count, 9)
     }
     
     func testOnUnregisteredCallable() throws {
@@ -1215,6 +1218,208 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(nil, mockRuntime.firstSharedState![MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER] as? String)
     }
 
+    // MARK: - Edge Consent Response: Transition & Guard Tests
+
+    func testConsentResponse_collectNo_doesNotResync() {
+        stateManager.pushIdentifier = MOCK_PUSH_TOKEN
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "n"))
+
+        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+    }
+
+    func testConsentResponse_collectPending_doesNotResync() {
+        stateManager.pushIdentifier = MOCK_PUSH_TOKEN
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "p"))
+
+        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+    }
+
+    func testConsentResponse_repeatedYes_onlyResyncsOnTransition() {
+        stateManager.pushIdentifier = MOCK_PUSH_TOKEN
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        XCTAssertEqual(1, dispatchedPushProfileEdgeEvents().count)
+    }
+
+    func testConsentResponse_resyncsAgainAfterToggle() {
+        stateManager.pushIdentifier = MOCK_PUSH_TOKEN
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "n"))
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        XCTAssertEqual(2, dispatchedPushProfileEdgeEvents().count)
+    }
+
+    func testConsentResponse_collectYes_noEdgeIdentityState_doesNotResync() {
+        stateManager.pushIdentifier = MOCK_PUSH_TOKEN
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+    }
+
+    func testConsentResponse_malformedOrMissingData_doesNotCrashOrResync() {
+        stateManager.pushIdentifier = MOCK_PUSH_TOKEN
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        let badPayloads: [[String: Any]?] = [
+            nil,
+            [:],
+            [MessagingConstants.SharedState.Consent.CONSENTS: "not-a-dictionary"],
+            [MessagingConstants.SharedState.Consent.CONSENTS: [
+                "adID": [MessagingConstants.SharedState.Consent.VAL: "y"]
+            ]]
+        ]
+
+        for data in badPayloads {
+            mockRuntime.simulateComingEvents(Event(name: "Consent Preferences Updated",
+                                                   type: EventType.edgeConsent,
+                                                   source: EventSource.responseContent,
+                                                   data: data))
+        }
+
+        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+    }
+
+    // MARK: - Edge Consent Response: Push Token Re-sync Tests
+
+    func testConsentResponse_collectYes_resyncsPersistedPushToken() {
+        stateManager.pushIdentifier = MOCK_PUSH_TOKEN
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        let pushEvents = dispatchedPushProfileEdgeEvents()
+        XCTAssertEqual(1, pushEvents.count)
+        XCTAssertEqual(EventType.edge, pushEvents.first?.type)
+        XCTAssertEqual(EventSource.requestContent, pushEvents.first?.source)
+        XCTAssertEqual(MOCK_PUSH_TOKEN, getDispatchedEventPushToken(event: pushEvents.first))
+    }
+
+    func testConsentResponse_collectYes_noPersistedPushToken_doesNotDispatch() {
+        stateManager.pushIdentifier = nil
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+    }
+
+    func testConsentResponse_collectYes_emptyPushIdentifier_doesNotDispatch() {
+        stateManager.pushIdentifier = ""
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+    }
+
+    // MARK: - Edge Consent Response: End-to-End Scenario (MOB-24789)
+
+    func testEndToEnd_pushTokenSetWhileConsentNo_thenRemoteConsentYes_resyncs() {
+        let mockConfig = [EXPERIENCE_CLOUD_ORG: MOCK_EXP_ORG_ID]
+        mockRuntime.simulateSharedState(for: MessagingConstants.SharedState.Configuration.NAME,
+                                        data: (value: mockConfig, status: SharedStateStatus.set))
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "n"))
+        XCTAssertEqual(0, dispatchedPushProfileEdgeEvents().count)
+
+        let setPushEvent = Event(name: "setPushIdentifier",
+                                 type: EventType.genericIdentity,
+                                 source: EventSource.requestContent,
+                                 data: [MessagingConstants.Event.Data.Key.PUSH_IDENTIFIER: MOCK_PUSH_TOKEN])
+        messaging.handleProcessEvent(setPushEvent)
+
+        XCTAssertEqual(MOCK_PUSH_TOKEN, stateManager.pushIdentifier)
+        XCTAssertEqual(1, dispatchedPushProfileEdgeEvents().count)
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        let pushEvents = dispatchedPushProfileEdgeEvents()
+        XCTAssertEqual(2, pushEvents.count)
+        XCTAssertEqual(MOCK_PUSH_TOKEN, getDispatchedEventPushToken(event: pushEvents[0]))
+        XCTAssertEqual(MOCK_PUSH_TOKEN, getDispatchedEventPushToken(event: pushEvents[1]))
+    }
+
+    func testEndToEnd_pushToStartTokenSetWhileConsentNo_thenRemoteConsentYes_resyncs() {
+        let mockConfig = [EXPERIENCE_CLOUD_ORG: MOCK_EXP_ORG_ID]
+        mockRuntime.simulateSharedState(for: MessagingConstants.SharedState.Configuration.NAME,
+                                        data: (value: mockConfig, status: SharedStateStatus.set))
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "n"))
+        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+
+        stateManager.pushToStartTokenStore.set(
+            LiveActivity.PushToStartToken(firstIssued: Date(), token: "pts-token-1"),
+            id: "AttrTypeA"
+        )
+        XCTAssertEqual(1, stateManager.pushToStartTokenStore.all().count)
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        let ptsEvents = dispatchedPushToStartEdgeEvents()
+        XCTAssertEqual(1, ptsEvents.count)
+        XCTAssertEqual(EventType.edge, ptsEvents.first?.type)
+        XCTAssertEqual(EventSource.requestContent, ptsEvents.first?.source)
+    }
+
+    // MARK: - Edge Consent Response: Live Activity Push-to-Start Token Re-sync Tests
+
+    func testConsentResponse_collectYes_resyncsPersistedPushToStartTokens() {
+        stateManager.pushToStartTokenStore.set(
+            LiveActivity.PushToStartToken(firstIssued: Date(), token: "pts-token-1"),
+            id: "AttrTypeA"
+        )
+        stateManager.pushToStartTokenStore.set(
+            LiveActivity.PushToStartToken(firstIssued: Date(), token: "pts-token-2"),
+            id: "AttrTypeB"
+        )
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        let ptsEvents = dispatchedPushToStartEdgeEvents()
+        XCTAssertEqual(1, ptsEvents.count)
+        XCTAssertEqual(EventType.edge, ptsEvents.first?.type)
+        XCTAssertEqual(EventSource.requestContent, ptsEvents.first?.source)
+    }
+
+    func testConsentResponse_collectYes_noPersistedPushToStartTokens_doesNotDispatch() {
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME,
+                                           data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+
+        mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
+
+        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+    }
+
     // MARK: - Helpers
     
     func getGenericEventHistoryDisqualifyEvent(iamMap: [String: String]? = nil) -> Event {
@@ -1507,5 +1712,34 @@ class MessagingTests: XCTestCase {
         let pushTokenEventData = event?.data?[MessagingConstants.Event.Data.Key.DATA] as? [String: Any]
         let pushNotificationDetails = pushTokenEventData?[MessagingConstants.XDM.Push.PUSH_NOTIFICATION_DETAILS] as? [[String: Any]]
         return pushNotificationDetails?.first?[MessagingConstants.XDM.Push.TOKEN] as? String
+    }
+
+    // MARK: - Consent test helpers
+
+    private func makeConsentEvent(collect: String?) -> Event {
+        var data: [String: Any] = [:]
+        var collectBlock: [String: Any] = [:]
+        if let collect = collect {
+            collectBlock[MessagingConstants.SharedState.Consent.VAL] = collect
+        }
+        data[MessagingConstants.SharedState.Consent.CONSENTS] = [
+            MessagingConstants.SharedState.Consent.COLLECT: collectBlock
+        ]
+        return Event(name: "Consent Preferences Updated",
+                     type: EventType.edgeConsent,
+                     source: EventSource.responseContent,
+                     data: data)
+    }
+
+    private func dispatchedPushProfileEdgeEvents() -> [Event] {
+        mockRuntime.dispatchedEvents.filter {
+            $0.name == MessagingConstants.Event.Name.PUSH_PROFILE_EDGE
+        }
+    }
+
+    private func dispatchedPushToStartEdgeEvents() -> [Event] {
+        mockRuntime.dispatchedEvents.filter {
+            $0.name == MessagingConstants.Event.Name.LiveActivity.PUSH_TO_START_EDGE
+        }
     }
 }

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1479,6 +1479,9 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(1, batchedTokens?.count)
         XCTAssertEqual("AttrTypeA", batchedTokens?.first?[MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE])
         XCTAssertEqual("pts-token-1", batchedTokens?.first?[MessagingConstants.XDM.Push.TOKEN])
+        // Store cleared so the dispatched re-sync re-populates it via `handleBatchedPushToStartTokenEvent`
+        // instead of being dropped by the same-token equivalence guard.
+        XCTAssertTrue(stateManager.pushToStartTokenStore.all().isEmpty)
     }
 
     // MARK: - Edge Consent Response: Live Activity Push-to-Start Token Re-sync Tests
@@ -1503,6 +1506,7 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(EventSource.requestContent, ptsEvents.first?.source)
         let batchedTokens = ptsEvents.first?.liveActivityBatchedPushToStartTokens
         XCTAssertEqual(2, batchedTokens?.count)
+        XCTAssertTrue(stateManager.pushToStartTokenStore.all().isEmpty)
     }
 
     func testConsentResponse_collectYes_noPersistedPushToStartTokens_doesNotDispatch() {

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1369,9 +1369,9 @@ class MessagingTests: XCTestCase {
         let badPayloads: [[String: Any]?] = [
             nil,
             [:],
-            [MessagingConstants.SharedState.Consent.CONSENTS: "not-a-dictionary"],
-            [MessagingConstants.SharedState.Consent.CONSENTS: [
-                "adID": [MessagingConstants.SharedState.Consent.VAL: "y"]
+            [MessagingConstants.Event.Data.Key.Consent.CONSENTS: "not-a-dictionary"],
+            [MessagingConstants.Event.Data.Key.Consent.CONSENTS: [
+                "adID": [MessagingConstants.Event.Data.Key.Consent.VAL: "y"]
             ]]
         ]
 
@@ -1814,10 +1814,10 @@ class MessagingTests: XCTestCase {
         var data: [String: Any] = [:]
         var collectBlock: [String: Any] = [:]
         if let collect = collect {
-            collectBlock[MessagingConstants.SharedState.Consent.VAL] = collect
+            collectBlock[MessagingConstants.Event.Data.Key.Consent.VAL] = collect
         }
-        data[MessagingConstants.SharedState.Consent.CONSENTS] = [
-            MessagingConstants.SharedState.Consent.COLLECT: collectBlock
+        data[MessagingConstants.Event.Data.Key.Consent.CONSENTS] = [
+            MessagingConstants.Event.Data.Key.Consent.COLLECT: collectBlock
         ]
         return Event(name: "Consent Preferences Updated",
                      type: EventType.edgeConsent,

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1194,6 +1194,50 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(self.MOCK_PUSH_TOKEN, self.getDispatchedEventPushToken(event: thirdPushTokenEvent))
     }
 
+    // MARK: - Push-to-Start Token Sync Optimization Tests
+
+    func testPushToStartTokenSync_whenTokenMatches_OptimizePushSyncIsTrue() {
+        let mockConfig = [EXPERIENCE_CLOUD_ORG: MOCK_EXP_ORG_ID, MessagingConstants.SharedState.Configuration.OPTIMIZE_PUSH_SYNC: true] as [String: Any]
+        mockRuntime.simulateSharedState(for: MessagingConstants.SharedState.Configuration.NAME, data: (value: mockConfig, status: SharedStateStatus.set))
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+        stateManager.pushToStartTokenStore.set(
+            LiveActivity.PushToStartToken(firstIssued: Date(), token: "pts-token-1"),
+            id: "AttrTypeA"
+        )
+
+        mockRuntime.simulateComingEvents(makeBatchedPushToStartEvent(tokens: [(token: "pts-token-1", attributeType: "AttrTypeA")]))
+
+        XCTAssertEqual(0, dispatchedPushToStartEdgeEvents().count)
+    }
+
+    func testPushToStartTokenSync_whenTokenMatches_OptimizePushSyncIsFalse_forcesSync() {
+        let mockConfig = [EXPERIENCE_CLOUD_ORG: MOCK_EXP_ORG_ID, MessagingConstants.SharedState.Configuration.OPTIMIZE_PUSH_SYNC: false] as [String: Any]
+        mockRuntime.simulateSharedState(for: MessagingConstants.SharedState.Configuration.NAME, data: (value: mockConfig, status: SharedStateStatus.set))
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+        stateManager.pushToStartTokenStore.set(
+            LiveActivity.PushToStartToken(firstIssued: Date(), token: "pts-token-1"),
+            id: "AttrTypeA"
+        )
+
+        mockRuntime.simulateComingEvents(makeBatchedPushToStartEvent(tokens: [(token: "pts-token-1", attributeType: "AttrTypeA")]))
+
+        XCTAssertEqual(1, dispatchedPushToStartEdgeEvents().count)
+    }
+
+    func testPushToStartTokenSync_whenNewToken_alwaysSyncs() {
+        let mockConfig = [EXPERIENCE_CLOUD_ORG: MOCK_EXP_ORG_ID, MessagingConstants.SharedState.Configuration.OPTIMIZE_PUSH_SYNC: true] as [String: Any]
+        mockRuntime.simulateSharedState(for: MessagingConstants.SharedState.Configuration.NAME, data: (value: mockConfig, status: SharedStateStatus.set))
+        mockRuntime.simulateXDMSharedState(for: MessagingConstants.SharedState.EdgeIdentity.NAME, data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
+        stateManager.pushToStartTokenStore.set(
+            LiveActivity.PushToStartToken(firstIssued: Date(), token: "pts-token-1"),
+            id: "AttrTypeA"
+        )
+
+        mockRuntime.simulateComingEvents(makeBatchedPushToStartEvent(tokens: [(token: "pts-token-2", attributeType: "AttrTypeA")]))
+
+        XCTAssertEqual(1, dispatchedPushToStartEdgeEvents().count)
+    }
+
     // MARK: - Reset Identities Event Handling Tests
 
     func testHandleResetIdentitiesEvent_clearsPushTokenAndAllLiveActivityStores() {
@@ -1479,8 +1523,6 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(1, batchedTokens?.count)
         XCTAssertEqual("AttrTypeA", batchedTokens?.first?[MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE])
         XCTAssertEqual("pts-token-1", batchedTokens?.first?[MessagingConstants.XDM.Push.TOKEN])
-        // Store cleared so the dispatched re-sync re-populates it via `handleBatchedPushToStartTokenEvent`
-        // instead of being dropped by the same-token equivalence guard.
         XCTAssertTrue(stateManager.pushToStartTokenStore.all().isEmpty)
     }
 
@@ -1851,6 +1893,23 @@ class MessagingTests: XCTestCase {
 
     private func dispatchedPushToStartResyncEvents() -> [Event] {
         mockRuntime.dispatchedEvents.filter { $0.isLiveActivityPushToStartTokenEvent }
+    }
+
+    private func makeBatchedPushToStartEvent(tokens: [(token: String, attributeType: String)]) -> Event {
+        let tokensArray = tokens.map { tokenData in
+            [
+                MessagingConstants.Event.Data.Key.LiveActivity.ATTRIBUTE_TYPE: tokenData.attributeType,
+                MessagingConstants.XDM.Push.TOKEN: tokenData.token
+            ]
+        }
+        let eventData: [String: Any] = [
+            MessagingConstants.Event.Data.Key.LiveActivity.PUSH_TO_START_TOKEN: true,
+            MessagingConstants.Event.Data.Key.LiveActivity.BATCHED_PUSH_TO_START_TOKENS: tokensArray
+        ]
+        return Event(name: "\(MessagingConstants.Event.Name.LiveActivity.PUSH_TO_START) (Batched)",
+                     type: EventType.messaging,
+                     source: EventSource.requestContent,
+                     data: eventData)
     }
 
     private func tokenFromResyncEvent(_ event: Event?) -> String? {

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -1330,7 +1330,7 @@ class MessagingTests: XCTestCase {
                                            data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
-        // Re-set the persisted push identifier because the first re-sync clears it.
+        // re-sync clears the persisted token; restore it so subsequent transitions are exercised
         stateManager.pushIdentifier = MOCK_PUSH_TOKEN
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
@@ -1344,7 +1344,6 @@ class MessagingTests: XCTestCase {
                                            data: (value: SampleEdgeIdentityState, status: SharedStateStatus.set))
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
-        // Re-set the persisted push identifier because the first re-sync clears it.
         stateManager.pushIdentifier = MOCK_PUSH_TOKEN
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "n"))
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
@@ -1353,9 +1352,6 @@ class MessagingTests: XCTestCase {
     }
 
     func testConsentResponse_collectYes_noEdgeIdentityState_dispatchesResyncForPipeline() {
-        // The consent listener no longer pre-checks Edge Identity; the dispatched re-sync events
-        // re-flow through `handleProcessEvent`, which itself defers until Edge Identity is ready.
-        // This mirrors how `handleResetIdentitiesEvent` operates and removes duplicated guards.
         stateManager.pushIdentifier = MOCK_PUSH_TOKEN
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
@@ -1404,8 +1400,6 @@ class MessagingTests: XCTestCase {
         XCTAssertEqual(EventType.genericIdentity, resyncEvents.first?.type)
         XCTAssertEqual(EventSource.requestContent, resyncEvents.first?.source)
         XCTAssertEqual(MOCK_PUSH_TOKEN, tokenFromResyncEvent(resyncEvents.first))
-        // Persisted token is cleared by the helper so handleProcessEvent's same-token
-        // optimization does not block the re-sync.
         XCTAssertNil(stateManager.pushIdentifier)
     }
 
@@ -1453,14 +1447,9 @@ class MessagingTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(makeConsentEvent(collect: "y"))
 
-        // Outbound Edge sync from setPushIdentifier still counts as 1; the consent re-sync
-        // produces an internal genericIdentity / requestContent event that re-flows through
-        // handleProcessEvent in production.
         XCTAssertEqual(1, dispatchedPushProfileEdgeEvents().count)
         let resyncEvents = dispatchedPushTokenResyncEvents()
-        // Both the original setPushEvent and the consent re-sync match the resync filter shape.
         XCTAssertTrue(resyncEvents.contains { tokenFromResyncEvent($0) == MOCK_PUSH_TOKEN })
-        // Persisted push identifier was cleared by the helper to bypass the same-token guard.
         XCTAssertNil(stateManager.pushIdentifier)
     }
 
@@ -1848,9 +1837,6 @@ class MessagingTests: XCTestCase {
         }
     }
 
-    /// Internal push-identifier re-sync events dispatched by `dispatchPersistedTokenResync`.
-    /// These are the same shape as a `setPushIdentifier` request event (genericIdentity / requestContent
-    /// with `pushidentifier` in the data) and are routed back through `handleProcessEvent`.
     private func dispatchedPushTokenResyncEvents() -> [Event] {
         mockRuntime.dispatchedEvents.filter {
             $0.type == EventType.genericIdentity
@@ -1859,8 +1845,6 @@ class MessagingTests: XCTestCase {
         }
     }
 
-    /// Internal push-to-start re-sync events dispatched by `dispatchPersistedTokenResync`.
-    /// These are routed back through `handleProcessEvent` → `handleBatchedPushToStartTokenEvent`.
     private func dispatchedPushToStartResyncEvents() -> [Event] {
         mockRuntime.dispatchedEvents.filter { $0.isLiveActivityPushToStartTokenEvent }
     }

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/HomeView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/HomeView.swift
@@ -42,6 +42,10 @@ struct HomeView: View {
                 .tabItem {
                     Label("Push", systemImage: "paperplane.fill")
                 }
+            SettingsView()
+                .tabItem {
+                    Label("Settings", systemImage: "gearshape.fill")
+                }
         }
     }
 }

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/PushView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/PushView.swift
@@ -11,14 +11,11 @@ governing permissions and limitations under the License.
 */
 
 import SwiftUI
-import AEPCore
 import AEPEdgeIdentity
-import AEPMessaging
 
 struct PushView: View {
     @State private var ECID: String?
     @State private var devicePushToken: String?
-    @State private var resetStatus: String?
 
     var body: some View {
         VStack {
@@ -36,30 +33,6 @@ struct PushView: View {
                 UIPasteboard.general.string = devicePushToken
             }
             
-            Divider().frame(height: 30)
-
-            VStack(spacing: 12) {
-                Text("Identity Reset")
-                    .font(.title3)
-                    .foregroundColor(.accentColor)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Button {
-                    resetAndReregister()
-                } label: {
-                    Text("Reset Identity")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-
-                if let status = resetStatus {
-                    Text(status)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-            }
-            .padding(.horizontal)
-
             Spacer()
         }
         .padding()
@@ -76,25 +49,6 @@ struct PushView: View {
         }
         
         devicePushToken = UserDefaults.standard.string(forKey: "devicePushToken")
-    }
-
-    private func resetAndReregister() {
-        let oldEcid = ECID ?? "unknown"
-        resetStatus = "Resetting identities..."
-
-        MobileCore.resetIdentities()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            // Re-register for remote notifications so the APNs callback
-            // fires and setPushIdentifier is called with the device token.
-            // Live Activity tokens are automatically re-synced by the SDK.
-            UIApplication.shared.registerForRemoteNotifications()
-
-            Identity.getExperienceCloudId { (ecid, error) in
-                ECID = ecid
-                resetStatus = "Done. ECID changed: \(oldEcid.prefix(8))... -> \(ecid?.prefix(8) ?? "nil")..."
-            }
-        }
     }
 }
 

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/SettingsView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/SettingsView.swift
@@ -1,0 +1,196 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import AEPEdgeConsent
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var collectConsent: CollectConsentValue = .unknown
+    @State private var isLoading = false
+    @State private var lastAction: String = ""
+
+    enum CollectConsentValue: String {
+        case yes = "y"
+        case no = "n"
+        case pending = "p"
+        case unknown = "—"
+
+        var label: String {
+            switch self {
+            case .yes:     return "Yes (y)"
+            case .no:      return "No (n)"
+            case .pending: return "Pending (p)"
+            case .unknown: return "Unknown"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .yes:     return .green
+            case .no:      return .red
+            case .pending: return .orange
+            case .unknown: return .secondary
+            }
+        }
+    }
+
+    var body: some View {
+        NavigationView {
+            List {
+                currentConsentSection
+                changeConsentSection
+                if !lastAction.isEmpty {
+                    lastActionSection
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Settings")
+            .onAppear { readConsent() }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var currentConsentSection: some View {
+        Section {
+            HStack {
+                Label("Collect Consent", systemImage: "checkmark.shield")
+                Spacer()
+                if isLoading {
+                    ProgressView()
+                        .padding(.trailing, 4)
+                } else {
+                    Text(collectConsent.label)
+                        .foregroundColor(collectConsent.color)
+                        .bold()
+                }
+            }
+            .padding(.vertical, 4)
+
+            Button {
+                readConsent()
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+        } header: {
+            Text("Current Consent")
+        } footer: {
+            Text("The current collect consent value stored in the SDK.")
+        }
+    }
+
+    private var changeConsentSection: some View {
+        Section {
+            consentButton(
+                title: "Set Yes",
+                subtitle: "Allow data collection",
+                icon: "checkmark.circle.fill",
+                iconColor: .green,
+                value: "y"
+            )
+            consentButton(
+                title: "Set No",
+                subtitle: "Block data collection",
+                icon: "xmark.circle.fill",
+                iconColor: .red,
+                value: "n"
+            )
+            consentButton(
+                title: "Set Pending",
+                subtitle: "Defer until user chooses",
+                icon: "questionmark.circle.fill",
+                iconColor: .orange,
+                value: "p"
+            )
+        } header: {
+            Text("Change Consent")
+        } footer: {
+            Text("Calls Consent.update(with:) and refreshes the displayed value.")
+        }
+    }
+
+    private var lastActionSection: some View {
+        Section {
+            HStack(spacing: 8) {
+                Image(systemName: "info.circle")
+                    .foregroundColor(.accentColor)
+                Text(lastAction)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.vertical, 4)
+        } header: {
+            Text("Last Action")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func consentButton(title: String, subtitle: String, icon: String, iconColor: Color, value: String) -> some View {
+        Button {
+            updateConsent(to: value)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .font(.title2)
+                    .foregroundColor(iconColor)
+                    .frame(width: 32)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .foregroundColor(.primary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                if collectConsent.rawValue == value {
+                    Image(systemName: "checkmark")
+                        .foregroundColor(.accentColor)
+                        .font(.footnote.bold())
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private func updateConsent(to value: String) {
+        Consent.update(with: ["consents": ["collect": ["val": value]]])
+        lastAction = "Called Consent.update(collect: \"\(value)\")"
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            readConsent()
+        }
+    }
+
+    private func readConsent() {
+        isLoading = true
+        Consent.getConsents { consents, error in
+            DispatchQueue.main.async {
+                isLoading = false
+                guard error == nil, let consents = consents else {
+                    collectConsent = .unknown
+                    return
+                }
+                let val = (consents["consents"] as? [String: Any])
+                    .flatMap { $0["collect"] as? [String: Any] }
+                    .flatMap { $0["val"] as? String }
+                    ?? ""
+                collectConsent = CollectConsentValue(rawValue: val) ?? .unknown
+            }
+        }
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+    }
+}

--- a/TestApps/MessagingDemoAppSwiftUI/AppPages/SettingsView.swift
+++ b/TestApps/MessagingDemoAppSwiftUI/AppPages/SettingsView.swift
@@ -10,8 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import AEPCore
 import AEPEdgeConsent
+import AEPEdgeIdentity
 import SwiftUI
+import UIKit
 
 struct SettingsView: View {
     @State private var collectConsent: CollectConsentValue = .unknown
@@ -48,6 +51,7 @@ struct SettingsView: View {
             List {
                 currentConsentSection
                 changeConsentSection
+                identityResetSection
                 if !lastAction.isEmpty {
                     lastActionSection
                 }
@@ -118,6 +122,20 @@ struct SettingsView: View {
         }
     }
 
+    private var identityResetSection: some View {
+        Section {
+            Button(role: .destructive) {
+                resetIdentity()
+            } label: {
+                Label("Reset Identity", systemImage: "arrow.counterclockwise.circle")
+            }
+        } header: {
+            Text("Identity Reset")
+        } footer: {
+            Text("Calls MobileCore.resetIdentities() and re-registers for remote notifications.")
+        }
+    }
+
     private var lastActionSection: some View {
         Section {
             HStack(spacing: 8) {
@@ -167,6 +185,22 @@ struct SettingsView: View {
         lastAction = "Called Consent.update(collect: \"\(value)\")"
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             readConsent()
+        }
+    }
+
+    private func resetIdentity() {
+        Identity.getExperienceCloudId { oldEcid, _ in
+            MobileCore.resetIdentities()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                UIApplication.shared.registerForRemoteNotifications()
+                Identity.getExperienceCloudId { newEcid, _ in
+                    DispatchQueue.main.async {
+                        let from = oldEcid?.prefix(8) ?? "nil"
+                        let to = newEcid?.prefix(8) ?? "nil"
+                        lastAction = "Reset identities. ECID: \(from)... -> \(to)..."
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When Set Push Identifier events are dispatched by the SDK, it stores the push token for that device in local storage.  On subsequent requests to set push identifier, the SDK compares the value it has in local storage (if any) against the value in the new request.  The SDK only sends the event to edge if the push token values are different.
The problem exists in an edge case related to the `collect` value in consent.  When `collect` is set to `n`, no events are sent to the Edge by the Edge extension.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
