### PR TITLE
Added new update propositions api with support of xdm and data fields

### DIFF
--- a/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
+++ b/AEPMessaging/Sources/ClassExtensions/Event+Messaging.swift
@@ -124,6 +124,16 @@ extension Event {
         data?[MessagingConstants.Event.Data.Key.UPDATE_PROPOSITIONS] as? Bool ?? false
     }
 
+    /// Custom XDM fields provided by the caller of `updatePropositionsForSurfaces(_:withXdm:andData:)` to attach to the personalization request.
+    var updatePropositionsXdm: [String: Any]? {
+        data?[MessagingConstants.Event.Data.Key.XDM] as? [String: Any]
+    }
+
+    /// Custom free-form data provided by the caller of `updatePropositionsForSurfaces(_:withXdm:andData:)` to attach to the personalization request.
+    var updatePropositionsData: [String: Any]? {
+        data?[MessagingConstants.Event.Data.Key.DATA] as? [String: Any]
+    }
+
     // MARK: - Track Propositions Public API event
 
     var isTrackPropositionsEvent: Bool {

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -97,7 +97,7 @@ import UserNotifications
     /// - Parameters:
     ///   - surfaces: An array of `Surface` objects.
     static func updatePropositionsForSurfaces(_ surfaces: [Surface]) {
-        updatePropositionsForSurfaces(surfaces, nil)
+        updatePropositionsForSurfaces(surfaces, withXdm: nil, andData: nil, nil)
     }
 
     /// Dispatches an event to fetch propositions for the provided surfaces from remote.
@@ -108,6 +108,34 @@ import UserNotifications
     ///   - completion: An optional completion handler to be called once the proposition response has been processed by the Messaging extension
     @objc(updatePropositionsForSurfaces:completion:)
     static func updatePropositionsForSurfaces(_ surfaces: [Surface], _ completion: ((Bool) -> Void)? = nil) {
+        updatePropositionsForSurfaces(surfaces, withXdm: nil, andData: nil, completion)
+    }
+
+    /// Dispatches an event to fetch propositions for the provided surfaces from remote, attaching custom XDM and/or free-form data to the personalization request.
+    ///
+    /// Any fields provided in `xdm` are merged into the request's XDM object, and any fields provided in `data` are merged into the request's free-form data object.
+    /// Internal keys required by the SDK (for example, the personalization request `eventType`) always take precedence and cannot be overwritten by the caller.
+    /// - Parameters:
+    ///   - surfaces: An array of `Surface` objects.
+    ///   - xdm: An optional dictionary of custom XDM fields to attach to the personalization request (for example, context fields used by decisioning eligibility rules).
+    ///   - data: An optional dictionary of custom free-form data to attach to the personalization request.
+    static func updatePropositionsForSurfaces(_ surfaces: [Surface], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil) {
+        updatePropositionsForSurfaces(surfaces, withXdm: xdm, andData: data, nil)
+    }
+
+    /// Dispatches an event to fetch propositions for the provided surfaces from remote, attaching custom XDM and/or free-form data to the personalization request.
+    ///
+    /// Any fields provided in `xdm` are merged into the request's XDM object, and any fields provided in `data` are merged into the request's free-form data object.
+    /// Internal keys required by the SDK (for example, the personalization request `eventType`) always take precedence and cannot be overwritten by the caller.
+    /// If provided, `completion` will be called on the Messaging extension's background thread once the response has been fully processed.
+    /// `true` will be passed to the `completion` method if a network response was returned and successfully processed.
+    /// - Parameters:
+    ///   - surfaces: An array of `Surface` objects.
+    ///   - xdm: An optional dictionary of custom XDM fields to attach to the personalization request (for example, context fields used by decisioning eligibility rules).
+    ///   - data: An optional dictionary of custom free-form data to attach to the personalization request.
+    ///   - completion: An optional completion handler to be called once the proposition response has been processed by the Messaging extension
+    @objc(updatePropositionsForSurfaces:withXdm:andData:completion:)
+    static func updatePropositionsForSurfaces(_ surfaces: [Surface], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil, _ completion: ((Bool) -> Void)? = nil) {
         let validSurfaces = surfaces
             .filter { $0.isValid }
 
@@ -118,10 +146,18 @@ import UserNotifications
             return
         }
 
-        let eventData: [String: Any] = [
+        var eventData: [String: Any] = [
             MessagingConstants.Event.Data.Key.UPDATE_PROPOSITIONS: true,
             MessagingConstants.Event.Data.Key.SURFACES: validSurfaces.compactMap { $0.asDictionary() }
         ]
+
+        if let xdm = xdm, !xdm.isEmpty {
+            eventData[MessagingConstants.Event.Data.Key.XDM] = xdm
+        }
+
+        if let data = data, !data.isEmpty {
+            eventData[MessagingConstants.Event.Data.Key.DATA] = data
+        }
 
         let event = Event(name: MessagingConstants.Event.Name.UPDATE_PROPOSITIONS,
                           type: EventType.messaging,

--- a/AEPMessaging/Sources/Messaging+PublicAPI.swift
+++ b/AEPMessaging/Sources/Messaging+PublicAPI.swift
@@ -115,18 +115,6 @@ import UserNotifications
     ///
     /// Any fields provided in `xdm` are merged into the request's XDM object, and any fields provided in `data` are merged into the request's free-form data object.
     /// Internal keys required by the SDK (for example, the personalization request `eventType`) always take precedence and cannot be overwritten by the caller.
-    /// - Parameters:
-    ///   - surfaces: An array of `Surface` objects.
-    ///   - xdm: An optional dictionary of custom XDM fields to attach to the personalization request (for example, context fields used by decisioning eligibility rules).
-    ///   - data: An optional dictionary of custom free-form data to attach to the personalization request.
-    static func updatePropositionsForSurfaces(_ surfaces: [Surface], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil) {
-        updatePropositionsForSurfaces(surfaces, withXdm: xdm, andData: data, nil)
-    }
-
-    /// Dispatches an event to fetch propositions for the provided surfaces from remote, attaching custom XDM and/or free-form data to the personalization request.
-    ///
-    /// Any fields provided in `xdm` are merged into the request's XDM object, and any fields provided in `data` are merged into the request's free-form data object.
-    /// Internal keys required by the SDK (for example, the personalization request `eventType`) always take precedence and cannot be overwritten by the caller.
     /// If provided, `completion` will be called on the Messaging extension's background thread once the response has been fully processed.
     /// `true` will be passed to the `completion` method if a network response was returned and successfully processed.
     /// - Parameters:

--- a/AEPMessaging/Sources/Messaging.swift
+++ b/AEPMessaging/Sources/Messaging.swift
@@ -277,7 +277,7 @@ public class Messaging: NSObject, Extension {
         // handle an event to request propositions from the remote
         if event.isUpdatePropositionsEvent {
             Log.debug(label: MessagingConstants.LOG_TAG, "Processing request to update propositions from the remote.")
-            fetchPropositions(event, for: event.surfaces ?? [])
+            fetchPropositions(event, for: event.surfaces ?? [], xdm: event.updatePropositionsXdm, data: event.updatePropositionsData)
             return
         }
 
@@ -840,7 +840,7 @@ public class Messaging: NSObject, Extension {
     /// - Parameters:
     ///   - event - parent event requesting that the messages be fetched. Used for event chaining to help with debugging.
     ///   - surfaces: an array of surface path strings for fetching propositions, if available.
-    private func fetchPropositions(_ event: Event, for surfaces: [Surface]? = nil) {
+    private func fetchPropositions(_ event: Event, for surfaces: [Surface]? = nil, xdm customXdm: [String: Any]? = nil, data customData: [String: Any]? = nil) {
         // check for completion handler for requesting event
         let handler = completionHandlerFor(originatingEventId: event.id)
 
@@ -864,36 +864,8 @@ public class Messaging: NSObject, Extension {
             requestedSurfaces = [Surface(uri: appSurface)]
         }
 
-        // begin construction of event data
-        var eventData: [String: Any] = [:]
-
-        // add `query` parameters containing supported schemas and requested surfaces
-        eventData[MessagingConstants.XDM.Inbound.Key.QUERY] = [
-            MessagingConstants.XDM.Inbound.Key.PERSONALIZATION: [
-                MessagingConstants.XDM.Inbound.Key.SCHEMAS: Messaging.supportedSchemas,
-                MessagingConstants.XDM.Inbound.Key.SURFACES: requestedSurfaces.compactMap { $0.uri }
-            ]
-        ]
-
-        // add `xdm` with an event type of `personalization.request`
-        eventData[MessagingConstants.XDM.Key.XDM] = [
-            MessagingConstants.XDM.Key.EVENT_TYPE: MessagingConstants.XDM.Inbound.EventType.PERSONALIZATION_REQUEST
-        ]
-
-        // add a `data` object to the request specifying the format desired in the response from XAS
-        eventData[MessagingConstants.Event.Data.Key.DATA] = [
-            MessagingConstants.Event.Data.AdobeKeys.NAMESPACE: [
-                MessagingConstants.Event.Data.AdobeKeys.AJO: [
-                    MessagingConstants.Event.Data.AdobeKeys.INAPP_RESPONSE_FORMAT: MessagingConstants.XDM.Inbound.Value.IAM_RESPONSE_FORMAT
-                ]
-            ]
-        ]
-
-        // add a `request` object so we get a response event from edge when the propositions stream is closed for this event
-        eventData[MessagingConstants.XDM.Key.REQUEST] = [
-            MessagingConstants.XDM.Key.SEND_COMPLETION: true
-        ]
-        // end construction of event data
+        // build the personalization request event data, merging any caller-provided custom XDM/data
+        let eventData = createPersonalizationRequestEventData(for: requestedSurfaces, xdm: customXdm, data: customData)
 
         let newEvent = event.createChainedEvent(name: MessagingConstants.Event.Name.RETRIEVE_MESSAGE_DEFINITIONS,
                                                 type: EventType.edge,
@@ -935,6 +907,59 @@ public class Messaging: NSObject, Extension {
                                                                          data: [MessagingConstants.Event.Data.Key.ENDING_EVENT_ID: endingEventId])
             self.dispatch(event: processCompletedEvent)
         }
+    }
+
+    /// Builds the event data for a `personalization.request` edge event for the provided surfaces.
+    ///
+    /// Any caller-provided `xdm` is merged into the request's XDM object and any caller-provided `data` is merged into the
+    /// request's free-form data object. Internal keys required by the SDK — the personalization request `eventType` in XDM and
+    /// the `__adobe` in-app response format in data — always take precedence and cannot be overwritten by the caller.
+    /// - Parameters:
+    ///   - surfaces: the valid surfaces to request propositions for.
+    ///   - customXdm: optional custom XDM fields to merge into the request XDM.
+    ///   - customData: optional custom free-form data to merge into the request data.
+    /// - Returns: the event data dictionary for the chained edge request event.
+    func createPersonalizationRequestEventData(for surfaces: [Surface], xdm customXdm: [String: Any]?, data customData: [String: Any]?) -> [String: Any] {
+        var eventData: [String: Any] = [:]
+
+        // add `query` parameters containing supported schemas and requested surfaces
+        eventData[MessagingConstants.XDM.Inbound.Key.QUERY] = [
+            MessagingConstants.XDM.Inbound.Key.PERSONALIZATION: [
+                MessagingConstants.XDM.Inbound.Key.SCHEMAS: Messaging.supportedSchemas,
+                MessagingConstants.XDM.Inbound.Key.SURFACES: surfaces.compactMap { $0.uri }
+            ]
+        ]
+
+        // add `xdm` with an event type of `personalization.request`, merging any caller-provided XDM.
+        // the internal `eventType` is required and always wins over a caller-provided value on collision.
+        var requestXdm: [String: Any] = [
+            MessagingConstants.XDM.Key.EVENT_TYPE: MessagingConstants.XDM.Inbound.EventType.PERSONALIZATION_REQUEST
+        ]
+        if let customXdm = customXdm {
+            requestXdm.merge(customXdm) { internalValue, _ in internalValue }
+        }
+        eventData[MessagingConstants.XDM.Key.XDM] = requestXdm
+
+        // add a `data` object to the request specifying the format desired in the response from XAS, merging any
+        // caller-provided data. the internal `__adobe` namespace is required and always wins on collision.
+        var requestData: [String: Any] = [
+            MessagingConstants.Event.Data.AdobeKeys.NAMESPACE: [
+                MessagingConstants.Event.Data.AdobeKeys.AJO: [
+                    MessagingConstants.Event.Data.AdobeKeys.INAPP_RESPONSE_FORMAT: MessagingConstants.XDM.Inbound.Value.IAM_RESPONSE_FORMAT
+                ]
+            ]
+        ]
+        if let customData = customData {
+            requestData.merge(customData) { internalValue, _ in internalValue }
+        }
+        eventData[MessagingConstants.Event.Data.Key.DATA] = requestData
+
+        // add a `request` object so we get a response event from edge when the propositions stream is closed for this event
+        eventData[MessagingConstants.XDM.Key.REQUEST] = [
+            MessagingConstants.XDM.Key.SEND_COMPLETION: true
+        ]
+
+        return eventData
     }
 
     func handleProcessCompletedEvent(_ event: Event) {

--- a/AEPMessaging/Sources/MessagingConstants.swift
+++ b/AEPMessaging/Sources/MessagingConstants.swift
@@ -111,6 +111,7 @@ enum MessagingConstants {
                 static let TRACK_PROPOSITIONS = "trackpropositions"
                 static let PROPOSITION_INTERACTION = "propositioninteraction"
                 static let SURFACES = "surfaces"
+                static let XDM = "xdm"
                 static let PROPOSITIONS = "propositions"
                 static let RESPONSE_ERROR = "responseerror"
                 static let ENDING_EVENT_ID = "endingEventId"

--- a/AEPMessaging/Tests/UnitTests/Event+MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/Event+MessagingTests.swift
@@ -548,9 +548,50 @@ class EventPlusMessagingTests: XCTestCase {
     func testSurfacesNoSurfaces() throws {
         // setup
         let event = Event(name: "s", type: EventType.messaging, source: EventSource.requestContent, data: [:])
-        
+
         // verify
-        XCTAssertNil(event.surfaces)        
+        XCTAssertNil(event.surfaces)
+    }
+
+    // MARK: - update propositions custom xdm / data
+
+    func testUpdatePropositionsXdm() throws {
+        // setup
+        let event = Event(name: "s", type: EventType.messaging, source: EventSource.requestContent, data: [
+            "xdm": ["_chipotle": ["restaurantId": "6099"]]
+        ])
+
+        // verify
+        let xdm = try XCTUnwrap(event.updatePropositionsXdm)
+        let chipotle = try XCTUnwrap(xdm["_chipotle"] as? [String: Any])
+        XCTAssertEqual("6099", chipotle["restaurantId"] as? String)
+    }
+
+    func testUpdatePropositionsXdmWhenAbsent() throws {
+        // setup
+        let event = Event(name: "s", type: EventType.messaging, source: EventSource.requestContent, data: [:])
+
+        // verify
+        XCTAssertNil(event.updatePropositionsXdm)
+    }
+
+    func testUpdatePropositionsData() throws {
+        // setup
+        let event = Event(name: "s", type: EventType.messaging, source: EventSource.requestContent, data: [
+            "data": ["customKey": "customValue"]
+        ])
+
+        // verify
+        let data = try XCTUnwrap(event.updatePropositionsData)
+        XCTAssertEqual("customValue", data["customKey"] as? String)
+    }
+
+    func testUpdatePropositionsDataWhenAbsent() throws {
+        // setup
+        let event = Event(name: "s", type: EventType.messaging, source: EventSource.requestContent, data: [:])
+
+        // verify
+        XCTAssertNil(event.updatePropositionsData)
     }
     
     // MARK: - get propositions api events

--- a/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
+++ b/AEPMessaging/Tests/UnitTests/Messaging+PublicApiTest.swift
@@ -480,11 +480,124 @@ class MessagingPublicApiTest: XCTestCase, AnyCodableAsserts {
         
         // test
         Messaging.updatePropositionsForSurfaces([])
-        
+
         // verify
         wait(for: [expectation], timeout: ASYNC_TIMEOUT)
     }
-    
+
+    func testUpdatePropositionsForSurfaces_withXdm() throws {
+        // setup
+        let expectation = XCTestExpectation(description: "updatePropositionsForSurfaces should dispatch an event carrying custom XDM.")
+        expectation.assertForOverFulfill = true
+
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(
+            type: "com.adobe.eventType.messaging",
+            source: "com.adobe.eventSource.requestContent") { event in
+                XCTAssertEqual(true, event.data?["updatepropositions"] as? Bool)
+                let xdm = event.data?["xdm"] as? [String: Any]
+                XCTAssertNotNil(xdm)
+                let chipotle = xdm?["_chipotle"] as? [String: Any]
+                XCTAssertEqual("6099", chipotle?["restaurantId"] as? String)
+                // data should be absent when not provided
+                XCTAssertNil(event.data?["data"])
+                expectation.fulfill()
+            }
+
+        // test
+        Messaging.updatePropositionsForSurfaces([Surface(path: "promos/feed1")],
+                                                withXdm: ["_chipotle": ["restaurantId": "6099"]])
+
+        // verify
+        wait(for: [expectation], timeout: ASYNC_TIMEOUT)
+    }
+
+    func testUpdatePropositionsForSurfaces_withData() throws {
+        // setup
+        let expectation = XCTestExpectation(description: "updatePropositionsForSurfaces should dispatch an event carrying custom data.")
+        expectation.assertForOverFulfill = true
+
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(
+            type: "com.adobe.eventType.messaging",
+            source: "com.adobe.eventSource.requestContent") { event in
+                XCTAssertEqual(true, event.data?["updatepropositions"] as? Bool)
+                let data = event.data?["data"] as? [String: Any]
+                XCTAssertEqual("customValue", data?["customKey"] as? String)
+                XCTAssertNil(event.data?["xdm"])
+                expectation.fulfill()
+            }
+
+        // test
+        Messaging.updatePropositionsForSurfaces([Surface(path: "promos/feed1")],
+                                                withXdm: nil,
+                                                andData: ["customKey": "customValue"])
+
+        // verify
+        wait(for: [expectation], timeout: ASYNC_TIMEOUT)
+    }
+
+    func testUpdatePropositionsForSurfaces_withXdmAndData_andCompletion() throws {
+        // setup
+        let expectation = XCTestExpectation(description: "updatePropositionsForSurfaces should dispatch an event carrying custom XDM and data.")
+        expectation.assertForOverFulfill = true
+
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(
+            type: "com.adobe.eventType.messaging",
+            source: "com.adobe.eventSource.requestContent") { event in
+                let xdm = event.data?["xdm"] as? [String: Any]
+                XCTAssertNotNil(xdm?["_chipotle"] as? [String: Any])
+                let data = event.data?["data"] as? [String: Any]
+                XCTAssertEqual("customValue", data?["customKey"] as? String)
+                expectation.fulfill()
+            }
+
+        // test - exercise the completion-bearing overload
+        Messaging.updatePropositionsForSurfaces([Surface(path: "promos/feed1")],
+                                                withXdm: ["_chipotle": ["restaurantId": "6099"]],
+                                                andData: ["customKey": "customValue"]) { _ in }
+
+        // verify
+        wait(for: [expectation], timeout: ASYNC_TIMEOUT)
+    }
+
+    func testUpdatePropositionsForSurfaces_backwardCompatible_noXdmOrDataKeys() throws {
+        // setup - the existing surfaces-only overload should not attach xdm/data keys
+        let expectation = XCTestExpectation(description: "updatePropositionsForSurfaces should dispatch an event without xdm/data keys.")
+        expectation.assertForOverFulfill = true
+
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(
+            type: "com.adobe.eventType.messaging",
+            source: "com.adobe.eventSource.requestContent") { event in
+                XCTAssertEqual(true, event.data?["updatepropositions"] as? Bool)
+                XCTAssertNil(event.data?["xdm"])
+                XCTAssertNil(event.data?["data"])
+                expectation.fulfill()
+            }
+
+        // test
+        Messaging.updatePropositionsForSurfaces([Surface(path: "promos/feed1")])
+
+        // verify
+        wait(for: [expectation], timeout: ASYNC_TIMEOUT)
+    }
+
+    func testUpdatePropositionsForSurfaces_withXdm_whenEmptySurfacesArray_doesNotDispatch() {
+        // setup
+        let expectation = XCTestExpectation(description: "updatePropositionsForSurfaces should not dispatch an event for empty surfaces even when xdm provided.")
+        expectation.isInverted = true
+
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(
+            type: "com.adobe.eventType.messaging",
+            source: "com.adobe.eventSource.requestContent") { _ in
+                expectation.fulfill()
+            }
+
+        // test
+        Messaging.updatePropositionsForSurfaces([], withXdm: ["_chipotle": ["restaurantId": "6099"]])
+
+        // verify
+        wait(for: [expectation], timeout: ASYNC_TIMEOUT)
+    }
+
     // MARK: - getPropositionsForSurfaces
     
     func testGetPropositionsForSurfacesNoValidSurfaces() throws {

--- a/AEPMessaging/Tests/UnitTests/MessagingTests.swift
+++ b/AEPMessaging/Tests/UnitTests/MessagingTests.swift
@@ -666,6 +666,123 @@ class MessagingTests: XCTestCase {
     //        XCTAssertEqual("mobileapp://com.apple.dt.xctest.tool/promos/feed1", surfaces[0])
     //    }
 
+    // MARK: - createPersonalizationRequestEventData (custom XDM / data merge)
+
+    private let CUSTOM_XDM_SURFACE = Surface(uri: "mobileapp://com.test.app/homescreen")
+
+    func testCreatePersonalizationRequestEventData_baseStructureWithoutCustomXdmOrData() throws {
+        // test
+        let eventData = messaging.createPersonalizationRequestEventData(for: [CUSTOM_XDM_SURFACE], xdm: nil, data: nil)
+
+        // verify query.personalization.surfaces and schemas
+        let query = try XCTUnwrap(eventData["query"] as? [String: Any])
+        let personalization = try XCTUnwrap(query["personalization"] as? [String: Any])
+        let surfaces = try XCTUnwrap(personalization["surfaces"] as? [String])
+        XCTAssertEqual(["mobileapp://com.test.app/homescreen"], surfaces)
+        XCTAssertEqual(Messaging.supportedSchemas, personalization["schemas"] as? [String])
+
+        // verify xdm carries only the internal eventType
+        let xdm = try XCTUnwrap(eventData["xdm"] as? [String: Any])
+        XCTAssertEqual("personalization.request", xdm["eventType"] as? String)
+        XCTAssertEqual(1, xdm.count)
+
+        // verify data carries only the internal __adobe response-format namespace
+        let data = try XCTUnwrap(eventData["data"] as? [String: Any])
+        let adobe = try XCTUnwrap(data["__adobe"] as? [String: Any])
+        let ajo = try XCTUnwrap(adobe["ajo"] as? [String: Any])
+        XCTAssertEqual(2, ajo["in-app-response-format"] as? Int)
+        XCTAssertEqual(1, data.count)
+
+        // verify request.sendCompletion
+        let request = try XCTUnwrap(eventData["request"] as? [String: Any])
+        XCTAssertEqual(true, request["sendCompletion"] as? Bool)
+    }
+
+    func testCreatePersonalizationRequestEventData_withCustomXdm() throws {
+        // setup
+        let customXdm: [String: Any] = ["_chipotle": ["restaurantId": "6099"]]
+
+        // test
+        let eventData = messaging.createPersonalizationRequestEventData(for: [CUSTOM_XDM_SURFACE], xdm: customXdm, data: nil)
+
+        // verify custom xdm rides alongside the internal eventType
+        let xdm = try XCTUnwrap(eventData["xdm"] as? [String: Any])
+        XCTAssertEqual("personalization.request", xdm["eventType"] as? String)
+        let chipotle = try XCTUnwrap(xdm["_chipotle"] as? [String: Any])
+        XCTAssertEqual("6099", chipotle["restaurantId"] as? String)
+    }
+
+    func testCreatePersonalizationRequestEventData_withCustomData() throws {
+        // setup
+        let customData: [String: Any] = ["customKey": "customValue"]
+
+        // test
+        let eventData = messaging.createPersonalizationRequestEventData(for: [CUSTOM_XDM_SURFACE], xdm: nil, data: customData)
+
+        // verify custom data rides alongside the internal __adobe namespace
+        let data = try XCTUnwrap(eventData["data"] as? [String: Any])
+        XCTAssertNotNil(data["__adobe"] as? [String: Any])
+        XCTAssertEqual("customValue", data["customKey"] as? String)
+    }
+
+    func testCreatePersonalizationRequestEventData_withCustomXdmAndData() throws {
+        // setup
+        let customXdm: [String: Any] = ["_chipotle": ["restaurantId": "6099"]]
+        let customData: [String: Any] = ["customKey": "customValue"]
+
+        // test
+        let eventData = messaging.createPersonalizationRequestEventData(for: [CUSTOM_XDM_SURFACE], xdm: customXdm, data: customData)
+
+        // verify both merged, internal keys intact
+        let xdm = try XCTUnwrap(eventData["xdm"] as? [String: Any])
+        XCTAssertEqual("personalization.request", xdm["eventType"] as? String)
+        XCTAssertNotNil(xdm["_chipotle"] as? [String: Any])
+        let data = try XCTUnwrap(eventData["data"] as? [String: Any])
+        XCTAssertNotNil(data["__adobe"] as? [String: Any])
+        XCTAssertEqual("customValue", data["customKey"] as? String)
+    }
+
+    func testCreatePersonalizationRequestEventData_customXdmCannotOverrideInternalEventType() throws {
+        // setup - caller maliciously/accidentally tries to override the internal eventType
+        let customXdm: [String: Any] = ["eventType": "some.other.type", "_chipotle": ["restaurantId": "6099"]]
+
+        // test
+        let eventData = messaging.createPersonalizationRequestEventData(for: [CUSTOM_XDM_SURFACE], xdm: customXdm, data: nil)
+
+        // verify internal eventType wins, custom sibling field still present
+        let xdm = try XCTUnwrap(eventData["xdm"] as? [String: Any])
+        XCTAssertEqual("personalization.request", xdm["eventType"] as? String)
+        XCTAssertNotNil(xdm["_chipotle"] as? [String: Any])
+    }
+
+    func testCreatePersonalizationRequestEventData_customDataCannotOverrideInternalAdobeNamespace() throws {
+        // setup - caller tries to override the internal __adobe response-format namespace
+        let customData: [String: Any] = ["__adobe": ["ajo": ["in-app-response-format": 999]], "customKey": "customValue"]
+
+        // test
+        let eventData = messaging.createPersonalizationRequestEventData(for: [CUSTOM_XDM_SURFACE], xdm: nil, data: customData)
+
+        // verify internal __adobe namespace wins, custom sibling field still present
+        let data = try XCTUnwrap(eventData["data"] as? [String: Any])
+        let adobe = try XCTUnwrap(data["__adobe"] as? [String: Any])
+        let ajo = try XCTUnwrap(adobe["ajo"] as? [String: Any])
+        XCTAssertEqual(2, ajo["in-app-response-format"] as? Int)
+        XCTAssertEqual("customValue", data["customKey"] as? String)
+    }
+
+    func testCreatePersonalizationRequestEventData_multipleSurfaces() throws {
+        // test
+        let eventData = messaging.createPersonalizationRequestEventData(
+            for: [Surface(uri: "mobileapp://com.test.app/one"), Surface(uri: "mobileapp://com.test.app/two")],
+            xdm: nil, data: nil)
+
+        // verify
+        let query = try XCTUnwrap(eventData["query"] as? [String: Any])
+        let personalization = try XCTUnwrap(query["personalization"] as? [String: Any])
+        let surfaces = try XCTUnwrap(personalization["surfaces"] as? [String])
+        XCTAssertEqual(["mobileapp://com.test.app/one", "mobileapp://com.test.app/two"], surfaces)
+    }
+
     func testHandleProcessEventNoIdentityMap() throws {
         // setup
         let mockConfig = [EXPERIENCE_CLOUD_ORG: MOCK_EXP_ORG_ID]


### PR DESCRIPTION
Added new update propositions api with support of xdm and data fields with backward compatibility.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
