### PR TITLE
fix: unread background renders opaque black when color unset for acti…

### DIFF
--- a/AEPMessaging/Sources/ClassExtensions/Color+AEP.swift
+++ b/AEPMessaging/Sources/ClassExtensions/Color+AEP.swift
@@ -68,7 +68,7 @@ extension Color {
             r = 0
             g = 0
             b = 0
-            a = 1
+            a = 0
         }
         
         self.init(.sRGB, red: r, green: g, blue: b, opacity: a)


### PR DESCRIPTION
…ve color scheme

Color(hex:) fell back to opaque black (r=0,g=0,b=0,a=1) for invalid or empty hex strings, which happens when an Inbox unread background color is left unconfigured for light or dark mode in AJO. Falls back to fully transparent instead.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
